### PR TITLE
Open-discovery pivot: auth, onboarding, engine, hardening

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "python3",
       "runtimeArgs": ["-m", "http.server", "7723", "--directory", "public/mockups"],
       "port": 7723
+    },
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
     }
   ]
 }

--- a/app/(marketing)/onboarding/page.tsx
+++ b/app/(marketing)/onboarding/page.tsx
@@ -59,8 +59,17 @@ export default function OnboardingPage() {
   const artistDebounceRef = useRef<NodeJS.Timeout | null>(null)
 
   // Genre state
-  const [genreQuery, setGenreQuery] = useState("")
   const [selectedGenres, setSelectedGenres] = useState<GenreNode[]>([])
+  const [openAnchors, setOpenAnchors] = useState<Set<string>>(new Set())
+
+  const toggleAnchor = (id: string) => {
+    setOpenAnchors((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
 
   // Last.fm state
   const [lastfmUsername, setLastfmUsername] = useState("")
@@ -94,12 +103,6 @@ export default function OnboardingPage() {
 
     return () => { if (artistDebounceRef.current) clearTimeout(artistDebounceRef.current) }
   }, [artistQuery])
-
-  const filteredGenres = genreQuery.trim().length >= 1
-    ? ALL_GENRES.filter((g) =>
-        g.label.toLowerCase().includes(genreQuery.trim().toLowerCase())
-      ).slice(0, 30)
-    : ALL_GENRES.slice(0, 30)
 
   const selectedArtistIds = new Set(selectedArtists.map((a) => a.id))
   const selectedGenreIds = new Set(selectedGenres.map((g) => g.id))
@@ -324,57 +327,25 @@ export default function OnboardingPage() {
           <PathCard
             icon={<span style={{ fontSize: 15 }}>♫</span>}
             title="Genres I love"
-            subtitle="Pick from 200+ genre tags"
+            subtitle="Start broad, drill into niche"
             open={openPaths.has("genres")}
             onToggle={() => togglePath("genres")}
             chipCount={selectedGenres.length}
           >
-            <div className="col gap-10">
-              {selectedGenres.length > 0 && (
-                <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                  {selectedGenres.map((g) => (
-                    <Chip key={g.id} label={g.label} onRemove={() => removeGenre(g.id)} />
-                  ))}
-                </div>
-              )}
-              <div className="field" style={{ height: 40, position: "relative" }}>
-                <Search
-                  size={14}
-                  style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: "var(--text-muted)", pointerEvents: "none" }}
+            <div className="col gap-6">
+              {ALL_GENRES.map((anchor) => (
+                <GenreAnchor
+                  key={anchor.id}
+                  anchor={anchor}
+                  expanded={openAnchors.has(anchor.id)}
+                  onToggleExpand={() => toggleAnchor(anchor.id)}
+                  selectedIds={selectedGenreIds}
+                  atCap={selectedGenres.length >= 20}
+                  onToggleSelect={(node) =>
+                    selectedGenreIds.has(node.id) ? removeGenre(node.id) : addGenre(node)
+                  }
                 />
-                <input
-                  type="text"
-                  placeholder="Filter genres…"
-                  value={genreQuery}
-                  onChange={(e) => setGenreQuery(e.target.value)}
-                  style={{ paddingLeft: 32 }}
-                />
-              </div>
-              <div
-                style={{
-                  maxHeight: 200,
-                  overflowY: "auto",
-                  display: "flex",
-                  flexWrap: "wrap",
-                  gap: 6,
-                  padding: "4px 0",
-                }}
-              >
-                {filteredGenres.map((genre) => {
-                  const already = selectedGenreIds.has(genre.id)
-                  return (
-                    <button
-                      key={genre.id}
-                      type="button"
-                      onClick={() => already ? removeGenre(genre.id) : addGenre(genre)}
-                      className={"chip" + (already ? " selected" : "")}
-                      style={{ fontSize: 12 }}
-                    >
-                      {genre.label}
-                    </button>
-                  )
-                })}
-              </div>
+              ))}
             </div>
           </PathCard>
 
@@ -549,5 +520,162 @@ function PathCard({
         </div>
       )}
     </div>
+  )
+}
+
+// ── GenreAnchor ───────────────────────────────────────────────────────────────
+
+function GenreAnchor({
+  anchor,
+  expanded,
+  onToggleExpand,
+  selectedIds,
+  atCap,
+  onToggleSelect,
+}: {
+  anchor: GenreNode
+  expanded: boolean
+  onToggleExpand: () => void
+  selectedIds: Set<string>
+  atCap: boolean
+  onToggleSelect: (node: GenreNode) => void
+}) {
+  const parentSelected = selectedIds.has(anchor.id)
+  const childSelectedCount = anchor.children.reduce(
+    (n, c) => (selectedIds.has(c.id) ? n + 1 : n),
+    0
+  )
+  const totalSelected = (parentSelected ? 1 : 0) + childSelectedCount
+
+  return (
+    <div
+      style={{
+        borderRadius: 10,
+        border: "1px solid var(--border)",
+        background: expanded ? "rgba(255,255,255,0.02)" : "transparent",
+        overflow: "hidden",
+        transition: "background 0.15s",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          width: "100%",
+          padding: "10px 12px",
+          background: "none",
+          border: 0,
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+      >
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
+            {anchor.label}
+            {totalSelected > 0 && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  padding: "1px 6px",
+                  borderRadius: 4,
+                  background: "rgba(139,92,246,0.2)",
+                  color: "var(--accent)",
+                }}
+              >
+                {totalSelected}
+              </span>
+            )}
+          </div>
+          <div className="mono" style={{ fontSize: 10.5, color: "var(--text-muted)", marginTop: 2 }}>
+            {anchor.children.length} sub-genres
+          </div>
+        </div>
+        <div style={{ color: "var(--text-faint)", flexShrink: 0 }}>
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </div>
+      </button>
+
+      {expanded && (
+        <div style={{ padding: "6px 8px 10px", borderTop: "1px solid var(--border)" }}>
+          <GenreRow
+            label={`Select all of ${anchor.label}`}
+            selected={parentSelected}
+            disabled={!parentSelected && atCap}
+            onClick={() => onToggleSelect(anchor)}
+            emphasis
+          />
+          {anchor.children.map((child) => {
+            const sel = selectedIds.has(child.id)
+            return (
+              <GenreRow
+                key={child.id}
+                label={child.label}
+                selected={sel}
+                disabled={!sel && atCap}
+                onClick={() => onToggleSelect(child)}
+              />
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── GenreRow ──────────────────────────────────────────────────────────────────
+
+function GenreRow({
+  label,
+  selected,
+  disabled,
+  onClick,
+  emphasis,
+}: {
+  label: string
+  selected: boolean
+  disabled?: boolean
+  onClick: () => void
+  emphasis?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        width: "100%",
+        padding: "8px 10px",
+        background: selected ? "var(--accent-soft)" : "transparent",
+        border: 0,
+        borderRadius: 8,
+        cursor: disabled ? "not-allowed" : "pointer",
+        textAlign: "left",
+        color: disabled ? "var(--text-faint)" : "var(--text-primary)",
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 14,
+          height: 14,
+          borderRadius: "50%",
+          border: `1.5px solid ${selected ? "var(--accent)" : "var(--border-strong)"}`,
+          background: selected ? "var(--accent)" : "transparent",
+          flexShrink: 0,
+          boxShadow: selected ? "0 0 8px var(--accent-glow)" : "none",
+          transition: "all 0.12s",
+        }}
+      />
+      <span style={{ fontSize: 13, fontWeight: emphasis ? 600 : 500 }}>{label}</span>
+    </button>
   )
 }

--- a/data/genres.json
+++ b/data/genres.json
@@ -1,2598 +1,3924 @@
 {
-  "generated": "2026-04-18T16:09:39.953Z",
-  "source": "wikidata",
+  "generated": "2026-04-18T23:09:35.721Z",
+  "source": "wikidata+anchored",
   "nodes": [
     {
-      "id": "Q69596",
-      "label": "Thumri",
-      "lastfmTag": "thumri",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q70076",
-      "label": "tappa",
-      "lastfmTag": "tappa",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q81105",
-      "label": "ca trù",
-      "lastfmTag": "ca-trù",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q82469",
-      "label": "Gstanzl",
-      "lastfmTag": "gstanzl",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q83390",
-      "label": "acclamatio",
-      "lastfmTag": "acclamatio",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q83440",
-      "label": "country music",
-      "lastfmTag": "country-music",
+      "id": "ANCHOR_rock",
+      "label": "Rock",
+      "lastfmTag": "rock",
       "parentId": null,
       "children": [
         {
-          "id": "Q213714",
-          "label": "bluegrass music",
-          "lastfmTag": "bluegrass-music",
-          "parentId": "Q83440",
+          "id": "Q209498",
+          "label": "2 tone",
+          "lastfmTag": "2-tone",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q236932",
+          "label": "acid rock",
+          "lastfmTag": "acid-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q428656",
+          "label": "album-oriented rock",
+          "lastfmTag": "album-oriented-rock",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
           "id": "Q438476",
           "label": "alternative country",
           "lastfmTag": "alternative-country",
-          "parentId": "Q83440",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q85477",
-      "label": "oratorio",
-      "lastfmTag": "oratorio",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q118120",
-      "label": "reel",
-      "lastfmTag": "reel",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q122772",
-      "label": "Austrian hip hop",
-      "lastfmTag": "austrian-hip-hop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q131272",
-      "label": "soul",
-      "lastfmTag": "soul",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q268253",
-          "label": "neo soul",
-          "lastfmTag": "neo-soul",
-          "parentId": "Q131272",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q131510",
-      "label": "mantra",
-      "lastfmTag": "mantra",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q131578",
-      "label": "J-pop",
-      "lastfmTag": "j-pop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q135637",
-      "label": "chiptune",
-      "lastfmTag": "chiptune",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q138020",
-      "label": "French hip-hop",
-      "lastfmTag": "french-hip-hop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q140222",
-      "label": "zajal",
-      "lastfmTag": "zajal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q145594",
-      "label": "Igbo music",
-      "lastfmTag": "igbo-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q155119",
-      "label": "cuarteto",
-      "lastfmTag": "cuarteto",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q155858",
-      "label": "music of Ukraine",
-      "lastfmTag": "music-of-ukraine",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q163775",
-      "label": "medieval music",
-      "lastfmTag": "medieval-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q163491",
-          "label": "ars antiqua",
-          "lastfmTag": "ars-antiqua",
-          "parentId": "Q163775",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q210854",
-          "label": "ars nova",
-          "lastfmTag": "ars-nova",
-          "parentId": "Q163775",
+          "id": "Q438503",
+          "label": "alternative hip-hop",
+          "lastfmTag": "alternative-hip-hop",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q471194",
-          "label": "troubadoric poetry",
-          "lastfmTag": "troubadoric-poetry",
-          "parentId": "Q163775",
+          "id": "Q20378",
+          "label": "alternative metal",
+          "lastfmTag": "alternative-metal",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q577996",
-          "label": "descant",
-          "lastfmTag": "descant",
-          "parentId": "Q163775",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q164444",
-      "label": "funk",
-      "lastfmTag": "funk",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q170435",
-      "label": "trance",
-      "lastfmTag": "trance",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q481900",
-          "label": "acid trance",
-          "lastfmTag": "acid-trance",
-          "parentId": "Q170435",
-          "children": []
-        },
-        {
-          "id": "Q622871",
-          "label": "psychedelic trance",
-          "lastfmTag": "psychedelic-trance",
-          "parentId": "Q170435",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q170611",
-      "label": "techno",
-      "lastfmTag": "techno",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q526463",
-          "label": "Detroit techno",
-          "lastfmTag": "detroit-techno",
-          "parentId": "Q170611",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q2743",
-      "label": "musical",
-      "lastfmTag": "musical",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q253137",
-          "label": "rock opera",
-          "lastfmTag": "rock-opera",
-          "parentId": "Q2743",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q3071",
-      "label": "punk rock",
-      "lastfmTag": "punk-rock",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q10922",
-          "label": "hardcore punk",
-          "lastfmTag": "hardcore-punk",
-          "parentId": "Q3071",
-          "children": [
-            {
-              "id": "Q183862",
-              "label": "metalcore",
-              "lastfmTag": "metalcore",
-              "parentId": "Q10922",
-              "children": [
-                {
-                  "id": "Q475221",
-                  "label": "deathcore",
-                  "lastfmTag": "deathcore",
-                  "parentId": "Q183862",
-                  "children": []
-                },
-                {
-                  "id": "Q616679",
-                  "label": "mathcore",
-                  "lastfmTag": "mathcore",
-                  "parentId": "Q183862",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "id": "Q188534",
-              "label": "grindcore",
-              "lastfmTag": "grindcore",
-              "parentId": "Q10922",
-              "children": []
-            },
-            {
-              "id": "Q542703",
-              "label": "melodic hardcore",
-              "lastfmTag": "melodic-hardcore",
-              "parentId": "Q10922",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q274401",
-          "label": "oi!",
-          "lastfmTag": "oi!",
-          "parentId": "Q3071",
-          "children": []
-        },
-        {
-          "id": "Q302401",
-          "label": "punkabilly",
-          "lastfmTag": "punkabilly",
-          "parentId": "Q3071",
-          "children": []
-        },
-        {
-          "id": "Q460674",
-          "label": "ska punk",
-          "lastfmTag": "ska-punk",
-          "parentId": "Q3071",
+          "id": "Q11366",
+          "label": "alternative rock",
+          "lastfmTag": "alternative-rock",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
           "id": "Q486365",
           "label": "anarcho-punk",
           "lastfmTag": "anarcho-punk",
-          "parentId": "Q3071",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q487914",
-          "label": "pop-punk",
-          "lastfmTag": "pop-punk",
-          "parentId": "Q3071",
+          "id": "Q483740",
+          "label": "Anatolian rock",
+          "lastfmTag": "anatolian-rock",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q602498",
-          "label": "nazi punk",
-          "lastfmTag": "nazi-punk",
-          "parentId": "Q3071",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q3858",
-      "label": "music of Israel",
-      "lastfmTag": "music-of-israel",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q4797",
-      "label": "conjunto",
-      "lastfmTag": "conjunto",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q8341",
-      "label": "jazz",
-      "lastfmTag": "jazz",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q105513",
-          "label": "bebop",
-          "lastfmTag": "bebop",
-          "parentId": "Q8341",
-          "children": [
-            {
-              "id": "Q181010",
-              "label": "hard bop",
-              "lastfmTag": "hard-bop",
-              "parentId": "Q105513",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q105527",
-          "label": "jazz fusion",
-          "lastfmTag": "jazz-fusion",
-          "parentId": "Q8341",
+          "id": "Q379033",
+          "label": "arena rock",
+          "lastfmTag": "arena-rock",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q166813",
-          "label": "Kansas City jazz",
-          "lastfmTag": "kansas-city-jazz",
-          "parentId": "Q8341",
+          "id": "Q646026",
+          "label": "Argentine rock",
+          "lastfmTag": "argentine-rock",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q181897",
-          "label": "stride piano",
-          "lastfmTag": "stride-piano",
-          "parentId": "Q8341",
-          "children": []
-        },
-        {
-          "id": "Q183016",
-          "label": "ska jazz",
-          "lastfmTag": "ska-jazz",
-          "parentId": "Q8341",
-          "children": []
-        },
-        {
-          "id": "Q203775",
-          "label": "swing",
-          "lastfmTag": "swing",
-          "parentId": "Q8341",
-          "children": [
-            {
-              "id": "Q447962",
-              "label": "swing revival",
-              "lastfmTag": "swing-revival",
-              "parentId": "Q203775",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q280955",
-          "label": "German jazz",
-          "lastfmTag": "german-jazz",
-          "parentId": "Q8341",
-          "children": []
-        },
-        {
-          "id": "Q492643",
-          "label": "trad jazz",
-          "lastfmTag": "trad-jazz",
-          "parentId": "Q8341",
-          "children": []
-        },
-        {
-          "id": "Q539089",
-          "label": "third stream",
-          "lastfmTag": "third-stream",
-          "parentId": "Q8341",
-          "children": []
-        },
-        {
-          "id": "Q591990",
-          "label": "jazz standard",
-          "lastfmTag": "jazz-standard",
-          "parentId": "Q8341",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q9730",
-      "label": "classical music",
-      "lastfmTag": "classical-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q131269",
-          "label": "sonata",
-          "lastfmTag": "sonata",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q140544",
-          "label": "toccata",
-          "lastfmTag": "toccata",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q174873",
-          "label": "cantata",
-          "lastfmTag": "cantata",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q1344",
-          "label": "opera",
-          "lastfmTag": "opera",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q8361",
-          "label": "Baroque music",
-          "lastfmTag": "baroque-music",
-          "parentId": "Q9730",
-          "children": [
-            {
-              "id": "Q208593",
-              "label": "sarabande",
-              "lastfmTag": "sarabande",
-              "parentId": "Q8361",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q17723",
-          "label": "Classical period",
-          "lastfmTag": "classical-period",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q181014",
-          "label": "fugue",
-          "lastfmTag": "fugue",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q188285",
-          "label": "motet",
-          "lastfmTag": "motet",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q189201",
-          "label": "chamber music",
-          "lastfmTag": "chamber-music",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q193217",
-          "label": "madrigal",
-          "lastfmTag": "madrigal",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q194172",
-          "label": "nocturne",
-          "lastfmTag": "nocturne",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q201405",
-          "label": "Renaissance music",
-          "lastfmTag": "renaissance-music",
-          "parentId": "Q9730",
-          "children": [
-            {
-              "id": "Q185858",
-              "label": "Franco-Flemish School",
-              "lastfmTag": "franco-flemish-school",
-              "parentId": "Q201405",
-              "children": []
-            },
-            {
-              "id": "Q288824",
-              "label": "galliard",
-              "lastfmTag": "galliard",
-              "parentId": "Q201405",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q202287",
-          "label": "overture",
-          "lastfmTag": "overture",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q207591",
-          "label": "Romantic music",
-          "lastfmTag": "romantic-music",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q207683",
-          "label": "canzona",
-          "lastfmTag": "canzona",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q207841",
-          "label": "étude",
-          "lastfmTag": "étude",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q212148",
-          "label": "prelude",
-          "lastfmTag": "prelude",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q214981",
-          "label": "theme and variation",
-          "lastfmTag": "theme-and-variation",
-          "parentId": "Q9730",
-          "children": []
-        },
-        {
-          "id": "Q215911",
-          "label": "serenade",
-          "lastfmTag": "serenade",
-          "parentId": "Q9730",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q9734",
-      "label": "symphony",
-      "lastfmTag": "symphony",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q9748",
-      "label": "concerto",
-      "lastfmTag": "concerto",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q210216",
-          "label": "concerto grosso",
-          "lastfmTag": "concerto-grosso",
-          "parentId": "Q9748",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q9759",
-      "label": "blues",
-      "lastfmTag": "blues",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q177447",
-          "label": "West Coast blues",
-          "lastfmTag": "west-coast-blues",
-          "parentId": "Q9759",
-          "children": []
-        },
-        {
-          "id": "Q212952",
-          "label": "boogie-woogie",
-          "lastfmTag": "boogie-woogie",
-          "parentId": "Q9759",
-          "children": []
-        },
-        {
-          "id": "Q515074",
-          "label": "Louisiana blues",
-          "lastfmTag": "louisiana-blues",
-          "parentId": "Q9759",
-          "children": [
-            {
-              "id": "Q516568",
-              "label": "New Orleans blues",
-              "lastfmTag": "new-orleans-blues",
-              "parentId": "Q515074",
-              "children": []
-            },
-            {
-              "id": "Q534606",
-              "label": "swamp blues",
-              "lastfmTag": "swamp-blues",
-              "parentId": "Q515074",
-              "children": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "Q9764",
-      "label": "flamenco",
-      "lastfmTag": "flamenco",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q9778",
-      "label": "electronic music",
-      "lastfmTag": "electronic-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q181999",
-          "label": "minimal electro",
-          "lastfmTag": "minimal-electro",
-          "parentId": "Q9778",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q11399",
-      "label": "rock music",
-      "lastfmTag": "rock-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q76092",
-          "label": "glam rock",
-          "lastfmTag": "glam-rock",
-          "parentId": "Q11399",
-          "children": []
-        },
-        {
-          "id": "Q83270",
-          "label": "hard rock",
-          "lastfmTag": "hard-rock",
-          "parentId": "Q11399",
-          "children": [
-            {
-              "id": "Q188539",
-              "label": "glam metal",
-              "lastfmTag": "glam-metal",
-              "parentId": "Q83270",
-              "children": []
-            },
-            {
-              "id": "Q617240",
-              "label": "stoner rock",
-              "lastfmTag": "stoner-rock",
-              "parentId": "Q83270",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q145980",
-          "label": "Zamrock",
-          "lastfmTag": "zamrock",
-          "parentId": "Q11399",
-          "children": []
-        },
-        {
-          "id": "Q7749",
-          "label": "rock and roll",
-          "lastfmTag": "rock-and-roll",
-          "parentId": "Q11399",
-          "children": [
-            {
-              "id": "Q203720",
-              "label": "rockabilly",
-              "lastfmTag": "rockabilly",
-              "parentId": "Q7749",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q11366",
-          "label": "alternative rock",
-          "lastfmTag": "alternative-rock",
-          "parentId": "Q11399",
-          "children": [
-            {
-              "id": "Q10926",
-              "label": "emo",
-              "lastfmTag": "emo",
-              "parentId": "Q11366",
-              "children": [
-                {
-                  "id": "Q11363",
-                  "label": "screamo",
-                  "lastfmTag": "screamo",
-                  "parentId": "Q10926",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "id": "Q11365",
-              "label": "grunge",
-              "lastfmTag": "grunge",
-              "parentId": "Q11366",
-              "children": []
-            },
-            {
-              "id": "Q183504",
-              "label": "indie rock",
-              "lastfmTag": "indie-rock",
-              "parentId": "Q11366",
-              "children": [
-                {
-                  "id": "Q267287",
-                  "label": "Dunedin sound",
-                  "lastfmTag": "dunedin-sound",
-                  "parentId": "Q183504",
-                  "children": []
-                },
-                {
-                  "id": "Q592330",
-                  "label": "dream pop",
-                  "lastfmTag": "dream-pop",
-                  "parentId": "Q183504",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "id": "Q189045",
-              "label": "Britpop",
-              "lastfmTag": "britpop",
-              "parentId": "Q11366",
-              "children": []
-            },
-            {
-              "id": "Q272167",
-              "label": "shoegaze",
-              "lastfmTag": "shoegaze",
-              "parentId": "Q11366",
-              "children": []
-            },
-            {
-              "id": "Q485395",
-              "label": "gothic rock",
-              "lastfmTag": "gothic-rock",
-              "parentId": "Q11366",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q181861",
-          "label": "noise rock",
-          "lastfmTag": "noise-rock",
-          "parentId": "Q11399",
-          "children": []
-        },
-        {
-          "id": "Q185162",
-          "label": "Latin rock",
-          "lastfmTag": "latin-rock",
-          "parentId": "Q11399",
-          "children": []
-        },
-        {
-          "id": "Q186472",
-          "label": "folk rock",
-          "lastfmTag": "folk-rock",
-          "parentId": "Q11399",
-          "children": []
-        },
-        {
-          "id": "Q187760",
-          "label": "new wave",
-          "lastfmTag": "new-wave",
-          "parentId": "Q11399",
-          "children": [
-            {
-              "id": "Q597240",
-              "label": "New Romantic",
-              "lastfmTag": "new-romantic",
-              "parentId": "Q187760",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q193355",
-          "label": "blues rock",
-          "lastfmTag": "blues-rock",
-          "parentId": "Q11399",
-          "children": []
-        },
-        {
-          "id": "Q206159",
-          "label": "psychedelic rock",
-          "lastfmTag": "psychedelic-rock",
-          "parentId": "Q11399",
-          "children": [
-            {
-              "id": "Q236913",
-              "label": "space rock",
-              "lastfmTag": "space-rock",
-              "parentId": "Q206159",
-              "children": []
-            },
-            {
-              "id": "Q236932",
-              "label": "acid rock",
-              "lastfmTag": "acid-rock",
-              "parentId": "Q206159",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q211573",
-          "label": "garage rock",
-          "lastfmTag": "garage-rock",
-          "parentId": "Q11399",
+          "id": "Q659599",
+          "label": "art punk",
+          "lastfmTag": "art-punk",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
           "id": "Q217467",
           "label": "art rock",
           "lastfmTag": "art-rock",
-          "parentId": "Q11399",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q220830",
-          "label": "surf music",
-          "lastfmTag": "surf-music",
-          "parentId": "Q11399",
+          "id": "Q193355",
+          "label": "blues rock",
+          "lastfmTag": "blues-rock",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
-          "id": "Q239459",
-          "label": "trip rock",
-          "lastfmTag": "trip-rock",
-          "parentId": "Q11399",
+          "id": "Q211418",
+          "label": "British Invasion",
+          "lastfmTag": "british-invasion",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q189045",
+          "label": "Britpop",
+          "lastfmTag": "britpop",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1064810",
+          "label": "Chinese rock",
+          "lastfmTag": "chinese-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q63885",
+          "label": "Christian punk",
+          "lastfmTag": "christian-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q753520",
+          "label": "Christian rock",
+          "lastfmTag": "christian-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q783097",
+          "label": "college rock",
+          "lastfmTag": "college-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1391336",
+          "label": "comedy rock",
+          "lastfmTag": "comedy-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q613408",
+          "label": "country rock",
+          "lastfmTag": "country-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q825769",
+          "label": "crust punk",
+          "lastfmTag": "crust-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1166218",
+          "label": "dark rock",
+          "lastfmTag": "dark-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1191923",
+          "label": "depro-punk",
+          "lastfmTag": "depro-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q904500",
+          "label": "Detroit rock",
+          "lastfmTag": "detroit-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q56580",
+          "label": "digital hardcore",
+          "lastfmTag": "digital-hardcore",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q724755",
+          "label": "early hardcore",
+          "lastfmTag": "early-hardcore",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q325504",
+          "label": "electronic rock",
+          "lastfmTag": "electronic-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q10926",
+          "label": "emo",
+          "lastfmTag": "emo",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1425661",
+          "label": "folk punk",
+          "lastfmTag": "folk-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q186472",
+          "label": "folk rock",
+          "lastfmTag": "folk-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q835891",
+          "label": "funk rock",
+          "lastfmTag": "funk-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q928825",
+          "label": "garage house",
+          "lastfmTag": "garage-house",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q211573",
+          "label": "garage rock",
+          "lastfmTag": "garage-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q328296",
+          "label": "GDR rock",
+          "lastfmTag": "gdr-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q24383",
+          "label": "German rock",
+          "lastfmTag": "german-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1123745",
+          "label": "glam punk",
+          "lastfmTag": "glam-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q76092",
+          "label": "glam rock",
+          "lastfmTag": "glam-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q485395",
+          "label": "gothic rock",
+          "lastfmTag": "gothic-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q11365",
+          "label": "grunge",
+          "lastfmTag": "grunge",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q339906",
+          "label": "happy hardcore",
+          "lastfmTag": "happy-hardcore",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q83270",
+          "label": "hard rock",
+          "lastfmTag": "hard-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q388906",
+          "label": "hardcore",
+          "lastfmTag": "hardcore",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q966564",
+          "label": "hardcore hip-hop",
+          "lastfmTag": "hardcore-hip-hop",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q10922",
+          "label": "hardcore punk",
+          "lastfmTag": "hardcore-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q747717",
+          "label": "heartland rock",
+          "lastfmTag": "heartland-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q830325",
+          "label": "horror punk",
+          "lastfmTag": "horror-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1317816",
+          "label": "indie folk",
+          "lastfmTag": "indie-folk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q842324",
+          "label": "indie pop",
+          "lastfmTag": "indie-pop",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q183504",
+          "label": "indie rock",
+          "lastfmTag": "indie-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1191299",
+          "label": "industrial hardcore",
+          "lastfmTag": "industrial-hardcore",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q968730",
+          "label": "industrial rock",
+          "lastfmTag": "industrial-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q725888",
+          "label": "Italian progressive rock",
+          "lastfmTag": "italian-progressive-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1055871",
+          "label": "Japanese rock",
+          "lastfmTag": "japanese-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q944465",
+          "label": "jazz rock",
+          "lastfmTag": "jazz-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1089050",
+          "label": "Latin alternative",
+          "lastfmTag": "latin-alternative",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q185162",
+          "label": "Latin rock",
+          "lastfmTag": "latin-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1132152",
+          "label": "math rock",
+          "lastfmTag": "math-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q641318",
+          "label": "medieval folk rock",
+          "lastfmTag": "medieval-folk-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q542703",
+          "label": "melodic hardcore",
+          "lastfmTag": "melodic-hardcore",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1037693",
+          "label": "modern rock",
+          "lastfmTag": "modern-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q602498",
+          "label": "nazi punk",
+          "lastfmTag": "nazi-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1051843",
+          "label": "neo-prog",
+          "lastfmTag": "neo-prog",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q181861",
+          "label": "noise rock",
+          "lastfmTag": "noise-rock",
+          "parentId": "ANCHOR_rock",
           "children": []
         },
         {
           "id": "Q484641",
           "label": "pop rock",
           "lastfmTag": "pop-rock",
-          "parentId": "Q11399",
-          "children": [
-            {
-              "id": "Q217191",
-              "label": "soft rock",
-              "lastfmTag": "soft-rock",
-              "parentId": "Q484641",
-              "children": []
-            },
-            {
-              "id": "Q546264",
-              "label": "beat music",
-              "lastfmTag": "beat-music",
-              "parentId": "Q484641",
-              "children": []
-            }
-          ]
+          "parentId": "ANCHOR_rock",
+          "children": []
         },
         {
-          "id": "Q613408",
-          "label": "country rock",
-          "lastfmTag": "country-rock",
-          "parentId": "Q11399",
+          "id": "Q487914",
+          "label": "pop-punk",
+          "lastfmTag": "pop-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q379671",
+          "label": "post-grunge",
+          "lastfmTag": "post-grunge",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q377910",
+          "label": "post-hardcore",
+          "lastfmTag": "post-hardcore",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q598929",
+          "label": "post-punk",
+          "lastfmTag": "post-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q209137",
+          "label": "post-rock",
+          "lastfmTag": "post-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q49451",
+          "label": "progressive rock",
+          "lastfmTag": "progressive-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q27190",
+          "label": "proto-punk",
+          "lastfmTag": "proto-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q846119",
+          "label": "psychedelic music",
+          "lastfmTag": "psychedelic-music",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q383982",
+          "label": "psychedelic pop",
+          "lastfmTag": "psychedelic-pop",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q206159",
+          "label": "psychedelic rock",
+          "lastfmTag": "psychedelic-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q622871",
+          "label": "psychedelic trance",
+          "lastfmTag": "psychedelic-trance",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q890575",
+          "label": "punk metal",
+          "lastfmTag": "punk-metal",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1273641",
+          "label": "punk pathetique",
+          "lastfmTag": "punk-pathetique",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1071244",
+          "label": "punk revival",
+          "lastfmTag": "punk-revival",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q3071",
+          "label": "punk rock",
+          "lastfmTag": "punk-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1307555",
+          "label": "punk'n'roll",
+          "lastfmTag": "punk-n-roll",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q877693",
+          "label": "rap rock",
+          "lastfmTag": "rap-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1234748",
+          "label": "retro-prog",
+          "lastfmTag": "retro-prog",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q828181",
+          "label": "Rock Against Communism",
+          "lastfmTag": "rock-against-communism",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q7749",
+          "label": "rock and roll",
+          "lastfmTag": "rock-and-roll",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q668657",
+          "label": "rock and roll revival",
+          "lastfmTag": "rock-and-roll-revival",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q11399",
+          "label": "rock music",
+          "lastfmTag": "rock-music",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q253137",
+          "label": "rock opera",
+          "lastfmTag": "rock-opera",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q203720",
+          "label": "rockabilly",
+          "lastfmTag": "rockabilly",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q834959",
+          "label": "samba rock",
+          "lastfmTag": "samba-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q11363",
+          "label": "screamo",
+          "lastfmTag": "screamo",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q272167",
+          "label": "shoegaze",
+          "lastfmTag": "shoegaze",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q460674",
+          "label": "ska punk",
+          "lastfmTag": "ska-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q828305",
+          "label": "skate punk",
+          "lastfmTag": "skate-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q217191",
+          "label": "soft rock",
+          "lastfmTag": "soft-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q852767",
+          "label": "Southern rock",
+          "lastfmTag": "southern-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q236913",
+          "label": "space rock",
+          "lastfmTag": "space-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q780517",
+          "label": "speed garage",
+          "lastfmTag": "speed-garage",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q617240",
+          "label": "stoner rock",
+          "lastfmTag": "stoner-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q383615",
+          "label": "street punk",
+          "lastfmTag": "street-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q220830",
+          "label": "surf music",
+          "lastfmTag": "surf-music",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q675553",
+          "label": "swamp rock",
+          "lastfmTag": "swamp-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q719927",
+          "label": "symphonic rock",
+          "lastfmTag": "symphonic-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q476983",
+          "label": "synth-punk",
+          "lastfmTag": "synth-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q239459",
+          "label": "trip rock",
+          "lastfmTag": "trip-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q1165777",
+          "label": "UK garage",
+          "lastfmTag": "uk-garage",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q131425",
+          "label": "visual kei",
+          "lastfmTag": "visual-kei",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q898530",
+          "label": "Wagnerian rock",
+          "lastfmTag": "wagnerian-rock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q824948",
+          "label": "Washington, D.C. hardcore punk",
+          "lastfmTag": "washington-d-c-hardcore-punk",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q145980",
+          "label": "Zamrock",
+          "lastfmTag": "zamrock",
+          "parentId": "ANCHOR_rock",
+          "children": []
+        },
+        {
+          "id": "Q196999",
+          "label": "Zeuhl",
+          "lastfmTag": "zeuhl",
+          "parentId": "ANCHOR_rock",
           "children": []
         }
       ]
     },
     {
-      "id": "Q11403",
-      "label": "samba",
-      "lastfmTag": "samba",
+      "id": "ANCHOR_pop",
+      "label": "Pop",
+      "lastfmTag": "pop",
       "parentId": null,
       "children": [
         {
-          "id": "Q19816",
-          "label": "batucada",
-          "lastfmTag": "batucada",
-          "parentId": "Q11403",
+          "id": "Q624081",
+          "label": "Arabic pop",
+          "lastfmTag": "arabic-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q46046",
+          "label": "baroque pop",
+          "lastfmTag": "baroque-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q997481",
+          "label": "bubblegum music",
+          "lastfmTag": "bubblegum-music",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q1192110",
+          "label": "C-pop",
+          "lastfmTag": "c-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q211756",
+          "label": "dance-pop",
+          "lastfmTag": "dance-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q592330",
+          "label": "dream pop",
+          "lastfmTag": "dream-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q188450",
+          "label": "electropop",
+          "lastfmTag": "electropop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q1162954",
+          "label": "French pop",
+          "lastfmTag": "french-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q278409",
+          "label": "Hokkien pop",
+          "lastfmTag": "hokkien-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q131578",
+          "label": "J-pop",
+          "lastfmTag": "j-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q1190565",
+          "label": "jangle pop",
+          "lastfmTag": "jangle-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q213665",
+          "label": "K-pop",
+          "lastfmTag": "k-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q547137",
+          "label": "Latin pop",
+          "lastfmTag": "latin-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q597240",
+          "label": "New Romantic",
+          "lastfmTag": "new-romantic",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q187760",
+          "label": "new wave",
+          "lastfmTag": "new-wave",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q1046838",
+          "label": "new wave of American heavy metal",
+          "lastfmTag": "new-wave-of-american-heavy-metal",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q370515",
+          "label": "new wave of British heavy metal",
+          "lastfmTag": "new-wave-of-british-heavy-metal",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q37073",
+          "label": "pop music",
+          "lastfmTag": "pop-music",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q837837",
+          "label": "power pop",
+          "lastfmTag": "power-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q378495",
+          "label": "Russian pop",
+          "lastfmTag": "russian-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q264289",
+          "label": "sophisti-pop",
+          "lastfmTag": "sophisti-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q1298934",
+          "label": "synth-pop",
+          "lastfmTag": "synth-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q739138",
+          "label": "teen pop",
+          "lastfmTag": "teen-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q1196752",
+          "label": "traditional pop",
+          "lastfmTag": "traditional-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q370778",
+          "label": "twee pop",
+          "lastfmTag": "twee-pop",
+          "parentId": "ANCHOR_pop",
+          "children": []
+        },
+        {
+          "id": "Q646528",
+          "label": "Yugoslav new wave",
+          "lastfmTag": "yugoslav-new-wave",
+          "parentId": "ANCHOR_pop",
           "children": []
         }
       ]
     },
     {
-      "id": "Q11401",
-      "label": "hip-hop",
+      "id": "ANCHOR_hiphop",
+      "label": "Hip-Hop",
       "lastfmTag": "hip-hop",
       "parentId": null,
       "children": [
         {
-          "id": "Q6010",
-          "label": "rapping",
-          "lastfmTag": "rapping",
-          "parentId": "Q11401",
-          "children": [
-            {
-              "id": "Q141459",
-              "label": "conscious hip-hop",
-              "lastfmTag": "conscious-hip-hop",
-              "parentId": "Q6010",
-              "children": []
-            },
-            {
-              "id": "Q438503",
-              "label": "alternative hip-hop",
-              "lastfmTag": "alternative-hip-hop",
-              "parentId": "Q6010",
-              "children": []
-            },
-            {
-              "id": "Q601235",
-              "label": "hip house",
-              "lastfmTag": "hip-house",
-              "parentId": "Q6010",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q255406",
-          "label": "jazz rap",
-          "lastfmTag": "jazz-rap",
-          "parentId": "Q11401",
+          "id": "Q387236",
+          "label": "African hip-hop",
+          "lastfmTag": "african-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q469630",
-          "label": "Canadian hip-hop",
-          "lastfmTag": "canadian-hip-hop",
-          "parentId": "Q11401",
+          "id": "Q624221",
+          "label": "Arabic hip-hop",
+          "lastfmTag": "arabic-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q783243",
+          "label": "Australian hip-hop",
+          "lastfmTag": "australian-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q122772",
+          "label": "Austrian hip hop",
+          "lastfmTag": "austrian-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q815536",
+          "label": "Belgian hip hop",
+          "lastfmTag": "belgian-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
           "id": "Q529742",
           "label": "boom bap",
           "lastfmTag": "boom-bap",
-          "parentId": "Q11401",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q546206",
-          "label": "Miami bass",
-          "lastfmTag": "miami-bass",
-          "parentId": "Q11401",
+          "id": "Q469630",
+          "label": "Canadian hip-hop",
+          "lastfmTag": "canadian-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q1399695",
+          "label": "Chicano rap",
+          "lastfmTag": "chicano-rap",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
           "id": "Q602646",
           "label": "comedy hip-hop",
           "lastfmTag": "comedy-hip-hop",
-          "parentId": "Q11401",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q12302",
-      "label": "bagad",
-      "lastfmTag": "bagad",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q18846",
-      "label": "ancient music",
-      "lastfmTag": "ancient-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q512359",
-          "label": "music of ancient Egypt",
-          "lastfmTag": "music-of-ancient-egypt",
-          "parentId": "Q18846",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q20378",
-      "label": "alternative metal",
-      "lastfmTag": "alternative-metal",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q213572",
-          "label": "Neue Deutsche Härte",
-          "lastfmTag": "neue-deutsche-härte",
-          "parentId": "Q20378",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q263734",
-          "label": "nu metal",
-          "lastfmTag": "nu-metal",
-          "parentId": "Q20378",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q20474",
-      "label": "dubstep",
-      "lastfmTag": "dubstep",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q20903",
-          "label": "brostep",
-          "lastfmTag": "brostep",
-          "parentId": "Q20474",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q20502",
-      "label": "house music",
-      "lastfmTag": "house-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q173844",
-          "label": "vocal house",
-          "lastfmTag": "vocal-house",
-          "parentId": "Q20502",
+          "id": "Q141459",
+          "label": "conscious hip-hop",
+          "lastfmTag": "conscious-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q202925",
-          "label": "tribal house",
-          "lastfmTag": "tribal-house",
-          "parentId": "Q20502",
+          "id": "Q1270332",
+          "label": "Danish hip hop",
+          "lastfmTag": "danish-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q598593",
-          "label": "tech house",
-          "lastfmTag": "tech-house",
-          "parentId": "Q20502",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q21092",
-      "label": "moombahton",
-      "lastfmTag": "moombahton",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q178145",
-      "label": "gothic metal",
-      "lastfmTag": "gothic-metal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q179465",
-      "label": "polyphony",
-      "lastfmTag": "polyphony",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q442133",
-          "label": "old classical vocal polyphony",
-          "lastfmTag": "old-classical-vocal-polyphony",
-          "parentId": "Q179465",
+          "id": "Q1259016",
+          "label": "drill and bass",
+          "lastfmTag": "drill-and-bass",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q448738",
-          "label": "ensalada",
-          "lastfmTag": "ensalada",
-          "parentId": "Q179465",
+          "id": "Q876171",
+          "label": "East Coast hip-hop",
+          "lastfmTag": "east-coast-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q599877",
-          "label": "organum",
-          "lastfmTag": "organum",
-          "parentId": "Q179465",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q180268",
-      "label": "gospel music",
-      "lastfmTag": "gospel-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q180853",
-      "label": "pavane",
-      "lastfmTag": "pavane",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q185298",
-      "label": "a cappella",
-      "lastfmTag": "a-cappella",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q185652",
-      "label": "ragtime",
-      "lastfmTag": "ragtime",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q185676",
-      "label": "fado",
-      "lastfmTag": "fado",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q186017",
-      "label": "contemporary vocal music",
-      "lastfmTag": "contemporary-vocal-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q188237",
-      "label": "music of Cape Verde",
-      "lastfmTag": "music-of-cape-verde",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q502535",
-          "label": "morna",
-          "lastfmTag": "morna",
-          "parentId": "Q188237",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q188450",
-      "label": "electropop",
-      "lastfmTag": "electropop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q188994",
-      "label": "drum and bass",
-      "lastfmTag": "drum-and-bass",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q193207",
-      "label": "ambient music",
-      "lastfmTag": "ambient-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q193605",
-      "label": "lullaby",
-      "lastfmTag": "lullaby",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q194492",
-      "label": "gamelan",
-      "lastfmTag": "gamelan",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q196999",
-      "label": "Zeuhl",
-      "lastfmTag": "zeuhl",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q199415",
-      "label": "ziglibithy",
-      "lastfmTag": "ziglibithy",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q202919",
-      "label": "berceuse",
-      "lastfmTag": "berceuse",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q202930",
-      "label": "reggaeton",
-      "lastfmTag": "reggaeton",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q204067",
-      "label": "Swedish hip hop",
-      "lastfmTag": "swedish-hip-hop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q205049",
-      "label": "world music",
-      "lastfmTag": "world-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q205978",
-      "label": "circus music",
-      "lastfmTag": "circus-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q208239",
-      "label": "salsa",
-      "lastfmTag": "salsa",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q208494",
-      "label": "industrial metal",
-      "lastfmTag": "industrial-metal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q209137",
-      "label": "post-rock",
-      "lastfmTag": "post-rock",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q209498",
-      "label": "2 tone",
-      "lastfmTag": "2-tone",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q209741",
-      "label": "programme music",
-      "lastfmTag": "programme-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q271802",
-          "label": "symphonic poem",
-          "lastfmTag": "symphonic-poem",
-          "parentId": "Q209741",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q211025",
-      "label": "march",
-      "lastfmTag": "march",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q208341",
-          "label": "pasodoble",
-          "lastfmTag": "pasodoble",
-          "parentId": "Q211025",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q211418",
-      "label": "British Invasion",
-      "lastfmTag": "british-invasion",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q211723",
-      "label": "speed metal",
-      "lastfmTag": "speed-metal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q211745",
-      "label": "atonality",
-      "lastfmTag": "atonality",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q211756",
-      "label": "dance-pop",
-      "lastfmTag": "dance-pop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q211781",
-      "label": "free jazz",
-      "lastfmTag": "free-jazz",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q212024",
-      "label": "spirituals",
-      "lastfmTag": "spirituals",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q212112",
-      "label": "bel canto",
-      "lastfmTag": "bel-canto",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q212688",
-      "label": "dub music",
-      "lastfmTag": "dub-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q212944",
-      "label": "klezmer",
-      "lastfmTag": "klezmer",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q213121",
-      "label": "new age music",
-      "lastfmTag": "new-age-music",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q613874",
-          "label": "neoclassical new-age music",
-          "lastfmTag": "neoclassical-new-age-music",
-          "parentId": "Q213121",
+          "id": "Q384181",
+          "label": "freestyle rap",
+          "lastfmTag": "freestyle-rap",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
-          "id": "Q622688",
-          "label": "Andean new age music",
-          "lastfmTag": "andean-new-age-music",
-          "parentId": "Q213121",
+          "id": "Q138020",
+          "label": "French hip-hop",
+          "lastfmTag": "french-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q213608",
-      "label": "beatboxing",
-      "lastfmTag": "beatboxing",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q213665",
-      "label": "K-pop",
-      "lastfmTag": "k-pop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q216860",
-      "label": "Lied",
-      "lastfmTag": "lied",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q216926",
-      "label": "raga",
-      "lastfmTag": "raga",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q216961",
-      "label": "Eurodance",
-      "lastfmTag": "eurodance",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q217295",
-      "label": "mass",
-      "lastfmTag": "mass",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q217597",
-      "label": "electro",
-      "lastfmTag": "electro",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q220528",
-      "label": "Rebetiko",
-      "lastfmTag": "rebetiko",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q220535",
-      "label": "verbunkos",
-      "lastfmTag": "verbunkos",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q221686",
-      "label": "twelve-tone technique",
-      "lastfmTag": "twelve-tone-technique",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q221772",
-      "label": "acid jazz",
-      "lastfmTag": "acid-jazz",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q221934",
-      "label": "narcocorrido",
-      "lastfmTag": "narcocorrido",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q222445",
-      "label": "marinera",
-      "lastfmTag": "marinera",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q223840",
-      "label": "hardstyle",
-      "lastfmTag": "hardstyle",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q224694",
-      "label": "white power music",
-      "lastfmTag": "white-power-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q227036",
-      "label": "zouglou",
-      "lastfmTag": "zouglou",
-      "parentId": null,
-      "children": [
+        },
         {
-          "id": "Q513357",
-          "label": "coupé-décalé",
-          "lastfmTag": "coupé-décalé",
-          "parentId": "Q227036",
+          "id": "Q753679",
+          "label": "gangsta rap",
+          "lastfmTag": "gangsta-rap",
+          "parentId": "ANCHOR_hiphop",
           "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q227045",
-      "label": "zouk",
-      "lastfmTag": "zouk",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q235858",
-      "label": "traditional folk music",
-      "lastfmTag": "traditional-folk-music",
-      "parentId": null,
-      "children": [
+        },
         {
-          "id": "Q127624",
-          "label": "white voice",
-          "lastfmTag": "white-voice",
-          "parentId": "Q235858",
+          "id": "Q454071",
+          "label": "German hip-hop",
+          "lastfmTag": "german-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q245296",
-      "label": "zydeco",
-      "lastfmTag": "zydeco",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q245931",
-      "label": "music of Cyprus",
-      "lastfmTag": "music-of-cyprus",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q250090",
-      "label": "Ruba'i",
-      "lastfmTag": "ruba'i",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q251192",
-      "label": "downtempo",
-      "lastfmTag": "downtempo",
-      "parentId": null,
-      "children": [
+        },
+        {
+          "id": "Q1166726",
+          "label": "grime",
+          "lastfmTag": "grime",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q1077172",
+          "label": "instrumental hip-hop",
+          "lastfmTag": "instrumental-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q840748",
+          "label": "Iranian hip hop",
+          "lastfmTag": "iranian-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q470611",
+          "label": "Italian hip-hop",
+          "lastfmTag": "italian-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q255406",
+          "label": "jazz rap",
+          "lastfmTag": "jazz-rap",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q420883",
+          "label": "LGBT hip hop",
+          "lastfmTag": "lgbt-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q773084",
+          "label": "Norwegian hip hop",
+          "lastfmTag": "norwegian-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q868855",
+          "label": "old-school hip-hop",
+          "lastfmTag": "old-school-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q969663",
+          "label": "political hip-hop",
+          "lastfmTag": "political-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q1109947",
+          "label": "ragga hip hop",
+          "lastfmTag": "ragga-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q856872",
+          "label": "rap metal",
+          "lastfmTag": "rap-metal",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q6010",
+          "label": "rapping",
+          "lastfmTag": "rapping",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q1253172",
+          "label": "Southern hip-hop",
+          "lastfmTag": "southern-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q204067",
+          "label": "Swedish hip hop",
+          "lastfmTag": "swedish-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q1337973",
+          "label": "Swiss hip hop",
+          "lastfmTag": "swiss-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
         {
           "id": "Q205560",
           "label": "trip hop",
           "lastfmTag": "trip-hop",
-          "parentId": "Q251192",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q252626",
-      "label": "jota",
-      "lastfmTag": "jota",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q252821",
-      "label": "Viennese couplet",
-      "lastfmTag": "viennese-couplet",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q252833",
-      "label": "Alpine folk music",
-      "lastfmTag": "alpine-folk-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q254866",
-      "label": "Schuhplattler",
-      "lastfmTag": "schuhplattler",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q254890",
-      "label": "nova cançó",
-      "lastfmTag": "nova-cançó",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q257533",
-      "label": "music of Japan",
-      "lastfmTag": "music-of-japan",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q131425",
-          "label": "visual kei",
-          "lastfmTag": "visual-kei",
-          "parentId": "Q257533",
-          "children": [
-            {
-              "id": "Q278357",
-              "label": "oshare kei",
-              "lastfmTag": "oshare-kei",
-              "parentId": "Q131425",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q226887",
-          "label": "noh",
-          "lastfmTag": "noh",
-          "parentId": "Q257533",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q260095",
-      "label": "ultra",
-      "lastfmTag": "ultra",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q262533",
-      "label": "dithyramb",
-      "lastfmTag": "dithyramb",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q263524",
-      "label": "Tswana music",
-      "lastfmTag": "tswana-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q264289",
-      "label": "sophisti-pop",
-      "lastfmTag": "sophisti-pop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q264922",
-      "label": "jingle",
-      "lastfmTag": "jingle",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q268673",
-      "label": "music of the United Kingdom",
-      "lastfmTag": "music-of-the-united-kingdom",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q461406",
-          "label": "change ringing",
-          "lastfmTag": "change-ringing",
-          "parentId": "Q268673",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         },
         {
           "id": "Q469343",
           "label": "UK rap",
           "lastfmTag": "uk-rap",
-          "parentId": "Q268673",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q965635",
+          "label": "underground hip-hop",
+          "lastfmTag": "underground-hip-hop",
+          "parentId": "ANCHOR_hiphop",
+          "children": []
+        },
+        {
+          "id": "Q429264",
+          "label": "West Coast hip-hop",
+          "lastfmTag": "west-coast-hip-hop",
+          "parentId": "ANCHOR_hiphop",
           "children": []
         }
       ]
     },
     {
-      "id": "Q277393",
-      "label": "music of China",
-      "lastfmTag": "music-of-china",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q278409",
-      "label": "Hokkien pop",
-      "lastfmTag": "hokkien-pop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q281111",
-      "label": "ghazal",
-      "lastfmTag": "ghazal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q282131",
-      "label": "merengue",
-      "lastfmTag": "merengue",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q283405",
-      "label": "punta",
-      "lastfmTag": "punta",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q286080",
-      "label": "acoustic music",
-      "lastfmTag": "acoustic-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q288901",
-      "label": "Jarana Yucateca",
-      "lastfmTag": "jarana-yucateca",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q290869",
-      "label": "son montuno",
-      "lastfmTag": "son-montuno",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q444340",
-      "label": "crab canon",
-      "lastfmTag": "crab-canon",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q446241",
-      "label": "neo-medieval music",
-      "lastfmTag": "neo-medieval-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q454071",
-      "label": "German hip-hop",
-      "lastfmTag": "german-hip-hop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q455686",
-      "label": "samba reggae",
-      "lastfmTag": "samba-reggae",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q458480",
-      "label": "neotraditional country",
-      "lastfmTag": "neotraditional-country",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q461064",
-      "label": "music in advertising",
-      "lastfmTag": "music-in-advertising",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q464129",
-      "label": "mariachi",
-      "lastfmTag": "mariachi",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q465978",
-      "label": "extreme metal",
-      "lastfmTag": "extreme-metal",
+      "id": "ANCHOR_rnb",
+      "label": "R&B / Soul",
+      "lastfmTag": "soul",
       "parentId": null,
       "children": [
+        {
+          "id": "Q384064",
+          "label": "African gospel",
+          "lastfmTag": "african-gospel",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q756146",
+          "label": "Atlanta blues",
+          "lastfmTag": "atlanta-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q885561",
+          "label": "blue-eyed soul",
+          "lastfmTag": "blue-eyed-soul",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q9759",
+          "label": "blues",
+          "lastfmTag": "blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q966438",
+          "label": "blues ballad",
+          "lastfmTag": "blues-ballad",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q918542",
+          "label": "British blues",
+          "lastfmTag": "british-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1071873",
+          "label": "Chicago blues",
+          "lastfmTag": "chicago-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1269729",
+          "label": "Chicago soul",
+          "lastfmTag": "chicago-soul",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1074569",
+          "label": "chipmunk soul",
+          "lastfmTag": "chipmunk-soul",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1309336",
+          "label": "classic female blues",
+          "lastfmTag": "classic-female-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q850412",
+          "label": "contemporary R&B",
+          "lastfmTag": "contemporary-r-b",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q336567",
+          "label": "cosmic disco",
+          "lastfmTag": "cosmic-disco",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q649823",
+          "label": "country blues",
+          "lastfmTag": "country-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1182371",
+          "label": "deep funk",
+          "lastfmTag": "deep-funk",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1127539",
+          "label": "Delta blues",
+          "lastfmTag": "delta-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q648311",
+          "label": "Detroit blues",
+          "lastfmTag": "detroit-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q58339",
+          "label": "disco",
+          "lastfmTag": "disco",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q360596",
+          "label": "disco house",
+          "lastfmTag": "disco-house",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1185390",
+          "label": "disco polo",
+          "lastfmTag": "disco-polo",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q546359",
+          "label": "doo-wop",
+          "lastfmTag": "doo-wop",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q640097",
+          "label": "electric blues",
+          "lastfmTag": "electric-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1325963",
+          "label": "electro funk",
+          "lastfmTag": "electro-funk",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q164444",
+          "label": "funk",
+          "lastfmTag": "funk",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q667659",
+          "label": "funk metal",
+          "lastfmTag": "funk-metal",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1045541",
+          "label": "G-funk",
+          "lastfmTag": "g-funk",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q180268",
+          "label": "gospel music",
+          "lastfmTag": "gospel-music",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q744417",
+          "label": "Italo disco",
+          "lastfmTag": "italo-disco",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q38656",
+          "label": "jazz-funk",
+          "lastfmTag": "jazz-funk",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q515074",
+          "label": "Louisiana blues",
+          "lastfmTag": "louisiana-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q509901",
+          "label": "Memphis blues",
+          "lastfmTag": "memphis-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q268253",
+          "label": "neo soul",
+          "lastfmTag": "neo-soul",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q840065",
+          "label": "new jack swing",
+          "lastfmTag": "new-jack-swing",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q516568",
+          "label": "New Orleans blues",
+          "lastfmTag": "new-orleans-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q577080",
+          "label": "P-Funk",
+          "lastfmTag": "p-funk",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1109497",
+          "label": "Piedmont blues",
+          "lastfmTag": "piedmont-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1190485",
+          "label": "post-disco",
+          "lastfmTag": "post-disco",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q45981",
+          "label": "rhythm and blues",
+          "lastfmTag": "rhythm-and-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q534606",
+          "label": "swamp blues",
+          "lastfmTag": "swamp-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q1271752",
+          "label": "Texas blues",
+          "lastfmTag": "texas-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q880270",
+          "label": "traditional black gospel",
+          "lastfmTag": "traditional-black-gospel",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        },
+        {
+          "id": "Q177447",
+          "label": "West Coast blues",
+          "lastfmTag": "west-coast-blues",
+          "parentId": "ANCHOR_rnb",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "ANCHOR_electronic",
+      "label": "Electronic",
+      "lastfmTag": "electronic",
+      "parentId": null,
+      "children": [
+        {
+          "id": "Q341364",
+          "label": "acid house",
+          "lastfmTag": "acid-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q341395",
+          "label": "acid techno",
+          "lastfmTag": "acid-techno",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q481900",
+          "label": "acid trance",
+          "lastfmTag": "acid-trance",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q388100",
+          "label": "Afro house",
+          "lastfmTag": "afro-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q193207",
+          "label": "ambient music",
+          "lastfmTag": "ambient-music",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q530750",
+          "label": "Berlin School of electronic music",
+          "lastfmTag": "berlin-school-of-electronic-music",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q663519",
+          "label": "breakbeat",
+          "lastfmTag": "breakbeat",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q20903",
+          "label": "brostep",
+          "lastfmTag": "brostep",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1071961",
+          "label": "Chicago house",
+          "lastfmTag": "chicago-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q135637",
+          "label": "chiptune",
+          "lastfmTag": "chiptune",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q756956",
+          "label": "dark ambient",
+          "lastfmTag": "dark-ambient",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q874038",
+          "label": "deep house",
+          "lastfmTag": "deep-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q526463",
+          "label": "Detroit techno",
+          "lastfmTag": "detroit-techno",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1339027",
+          "label": "dream trance",
+          "lastfmTag": "dream-trance",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q188994",
+          "label": "drum and bass",
+          "lastfmTag": "drum-and-bass",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1262781",
+          "label": "dub techno",
+          "lastfmTag": "dub-techno",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q20474",
+          "label": "dubstep",
+          "lastfmTag": "dubstep",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1228230",
+          "label": "Dutch house",
+          "lastfmTag": "dutch-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q217597",
+          "label": "electro",
+          "lastfmTag": "electro",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q784310",
+          "label": "electro hop",
+          "lastfmTag": "electro-hop",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q627906",
+          "label": "electro house",
+          "lastfmTag": "electro-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q602561",
+          "label": "electro swing",
+          "lastfmTag": "electro-swing",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1325966",
+          "label": "electro wave",
+          "lastfmTag": "electro-wave",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1403744",
+          "label": "electro-industrial",
+          "lastfmTag": "electro-industrial",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q372103",
+          "label": "electronic body music",
+          "lastfmTag": "electronic-body-music",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q851213",
+          "label": "electronic dance music",
+          "lastfmTag": "electronic-dance-music",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q9778",
+          "label": "electronic music",
+          "lastfmTag": "electronic-music",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1415568",
+          "label": "filter house",
+          "lastfmTag": "filter-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q949369",
+          "label": "funky house",
+          "lastfmTag": "funky-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q835131",
+          "label": "Goa trance",
+          "lastfmTag": "goa-trance",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q832665",
+          "label": "hard trance",
+          "lastfmTag": "hard-trance",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q223840",
+          "label": "hardstyle",
+          "lastfmTag": "hardstyle",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q601235",
+          "label": "hip house",
+          "lastfmTag": "hip-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q20502",
+          "label": "house music",
+          "lastfmTag": "house-music",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q46649",
+          "label": "jump-up",
+          "lastfmTag": "jump-up",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1102161",
+          "label": "jungle",
+          "lastfmTag": "jungle",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q181999",
+          "label": "minimal electro",
+          "lastfmTag": "minimal-electro",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q750811",
+          "label": "minimal house",
+          "lastfmTag": "minimal-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q21092",
+          "label": "moombahton",
+          "lastfmTag": "moombahton",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q915152",
+          "label": "progressive house",
+          "lastfmTag": "progressive-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q598593",
+          "label": "tech house",
+          "lastfmTag": "tech-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q170611",
+          "label": "techno",
+          "lastfmTag": "techno",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q170435",
+          "label": "trance",
+          "lastfmTag": "trance",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q202925",
+          "label": "tribal house",
+          "lastfmTag": "tribal-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1136765",
+          "label": "uplifting trance",
+          "lastfmTag": "uplifting-trance",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q173844",
+          "label": "vocal house",
+          "lastfmTag": "vocal-house",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        },
+        {
+          "id": "Q1027999",
+          "label": "vocal trance",
+          "lastfmTag": "vocal-trance",
+          "parentId": "ANCHOR_electronic",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "ANCHOR_jazz",
+      "label": "Jazz",
+      "lastfmTag": "jazz",
+      "parentId": null,
+      "children": [
+        {
+          "id": "Q221772",
+          "label": "acid jazz",
+          "lastfmTag": "acid-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q632393",
+          "label": "archaic jazz",
+          "lastfmTag": "archaic-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q790188",
+          "label": "avant-garde jazz",
+          "lastfmTag": "avant-garde-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q105513",
+          "label": "bebop",
+          "lastfmTag": "bebop",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q486263",
+          "label": "bossa nova",
+          "lastfmTag": "bossa-nova",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q1034231",
+          "label": "cape jazz",
+          "lastfmTag": "cape-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q1092553",
+          "label": "Celtic fusion",
+          "lastfmTag": "celtic-fusion",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q352235",
+          "label": "Chicago jazz",
+          "lastfmTag": "chicago-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q327547",
+          "label": "cool jazz",
+          "lastfmTag": "cool-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q846833",
+          "label": "crossover jazz",
+          "lastfmTag": "crossover-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q906647",
+          "label": "Dixieland jazz",
+          "lastfmTag": "dixieland-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q1371364",
+          "label": "ethno jazz",
+          "lastfmTag": "ethno-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q211781",
+          "label": "free jazz",
+          "lastfmTag": "free-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q280955",
+          "label": "German jazz",
+          "lastfmTag": "german-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q844245",
+          "label": "Gypsy jazz",
+          "lastfmTag": "gypsy-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q181010",
+          "label": "hard bop",
+          "lastfmTag": "hard-bop",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q105527",
+          "label": "jazz fusion",
+          "lastfmTag": "jazz-fusion",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q591990",
+          "label": "jazz standard",
+          "lastfmTag": "jazz-standard",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q166813",
+          "label": "Kansas City jazz",
+          "lastfmTag": "kansas-city-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q837389",
+          "label": "Latin jazz",
+          "lastfmTag": "latin-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q1127530",
+          "label": "modal jazz",
+          "lastfmTag": "modal-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q1136331",
+          "label": "nu jazz",
+          "lastfmTag": "nu-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q1092837",
+          "label": "post-bop",
+          "lastfmTag": "post-bop",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q185652",
+          "label": "ragtime",
+          "lastfmTag": "ragtime",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q1249907",
+          "label": "Roma jazz",
+          "lastfmTag": "roma-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q183016",
+          "label": "ska jazz",
+          "lastfmTag": "ska-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q831354",
+          "label": "smooth jazz",
+          "lastfmTag": "smooth-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q181897",
+          "label": "stride piano",
+          "lastfmTag": "stride-piano",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q203775",
+          "label": "swing",
+          "lastfmTag": "swing",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q447962",
+          "label": "swing revival",
+          "lastfmTag": "swing-revival",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        },
+        {
+          "id": "Q492643",
+          "label": "trad jazz",
+          "lastfmTag": "trad-jazz",
+          "parentId": "ANCHOR_jazz",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "ANCHOR_classical",
+      "label": "Classical",
+      "lastfmTag": "classical",
+      "parentId": null,
+      "children": [
+        {
+          "id": "Q1338153",
+          "label": "20th-century classical music",
+          "lastfmTag": "20th-century-classical-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q185298",
+          "label": "a cappella",
+          "lastfmTag": "a-cappella",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q18846",
+          "label": "ancient music",
+          "lastfmTag": "ancient-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q623904",
+          "label": "Andalusi classical music",
+          "lastfmTag": "andalusi-classical-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q163491",
+          "label": "ars antiqua",
+          "lastfmTag": "ars-antiqua",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q210854",
+          "label": "ars nova",
+          "lastfmTag": "ars-nova",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q211745",
+          "label": "atonality",
+          "lastfmTag": "atonality",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q8361",
+          "label": "Baroque music",
+          "lastfmTag": "baroque-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q212112",
+          "label": "bel canto",
+          "lastfmTag": "bel-canto",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q202919",
+          "label": "berceuse",
+          "lastfmTag": "berceuse",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q174873",
+          "label": "cantata",
+          "lastfmTag": "cantata",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q207683",
+          "label": "canzona",
+          "lastfmTag": "canzona",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q41270",
+          "label": "cavatina",
+          "lastfmTag": "cavatina",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q189201",
+          "label": "chamber music",
+          "lastfmTag": "chamber-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1076513",
+          "label": "choral music",
+          "lastfmTag": "choral-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q856713",
+          "label": "Christian hymn",
+          "lastfmTag": "christian-hymn",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q9730",
+          "label": "classical music",
+          "lastfmTag": "classical-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q17723",
+          "label": "Classical period",
+          "lastfmTag": "classical-period",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q9748",
+          "label": "concerto",
+          "lastfmTag": "concerto",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q210216",
+          "label": "concerto grosso",
+          "lastfmTag": "concerto-grosso",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q612024",
+          "label": "contemporary classical music",
+          "lastfmTag": "contemporary-classical-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q186017",
+          "label": "contemporary vocal music",
+          "lastfmTag": "contemporary-vocal-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q59158",
+          "label": "dhrupad",
+          "lastfmTag": "dhrupad",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q836571",
+          "label": "fantasia",
+          "lastfmTag": "fantasia",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q185858",
+          "label": "Franco-Flemish School",
+          "lastfmTag": "franco-flemish-school",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q927425",
+          "label": "French overture",
+          "lastfmTag": "french-overture",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q181014",
+          "label": "fugue",
+          "lastfmTag": "fugue",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q288824",
+          "label": "galliard",
+          "lastfmTag": "galliard",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q26473",
+          "label": "Gregorian chant",
+          "lastfmTag": "gregorian-chant",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q484692",
+          "label": "hymn",
+          "lastfmTag": "hymn",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q852027",
+          "label": "impromptu",
+          "lastfmTag": "impromptu",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1323698",
+          "label": "Indian classical music",
+          "lastfmTag": "indian-classical-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q62128",
+          "label": "Khyal",
+          "lastfmTag": "khyal",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q216860",
+          "label": "Lied",
+          "lastfmTag": "lied",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q193217",
+          "label": "madrigal",
+          "lastfmTag": "madrigal",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q211025",
+          "label": "march",
+          "lastfmTag": "march",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q217295",
+          "label": "mass",
+          "lastfmTag": "mass",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q151942",
+          "label": "mazurka",
+          "lastfmTag": "mazurka",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q163775",
+          "label": "medieval music",
+          "lastfmTag": "medieval-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q188285",
+          "label": "motet",
+          "lastfmTag": "motet",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q725011",
+          "label": "neo-classical metal",
+          "lastfmTag": "neo-classical-metal",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q446241",
+          "label": "neo-medieval music",
+          "lastfmTag": "neo-medieval-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q194172",
+          "label": "nocturne",
+          "lastfmTag": "nocturne",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q442133",
+          "label": "old classical vocal polyphony",
+          "lastfmTag": "old-classical-vocal-polyphony",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1344",
+          "label": "opera",
+          "lastfmTag": "opera",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q85477",
+          "label": "oratorio",
+          "lastfmTag": "oratorio",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q202287",
+          "label": "overture",
+          "lastfmTag": "overture",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q208341",
+          "label": "pasodoble",
+          "lastfmTag": "pasodoble",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q180853",
+          "label": "pavane",
+          "lastfmTag": "pavane",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q212148",
+          "label": "prelude",
+          "lastfmTag": "prelude",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q209741",
+          "label": "programme music",
+          "lastfmTag": "programme-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1293057",
+          "label": "Protestant hymn",
+          "lastfmTag": "protestant-hymn",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q523896",
+          "label": "regional hymn",
+          "lastfmTag": "regional-hymn",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q201405",
+          "label": "Renaissance music",
+          "lastfmTag": "renaissance-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q207591",
+          "label": "Romantic music",
+          "lastfmTag": "romantic-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1314422",
+          "label": "sacred concerto",
+          "lastfmTag": "sacred-concerto",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q208593",
+          "label": "sarabande",
+          "lastfmTag": "sarabande",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q131269",
+          "label": "sonata",
+          "lastfmTag": "sonata",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q486415",
+          "label": "symphonic metal",
+          "lastfmTag": "symphonic-metal",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q271802",
+          "label": "symphonic poem",
+          "lastfmTag": "symphonic-poem",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q9734",
+          "label": "symphony",
+          "lastfmTag": "symphony",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q177771",
+          "label": "threnody",
+          "lastfmTag": "threnody",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q140544",
+          "label": "toccata",
+          "lastfmTag": "toccata",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1361883",
+          "label": "Trecento Madrigal",
+          "lastfmTag": "trecento-madrigal",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1399964",
+          "label": "uplifting classical",
+          "lastfmTag": "uplifting-classical",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q685884",
+          "label": "vocal music",
+          "lastfmTag": "vocal-music",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q1140291",
+          "label": "wedding march",
+          "lastfmTag": "wedding-march",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        },
+        {
+          "id": "Q127624",
+          "label": "white voice",
+          "lastfmTag": "white-voice",
+          "parentId": "ANCHOR_classical",
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "ANCHOR_metal",
+      "label": "Metal",
+      "lastfmTag": "metal",
+      "parentId": null,
+      "children": [
+        {
+          "id": "Q641357",
+          "label": "avant-garde metal",
+          "lastfmTag": "avant-garde-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
         {
           "id": "Q132438",
           "label": "black metal",
           "lastfmTag": "black-metal",
-          "parentId": "Q465978",
-          "children": [
-            {
-              "id": "Q213149",
-              "label": "viking metal",
-              "lastfmTag": "viking-metal",
-              "parentId": "Q132438",
-              "children": []
-            },
-            {
-              "id": "Q533914",
-              "label": "National Socialist black metal",
-              "lastfmTag": "national-socialist-black-metal",
-              "parentId": "Q132438",
-              "children": []
-            }
-          ]
-        },
-        {
-          "id": "Q186170",
-          "label": "doom metal",
-          "lastfmTag": "doom-metal",
-          "parentId": "Q465978",
+          "parentId": "ANCHOR_metal",
           "children": []
         },
         {
-          "id": "Q241662",
-          "label": "groove metal",
-          "lastfmTag": "groove-metal",
-          "parentId": "Q465978",
+          "id": "Q822914",
+          "label": "Christian metal",
+          "lastfmTag": "christian-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q932977",
+          "label": "crossover thrash",
+          "lastfmTag": "crossover-thrash",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q1166197",
+          "label": "dark metal",
+          "lastfmTag": "dark-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q1181308",
+          "label": "death 'n' roll",
+          "lastfmTag": "death-n-roll",
+          "parentId": "ANCHOR_metal",
           "children": []
         },
         {
           "id": "Q483251",
           "label": "death metal",
           "lastfmTag": "death-metal",
-          "parentId": "Q465978",
-          "children": [
-            {
-              "id": "Q253918",
-              "label": "melodic death metal",
-              "lastfmTag": "melodic-death-metal",
-              "parentId": "Q483251",
-              "children": []
-            },
-            {
-              "id": "Q542971",
-              "label": "progressive death metal",
-              "lastfmTag": "progressive-death-metal",
-              "parentId": "Q483251",
-              "children": []
-            }
-          ]
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q475221",
+          "label": "deathcore",
+          "lastfmTag": "deathcore",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q186170",
+          "label": "doom metal",
+          "lastfmTag": "doom-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q465978",
+          "label": "extreme metal",
+          "lastfmTag": "extreme-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q484179",
+          "label": "folk metal",
+          "lastfmTag": "folk-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q188539",
+          "label": "glam metal",
+          "lastfmTag": "glam-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q178145",
+          "label": "gothic metal",
+          "lastfmTag": "gothic-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q188534",
+          "label": "grindcore",
+          "lastfmTag": "grindcore",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q241662",
+          "label": "groove metal",
+          "lastfmTag": "groove-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q38848",
+          "label": "heavy metal music",
+          "lastfmTag": "heavy-metal-music",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q208494",
+          "label": "industrial metal",
+          "lastfmTag": "industrial-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q616679",
+          "label": "mathcore",
+          "lastfmTag": "mathcore",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q253918",
+          "label": "melodic death metal",
+          "lastfmTag": "melodic-death-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q183862",
+          "label": "metalcore",
+          "lastfmTag": "metalcore",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q533914",
+          "label": "National Socialist black metal",
+          "lastfmTag": "national-socialist-black-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q1414858",
+          "label": "New York death metal",
+          "lastfmTag": "new-york-death-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q263734",
+          "label": "nu metal",
+          "lastfmTag": "nu-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q41343",
+          "label": "post-metal",
+          "lastfmTag": "post-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q57143",
+          "label": "power metal",
+          "lastfmTag": "power-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q542971",
+          "label": "progressive death metal",
+          "lastfmTag": "progressive-death-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q484344",
+          "label": "progressive metal",
+          "lastfmTag": "progressive-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q720959",
+          "label": "sludge metal",
+          "lastfmTag": "sludge-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q211723",
+          "label": "speed metal",
+          "lastfmTag": "speed-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q1076092",
+          "label": "technical death metal",
+          "lastfmTag": "technical-death-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
         },
         {
           "id": "Q483352",
           "label": "thrash metal",
           "lastfmTag": "thrash-metal",
-          "parentId": "Q465978",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q466445",
-      "label": "American primitive guitar",
-      "lastfmTag": "american-primitive-guitar",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q470611",
-      "label": "Italian hip-hop",
-      "lastfmTag": "italian-hip-hop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q473602",
-      "label": "music of Poland",
-      "lastfmTag": "music-of-poland",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q151942",
-          "label": "mazurka",
-          "lastfmTag": "mazurka",
-          "parentId": "Q473602",
-          "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q476091",
-      "label": "slow jam",
-      "lastfmTag": "slow-jam",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q476983",
-      "label": "synth-punk",
-      "lastfmTag": "synth-punk",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q478176",
-      "label": "piphat",
-      "lastfmTag": "piphat",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q482981",
-      "label": "pansori",
-      "lastfmTag": "pansori",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q483740",
-      "label": "Anatolian rock",
-      "lastfmTag": "anatolian-rock",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q484179",
-      "label": "folk metal",
-      "lastfmTag": "folk-metal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q484344",
-      "label": "progressive metal",
-      "lastfmTag": "progressive-metal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q484692",
-      "label": "hymn",
-      "lastfmTag": "hymn",
-      "parentId": null,
-      "children": [
-        {
-          "id": "Q177771",
-          "label": "threnody",
-          "lastfmTag": "threnody",
-          "parentId": "Q484692",
+          "parentId": "ANCHOR_metal",
           "children": []
         },
         {
-          "id": "Q541947",
-          "label": "anthem",
-          "lastfmTag": "anthem",
-          "parentId": "Q484692",
+          "id": "Q1133657",
+          "label": "traditional heavy metal",
+          "lastfmTag": "traditional-heavy-metal",
+          "parentId": "ANCHOR_metal",
           "children": []
         },
         {
-          "id": "Q574784",
-          "label": "lauda",
-          "lastfmTag": "lauda",
-          "parentId": "Q484692",
+          "id": "Q970409",
+          "label": "unblack metal",
+          "lastfmTag": "unblack-metal",
+          "parentId": "ANCHOR_metal",
+          "children": []
+        },
+        {
+          "id": "Q213149",
+          "label": "viking metal",
+          "lastfmTag": "viking-metal",
+          "parentId": "ANCHOR_metal",
           "children": []
         }
       ]
     },
     {
-      "id": "Q485915",
-      "label": "trot",
-      "lastfmTag": "trot",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q486263",
-      "label": "bossa nova",
-      "lastfmTag": "bossa-nova",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q486415",
-      "label": "symphonic metal",
-      "lastfmTag": "symphonic-metal",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q487965",
-      "label": "industrial music",
-      "lastfmTag": "industrial-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q489913",
-      "label": "bolero",
-      "lastfmTag": "bolero",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q491621",
-      "label": "tusch",
-      "lastfmTag": "tusch",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q492067",
-      "label": "Buddhist music",
-      "lastfmTag": "buddhist-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q492096",
-      "label": "Andean music",
-      "lastfmTag": "andean-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q492264",
-      "label": "film score",
-      "lastfmTag": "film-score",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q496929",
-      "label": "maloya",
-      "lastfmTag": "maloya",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q497674",
-      "label": "pungmul",
-      "lastfmTag": "pungmul",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q497957",
-      "label": "nueva trova",
-      "lastfmTag": "nueva-trova",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q502448",
-      "label": "coco",
-      "lastfmTag": "coco",
+      "id": "ANCHOR_folk",
+      "label": "Folk",
+      "lastfmTag": "folk",
       "parentId": null,
       "children": [
         {
-          "id": "Q504476",
-          "label": "Ciranda",
-          "lastfmTag": "ciranda",
-          "parentId": "Q502448",
+          "id": "Q286080",
+          "label": "acoustic music",
+          "lastfmTag": "acoustic-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q252833",
+          "label": "Alpine folk music",
+          "lastfmTag": "alpine-folk-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q574651",
+          "label": "anti-folk",
+          "lastfmTag": "anti-folk",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q12302",
+          "label": "bagad",
+          "lastfmTag": "bagad",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q213714",
+          "label": "bluegrass music",
+          "lastfmTag": "bluegrass-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q854451",
+          "label": "Celtic music",
+          "lastfmTag": "celtic-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q43343",
+          "label": "folk music",
+          "lastfmTag": "folk-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q722989",
+          "label": "Hungarian folk music",
+          "lastfmTag": "hungarian-folk-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q1162461",
+          "label": "Hungarian folk song",
+          "lastfmTag": "hungarian-folk-song",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q627181",
+          "label": "industrial folk music",
+          "lastfmTag": "industrial-folk-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q1048249",
+          "label": "Italian folk music",
+          "lastfmTag": "italian-folk-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q193605",
+          "label": "lullaby",
+          "lastfmTag": "lullaby",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q649634",
+          "label": "progressive folk",
+          "lastfmTag": "progressive-folk",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q118120",
+          "label": "reel",
+          "lastfmTag": "reel",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q1195253",
+          "label": "sea shanty",
+          "lastfmTag": "sea-shanty",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q1077388",
+          "label": "sentimental ballad",
+          "lastfmTag": "sentimental-ballad",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q606089",
+          "label": "skiffle",
+          "lastfmTag": "skiffle",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q1103669",
+          "label": "Țara Călatei folk music and dance",
+          "lastfmTag": "ara-c-latei-folk-music-and-dance",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q235858",
+          "label": "traditional folk music",
+          "lastfmTag": "traditional-folk-music",
+          "parentId": "ANCHOR_folk",
+          "children": []
+        },
+        {
+          "id": "Q786815",
+          "label": "turbo-folk",
+          "lastfmTag": "turbo-folk",
+          "parentId": "ANCHOR_folk",
           "children": []
         }
       ]
     },
     {
-      "id": "Q502658",
-      "label": "work song",
-      "lastfmTag": "work-song",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q502808",
-      "label": "xote",
-      "lastfmTag": "xote",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q503354",
-      "label": "Christmas carol",
-      "lastfmTag": "christmas-carol",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q504635",
-      "label": "crossover",
-      "lastfmTag": "crossover",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q505343",
-      "label": "jongo",
-      "lastfmTag": "jongo",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q507246",
-      "label": "serialism",
-      "lastfmTag": "serialism",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q508790",
-      "label": "chastushka",
-      "lastfmTag": "chastushka",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q509901",
-      "label": "Memphis blues",
-      "lastfmTag": "memphis-blues",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q517415",
-      "label": "Europop",
-      "lastfmTag": "europop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q523896",
-      "label": "regional hymn",
-      "lastfmTag": "regional-hymn",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q525073",
-      "label": "music of Asia",
-      "lastfmTag": "music-of-asia",
+      "id": "ANCHOR_country",
+      "label": "Country",
+      "lastfmTag": "country",
       "parentId": null,
       "children": [
         {
-          "id": "Q130572",
-          "label": "music of the Soviet Union",
-          "lastfmTag": "music-of-the-soviet-union",
-          "parentId": "Q525073",
+          "id": "Q804401",
+          "label": "Bakersfield sound",
+          "lastfmTag": "bakersfield-sound",
+          "parentId": "ANCHOR_country",
+          "children": []
+        },
+        {
+          "id": "Q83440",
+          "label": "country music",
+          "lastfmTag": "country-music",
+          "parentId": "ANCHOR_country",
+          "children": []
+        },
+        {
+          "id": "Q458480",
+          "label": "neotraditional country",
+          "lastfmTag": "neotraditional-country",
+          "parentId": "ANCHOR_country",
+          "children": []
+        },
+        {
+          "id": "Q964658",
+          "label": "outlaw country",
+          "lastfmTag": "outlaw-country",
+          "parentId": "ANCHOR_country",
+          "children": []
+        },
+        {
+          "id": "Q1425111",
+          "label": "western music",
+          "lastfmTag": "western-music",
+          "parentId": "ANCHOR_country",
           "children": []
         }
       ]
     },
     {
-      "id": "Q527675",
-      "label": "bambuco",
-      "lastfmTag": "bambuco",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q530750",
-      "label": "Berlin School of electronic music",
-      "lastfmTag": "berlin-school-of-electronic-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q531426",
-      "label": "music of India",
-      "lastfmTag": "music-of-india",
+      "id": "ANCHOR_world",
+      "label": "World",
+      "lastfmTag": "world",
       "parentId": null,
       "children": [
+        {
+          "id": "Q972634",
+          "label": "African popular music",
+          "lastfmTag": "african-popular-music",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q388207",
+          "label": "African-American music",
+          "lastfmTag": "african-american-music",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q388296",
+          "label": "Afrobeat",
+          "lastfmTag": "afrobeat",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q47112",
+          "label": "Albanian iso-polyphony",
+          "lastfmTag": "albanian-iso-polyphony",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q624044",
+          "label": "Arabic music",
+          "lastfmTag": "arabic-music",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q25116",
+          "label": "Argentine tango",
+          "lastfmTag": "argentine-tango",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q40461",
+          "label": "bachata",
+          "lastfmTag": "bachata",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q19816",
+          "label": "batucada",
+          "lastfmTag": "batucada",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q854844",
+          "label": "bhangra",
+          "lastfmTag": "bhangra",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1014887",
+          "label": "burger-highlife",
+          "lastfmTag": "burger-highlife",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q870340",
+          "label": "chalga",
+          "lastfmTag": "chalga",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1062328",
+          "label": "chanson",
+          "lastfmTag": "chanson",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1076539",
+          "label": "choro",
+          "lastfmTag": "choro",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q4797",
+          "label": "conjunto",
+          "lastfmTag": "conjunto",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1127157",
+          "label": "conscious reggae",
+          "lastfmTag": "conscious-reggae",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q155119",
+          "label": "cuarteto",
+          "lastfmTag": "cuarteto",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q723418",
+          "label": "cumbia",
+          "lastfmTag": "cumbia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1143743",
+          "label": "cumbia romántica",
+          "lastfmTag": "cumbia-rom-ntica",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1143752",
+          "label": "cumbia villera",
+          "lastfmTag": "cumbia-villera",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1143744",
+          "label": "digital cumbia",
+          "lastfmTag": "digital-cumbia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q212688",
+          "label": "dub music",
+          "lastfmTag": "dub-music",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1113204",
+          "label": "dub poetry",
+          "lastfmTag": "dub-poetry",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1277532",
+          "label": "early reggae",
+          "lastfmTag": "early-reggae",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q873478",
+          "label": "enka",
+          "lastfmTag": "enka",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1205368",
+          "label": "European tango",
+          "lastfmTag": "european-tango",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q185676",
+          "label": "fado",
+          "lastfmTag": "fado",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q9764",
+          "label": "flamenco",
+          "lastfmTag": "flamenco",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q194492",
+          "label": "gamelan",
+          "lastfmTag": "gamelan",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q963061",
+          "label": "highlife",
+          "lastfmTag": "highlife",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q145594",
+          "label": "Igbo music",
+          "lastfmTag": "igbo-music",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1386554",
+          "label": "Japanese ska",
+          "lastfmTag": "japanese-ska",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q212944",
+          "label": "klezmer",
+          "lastfmTag": "klezmer",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q131510",
+          "label": "mantra",
+          "lastfmTag": "mantra",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q464129",
+          "label": "mariachi",
+          "lastfmTag": "mariachi",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q282131",
+          "label": "merengue",
+          "lastfmTag": "merengue",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q383103",
+          "label": "music of Afghanistan",
+          "lastfmTag": "music-of-afghanistan",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q369820",
+          "label": "music of Africa",
+          "lastfmTag": "music-of-africa",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1075799",
+          "label": "music of Albania",
+          "lastfmTag": "music-of-albania",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q512359",
+          "label": "music of ancient Egypt",
+          "lastfmTag": "music-of-ancient-egypt",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1139787",
+          "label": "music of ancient Greece",
+          "lastfmTag": "music-of-ancient-greece",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q645992",
+          "label": "music of Argentina",
+          "lastfmTag": "music-of-argentina",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q525073",
+          "label": "music of Asia",
+          "lastfmTag": "music-of-asia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q724104",
+          "label": "music of Azerbaijan",
+          "lastfmTag": "music-of-azerbaijan",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q968018",
+          "label": "music of Belize",
+          "lastfmTag": "music-of-belize",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q592807",
+          "label": "music of Bhutan",
+          "lastfmTag": "music-of-bhutan",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1132929",
+          "label": "music of Botswana",
+          "lastfmTag": "music-of-botswana",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q899215",
+          "label": "music of Brazil",
+          "lastfmTag": "music-of-brazil",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q910606",
+          "label": "music of Brittany",
+          "lastfmTag": "music-of-brittany",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1003981",
+          "label": "music of Bulgaria",
+          "lastfmTag": "music-of-bulgaria",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q188237",
+          "label": "music of Cape Verde",
+          "lastfmTag": "music-of-cape-verde",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q277393",
+          "label": "music of China",
+          "lastfmTag": "music-of-china",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q920883",
+          "label": "music of Colombia",
+          "lastfmTag": "music-of-colombia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1236268",
+          "label": "music of Croatia",
+          "lastfmTag": "music-of-croatia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q245931",
+          "label": "music of Cyprus",
+          "lastfmTag": "music-of-cyprus",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1417976",
+          "label": "music of Finland",
+          "lastfmTag": "music-of-finland",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q672134",
+          "label": "music of France",
+          "lastfmTag": "music-of-france",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q919948",
+          "label": "music of Greenland",
+          "lastfmTag": "music-of-greenland",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1298412",
+          "label": "music of Guatemala",
+          "lastfmTag": "music-of-guatemala",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1071834",
+          "label": "music of Hawaii",
+          "lastfmTag": "music-of-hawaii",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q932477",
+          "label": "music of Hungary",
+          "lastfmTag": "music-of-hungary",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q531426",
+          "label": "music of India",
+          "lastfmTag": "music-of-india",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1210921",
+          "label": "music of Indonesia",
+          "lastfmTag": "music-of-indonesia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1378776",
+          "label": "music of Ireland",
+          "lastfmTag": "music-of-ireland",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q3858",
+          "label": "music of Israel",
+          "lastfmTag": "music-of-israel",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q572717",
+          "label": "music of Jamaica",
+          "lastfmTag": "music-of-jamaica",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q257533",
+          "label": "music of Japan",
+          "lastfmTag": "music-of-japan",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1131855",
+          "label": "music of Kazakhstan",
+          "lastfmTag": "music-of-kazakhstan",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q716060",
+          "label": "music of Korea",
+          "lastfmTag": "music-of-korea",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q761163",
+          "label": "music of Laos",
+          "lastfmTag": "music-of-laos",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q727781",
+          "label": "music of Latin America",
+          "lastfmTag": "music-of-latin-america",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1091536",
+          "label": "music of Madagascar",
+          "lastfmTag": "music-of-madagascar",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q608490",
+          "label": "music of Namibia",
+          "lastfmTag": "music-of-namibia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q833189",
+          "label": "music of Norway",
+          "lastfmTag": "music-of-norway",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q473602",
+          "label": "music of Poland",
+          "lastfmTag": "music-of-poland",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q427183",
+          "label": "music of Puerto Rico",
+          "lastfmTag": "music-of-puerto-rico",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q935086",
+          "label": "music of Qatar",
+          "lastfmTag": "music-of-qatar",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
         {
           "id": "Q289505",
           "label": "music of Rajasthan",
           "lastfmTag": "music-of-rajasthan",
-          "parentId": "Q531426",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q852210",
+          "label": "music of Romania",
+          "lastfmTag": "music-of-romania",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1048469",
+          "label": "music of Scotland",
+          "lastfmTag": "music-of-scotland",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q964987",
+          "label": "music of Spain",
+          "lastfmTag": "music-of-spain",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q846784",
+          "label": "music of Sweden",
+          "lastfmTag": "music-of-sweden",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q956925",
+          "label": "music of Taiwan",
+          "lastfmTag": "music-of-taiwan",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q867306",
+          "label": "music of Thailand",
+          "lastfmTag": "music-of-thailand",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q377185",
+          "label": "music of the Netherlands",
+          "lastfmTag": "music-of-the-netherlands",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q130572",
+          "label": "music of the Soviet Union",
+          "lastfmTag": "music-of-the-soviet-union",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q268673",
+          "label": "music of the United Kingdom",
+          "lastfmTag": "music-of-the-united-kingdom",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q936552",
+          "label": "music of Tunisia",
+          "lastfmTag": "music-of-tunisia",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1074080",
+          "label": "music of Turkey",
+          "lastfmTag": "music-of-turkey",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q155858",
+          "label": "music of Ukraine",
+          "lastfmTag": "music-of-ukraine",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q23965",
+          "label": "music of Uruguay",
+          "lastfmTag": "music-of-uruguay",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1156957",
+          "label": "music of Vietnam",
+          "lastfmTag": "music-of-vietnam",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q179465",
+          "label": "polyphony",
+          "lastfmTag": "polyphony",
+          "parentId": "ANCHOR_world",
           "children": []
         },
         {
           "id": "Q512410",
           "label": "qawwali",
           "lastfmTag": "qawwali",
-          "parentId": "Q531426",
+          "parentId": "ANCHOR_world",
           "children": []
         },
         {
-          "id": "Q544440",
-          "label": "filmi music",
-          "lastfmTag": "filmi-music",
-          "parentId": "Q531426",
+          "id": "Q216926",
+          "label": "raga",
+          "lastfmTag": "raga",
+          "parentId": "ANCHOR_world",
           "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q533946",
-      "label": "lambada",
-      "lastfmTag": "lambada",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q535328",
-      "label": "gaita zuliana",
-      "lastfmTag": "gaita-zuliana",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q546359",
-      "label": "doo-wop",
-      "lastfmTag": "doo-wop",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q547137",
-      "label": "Latin pop",
-      "lastfmTag": "latin-pop",
-      "parentId": null,
-      "children": [
+        },
         {
-          "id": "Q535402",
-          "label": "tropipop",
-          "lastfmTag": "tropipop",
-          "parentId": "Q547137",
+          "id": "Q220528",
+          "label": "Rebetiko",
+          "lastfmTag": "rebetiko",
+          "parentId": "ANCHOR_world",
           "children": []
-        }
-      ]
-    },
-    {
-      "id": "Q556959",
-      "label": "mbalax",
-      "lastfmTag": "mbalax",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q564848",
-      "label": "aria di sorbetto",
-      "lastfmTag": "aria-di-sorbetto",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q567915",
-      "label": "gigue",
-      "lastfmTag": "gigue",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q572717",
-      "label": "music of Jamaica",
-      "lastfmTag": "music-of-jamaica",
-      "parentId": null,
-      "children": [
+        },
         {
           "id": "Q9794",
           "label": "reggae",
           "lastfmTag": "reggae",
-          "parentId": "Q572717",
-          "children": [
-            {
-              "id": "Q474027",
-              "label": "dancehall",
-              "lastfmTag": "dancehall",
-              "parentId": "Q9794",
-              "children": []
-            },
-            {
-              "id": "Q500879",
-              "label": "reggae en Español",
-              "lastfmTag": "reggae-en-español",
-              "parentId": "Q9794",
-              "children": []
-            }
-          ]
+          "parentId": "ANCHOR_world",
+          "children": []
         },
         {
-          "id": "Q573484",
-          "label": "rocksteady",
-          "lastfmTag": "rocksteady",
-          "parentId": "Q572717",
+          "id": "Q500879",
+          "label": "reggae en Español",
+          "lastfmTag": "reggae-en-espa-ol",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q202930",
+          "label": "reggaeton",
+          "lastfmTag": "reggaeton",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q1299260",
+          "label": "roots reggae",
+          "lastfmTag": "roots-reggae",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q208239",
+          "label": "salsa",
+          "lastfmTag": "salsa",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q11403",
+          "label": "samba",
+          "lastfmTag": "samba",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q455686",
+          "label": "samba reggae",
+          "lastfmTag": "samba-reggae",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q54365",
+          "label": "ska",
+          "lastfmTag": "ska",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q70076",
+          "label": "tappa",
+          "lastfmTag": "tappa",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q69596",
+          "label": "Thumri",
+          "lastfmTag": "thumri",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q205049",
+          "label": "world music",
+          "lastfmTag": "world-music",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q140222",
+          "label": "zajal",
+          "lastfmTag": "zajal",
+          "parentId": "ANCHOR_world",
+          "children": []
+        },
+        {
+          "id": "Q227045",
+          "label": "zouk",
+          "lastfmTag": "zouk",
+          "parentId": "ANCHOR_world",
           "children": []
         }
       ]
     },
     {
-      "id": "Q572901",
-      "label": "minimalist music",
-      "lastfmTag": "minimalist-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q574651",
-      "label": "anti-folk",
-      "lastfmTag": "anti-folk",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q577080",
-      "label": "P-Funk",
-      "lastfmTag": "p-funk",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q579955",
-      "label": "regueifa",
-      "lastfmTag": "regueifa",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q582093",
-      "label": "antiphon",
-      "lastfmTag": "antiphon",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q584752",
-      "label": "pornogrind",
-      "lastfmTag": "pornogrind",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q585588",
-      "label": "Khaliji",
-      "lastfmTag": "khaliji",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q586110",
-      "label": "forró",
-      "lastfmTag": "forró",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q590662",
-      "label": "bend-skin",
-      "lastfmTag": "bend-skin",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q592060",
-      "label": "free improvisation",
-      "lastfmTag": "free-improvisation",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q592807",
-      "label": "music of Bhutan",
-      "lastfmTag": "music-of-bhutan",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q597493",
-      "label": "chacarera",
-      "lastfmTag": "chacarera",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q598929",
-      "label": "post-punk",
-      "lastfmTag": "post-punk",
+      "id": "ANCHOR_experimental",
+      "label": "Experimental",
+      "lastfmTag": "experimental",
       "parentId": null,
       "children": [
         {
-          "id": "Q284543",
-          "label": "ethereal wave",
-          "lastfmTag": "ethereal-wave",
-          "parentId": "Q598929",
+          "id": "Q83390",
+          "label": "acclamatio",
+          "lastfmTag": "acclamatio",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q650316",
+          "label": "drone music",
+          "lastfmTag": "drone-music",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q492264",
+          "label": "film score",
+          "lastfmTag": "film-score",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q1100989",
+          "label": "glitch",
+          "lastfmTag": "glitch",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q82469",
+          "label": "Gstanzl",
+          "lastfmTag": "gstanzl",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q42201",
+          "label": "independent music",
+          "lastfmTag": "independent-music",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q487965",
+          "label": "industrial music",
+          "lastfmTag": "industrial-music",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q643684",
+          "label": "jukebox musical",
+          "lastfmTag": "jukebox-musical",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q310871",
+          "label": "lowercase",
+          "lastfmTag": "lowercase",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q1078010",
+          "label": "martial industrial",
+          "lastfmTag": "martial-industrial",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q48445",
+          "label": "mashup",
+          "lastfmTag": "mashup",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q572901",
+          "label": "minimalist music",
+          "lastfmTag": "minimalist-music",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q2743",
+          "label": "musical",
+          "lastfmTag": "musical",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q1049625",
+          "label": "musical improvisation",
+          "lastfmTag": "musical-improvisation",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q1370345",
+          "label": "musical theater",
+          "lastfmTag": "musical-theater",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q823560",
+          "label": "musique concrète",
+          "lastfmTag": "musique-concr-te",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q726239",
+          "label": "noise music",
+          "lastfmTag": "noise-music",
+          "parentId": "ANCHOR_experimental",
+          "children": []
+        },
+        {
+          "id": "Q936942",
+          "label": "post-industrial music",
+          "lastfmTag": "post-industrial-music",
+          "parentId": "ANCHOR_experimental",
           "children": []
         }
       ]
-    },
-    {
-      "id": "Q599510",
-      "label": "romance",
-      "lastfmTag": "romance",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q600094",
-      "label": "paean",
-      "lastfmTag": "paean",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q602561",
-      "label": "electro swing",
-      "lastfmTag": "electro-swing",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q602859",
-      "label": "Lamentations of Jeremiah the Prophet",
-      "lastfmTag": "lamentations-of-jeremiah-the-prophet",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q604748",
-      "label": "responsory",
-      "lastfmTag": "responsory",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q606089",
-      "label": "skiffle",
-      "lastfmTag": "skiffle",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q606393",
-      "label": "Hi-NRG",
-      "lastfmTag": "hi-nrg",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q608490",
-      "label": "music of Namibia",
-      "lastfmTag": "music-of-namibia",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q608862",
-      "label": "anime song",
-      "lastfmTag": "anime-song",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q610022",
-      "label": "kaseko",
-      "lastfmTag": "kaseko",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q612024",
-      "label": "contemporary classical music",
-      "lastfmTag": "contemporary-classical-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q613707",
-      "label": "expressionist music",
-      "lastfmTag": "expressionist-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q615418",
-      "label": "sonorism",
-      "lastfmTag": "sonorism",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q615455",
-      "label": "lhamo",
-      "lastfmTag": "lhamo",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q616425",
-      "label": "pirekua",
-      "lastfmTag": "pirekua",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q617338",
-      "label": "apala",
-      "lastfmTag": "apala",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q620979",
-      "label": "Appenzeller string music",
-      "lastfmTag": "appenzeller-string-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q623715",
-      "label": "aleatoric music",
-      "lastfmTag": "aleatoric-music",
-      "parentId": null,
-      "children": []
-    },
-    {
-      "id": "Q623823",
-      "label": "arabesque",
-      "lastfmTag": "arabesque",
-      "parentId": null,
-      "children": []
     }
   ]
 }

--- a/scripts/build-genre-taxonomy.ts
+++ b/scripts/build-genre-taxonomy.ts
@@ -12,8 +12,6 @@ interface GenreNode {
 interface SparqlBinding {
   genre: { value: string }
   genreLabel: { value: string }
-  parent?: { value: string }
-  parentLabel?: { value: string }
 }
 
 interface SparqlResult {
@@ -22,38 +20,142 @@ interface SparqlResult {
   }
 }
 
+interface Anchor {
+  id: string
+  label: string
+  lastfmTag: string
+  match: (string | RegExp)[]
+}
+
 const SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql'
 
 const SPARQL_QUERY = `
-SELECT ?genre ?genreLabel ?parent ?parentLabel WHERE {
+SELECT ?genre ?genreLabel WHERE {
   ?genre wdt:P31 wd:Q188451.
-  OPTIONAL { ?genre wdt:P279 ?parent. ?parent wdt:P31 wd:Q188451. }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 }
-LIMIT 500
+LIMIT 1000
 `
+
+const ANCHORS: Anchor[] = [
+  {
+    id: 'ANCHOR_rock',
+    label: 'Rock',
+    lastfmTag: 'rock',
+    match: [/\brock\b/i, /\bpunk\b/i, /\bshoegaze\b/i, /\bgrunge\b/i, /\bemo\b/i, /\bindie\b/i, /\bpost[- ]punk\b/i, /\bhardcore\b/i, /\bgarage\b/i, /\bpsychedelic\b/i, /\bscreamo\b/i, /\bsurf\b/i, /\brockabilly\b/i, /\bbritpop\b/i, /\balternative\b/i, /\bzamrock\b/i, /\bzeuhl\b/i, /\b2 tone\b/i, /\btwo[- ]tone\b/i, /\bbritish invasion\b/i, /\bvisual kei\b/i, /\bgoth\b/i, /\bprog\b/i, /\bmath rock\b/i],
+  },
+  {
+    id: 'ANCHOR_pop',
+    label: 'Pop',
+    lastfmTag: 'pop',
+    match: [/\bpop\b/i, /\bsynth[- ]?pop\b/i, /\bdream pop\b/i, /\bbubblegum\b/i, /\bj-pop\b/i, /\bk-pop\b/i, /\belectropop\b/i, /\bnew wave\b/i, /\bnew romantic\b/i, /\bteen pop\b/i, /\bcity pop\b/i, /\bhypnagogic\b/i],
+  },
+  {
+    id: 'ANCHOR_hiphop',
+    label: 'Hip-Hop',
+    lastfmTag: 'hip-hop',
+    match: [/\bhip[- ]?hop\b/i, /\brap\b/i, /\brapping\b/i, /\btrap\b/i, /\bdrill\b/i, /\bgrime\b/i, /\bboom bap\b/i, /\bcloud rap\b/i, /\bmumble\b/i, /\btrip hop\b/i],
+  },
+  {
+    id: 'ANCHOR_rnb',
+    label: 'R&B / Soul',
+    lastfmTag: 'soul',
+    match: [/\bsoul\b/i, /\brhythm and blues\b/i, /\br&b\b/i, /\bfunk\b/i, /\bmotown\b/i, /\bneo[- ]soul\b/i, /\bgospel\b/i, /\bdisco\b/i, /\bblues\b/i, /\bdoo[- ]wop\b/i, /\bnew jack swing\b/i, /\bquiet storm\b/i],
+  },
+  {
+    id: 'ANCHOR_electronic',
+    label: 'Electronic',
+    lastfmTag: 'electronic',
+    match: [/\belectronic\b/i, /\btechno\b/i, /\bhouse\b/i, /\btrance\b/i, /\bambient\b/i, /\bdrum and bass\b/i, /\bdubstep\b/i, /\bbrostep\b/i, /\bidm\b/i, /\belectro\b/i, /\bgarage\b/i, /\bbreakbeat\b/i, /\bchiptune\b/i, /\bsynthwave\b/i, /\bvaporwave\b/i, /\bedm\b/i, /\bjungle\b/i, /\bjump[- ]up\b/i, /\bmoombahton\b/i, /\bbass music\b/i, /\bbigroom\b/i, /\bhardstyle\b/i],
+  },
+  {
+    id: 'ANCHOR_jazz',
+    label: 'Jazz',
+    lastfmTag: 'jazz',
+    match: [/\bjazz\b/i, /\bbebop\b/i, /\bswing\b/i, /\bfusion\b/i, /\bdixieland\b/i, /\bragtime\b/i, /\bbossa\b/i, /\bhard bop\b/i, /\bstride piano\b/i, /\bcool\b/i, /\bpost[- ]bop\b/i, /\bsmooth jazz\b/i],
+  },
+  {
+    id: 'ANCHOR_classical',
+    label: 'Classical',
+    lastfmTag: 'classical',
+    match: [/\bclassical\b/i, /\bbaroque\b/i, /\bromantic\b/i, /\bsymphon/i, /\bopera\b/i, /\boratorio\b/i, /\bconcerto\b/i, /\bsonata\b/i, /\bchoral\b/i, /\bmedieval\b/i, /\brenaissance\b/i, /\bchamber\b/i, /\bancient music\b/i, /\bgregorian\b/i, /\bplainsong\b/i, /\bplainchant\b/i, /\bcavatina\b/i, /\bmadrigal\b/i, /\bhymn\b/i, /\bmotet\b/i, /\bcantata\b/i, /\brequiem\b/i, /\bfugue\b/i, /\betude\b/i, /\bprelude\b/i, /\bmass\b/i, /\bdhrupad\b/i, /\bkhyal\b/i, /\bars antiqua\b/i, /\bars nova\b/i, /\btoccata\b/i, /\bnocturne\b/i, /\bmazurka\b/i, /\bpavane\b/i, /\bthrenody\b/i, /\bfranco[- ]flemish\b/i, /\ba cappella\b/i, /\bvocal music\b/i, /\bwhite voice\b/i, /\blied\b/i, /\belegy\b/i, /\bscherzo\b/i, /\boverture\b/i, /\bberceuse\b/i, /\bcanzona\b/i, /\bétude\b/i, /\bsarabande\b/i, /\bpasodoble\b/i, /\bprogramme music\b/i, /\bmarch\b/i, /\batonal/i, /\bbel canto\b/i, /\bgalliard\b/i, /\bpolonaise\b/i, /\bmenuet\b/i, /\bminuet\b/i, /\bwaltz\b/i, /\bimpromptu\b/i, /\bfantasia\b/i, /\bstudy\b/i],
+  },
+  {
+    id: 'ANCHOR_metal',
+    label: 'Metal',
+    lastfmTag: 'metal',
+    match: [/\bmetal\b/i, /\bmetalcore\b/i, /\bthrash\b/i, /\bdeath\b/i, /\bblack metal\b/i, /\bdoom\b/i, /\bsludge\b/i, /\bgrindcore\b/i, /\bdeathcore\b/i, /\bmathcore\b/i, /\bpower metal\b/i, /\bviking\b/i, /\bpagan\b/i, /\bcrust\b/i],
+  },
+  {
+    id: 'ANCHOR_folk',
+    label: 'Folk',
+    lastfmTag: 'folk',
+    match: [/\bfolk\b/i, /\bacoustic\b/i, /\bbluegrass\b/i, /\bcelt/i, /\bballad\b/i, /\breel\b/i, /\bshanty\b/i, /\bsinger[- ]songwriter\b/i, /\bbagad\b/i, /\bbothy\b/i, /\bappalachian\b/i, /\bsea chant/i, /\blullaby\b/i, /\bskiffle\b/i, /\bdrinking song\b/i],
+  },
+  {
+    id: 'ANCHOR_country',
+    label: 'Country',
+    lastfmTag: 'country',
+    match: [/\bcountry\b/i, /\bhonky[- ]tonk\b/i, /\bwestern\b/i, /\balt[- ]country\b/i, /\bamericana\b/i, /\bouthwestern\b/i, /\bnashville\b/i, /\bbakersfield\b/i, /\boutlaw\b/i, /\btex[- ]mex\b/i, /\bbluegrass\b/i],
+  },
+  {
+    id: 'ANCHOR_world',
+    label: 'World',
+    lastfmTag: 'world',
+    match: [/\bworld\b/i, /\breggae\b/i, /\bska\b/i, /\bdub\b/i, /\bcumbia\b/i, /\bsalsa\b/i, /\bmerengue\b/i, /\btango\b/i, /\bsamba\b/i, /\bafrobeat\b/i, /\bhighlife\b/i, /\bigbo\b/i, /\bmbaqanga\b/i, /\bcuarteto\b/i, /\bzajal\b/i, /\bmantra\b/i, /\bthumri\b/i, /\btappa\b/i, /\bca trù\b/i, /\bukraine\b/i, /\baustrian\b/i, /\bfrench\b/i, /\barabic\b/i, /\blatin\b/i, /\breggaeton\b/i, /\bflamenco\b/i, /\bcarib/i, /\bbhangra\b/i, /\braga\b/i, /\bqawwali\b/i, /\brai\b/i, /\bfado\b/i, /\btarab\b/i, /\bsoukous\b/i, /\bgnawa\b/i, /\bbachata\b/i, /\bbatucada\b/i, /\bchoro\b/i, /\bmusic of\b/i, /\bconjunto\b/i, /\bpolyphony\b/i, /\bmusic from\b/i, /\btraditional\b/i, /\bklezmer\b/i, /\bjarocho\b/i, /\bforró\b/i, /\bpagode\b/i, /\bmpb\b/i, /\bsertanej/i, /\bchanson\b/i, /\benka\b/i, /\bj-rock\b/i, /\bgamelan\b/i, /\bmariachi\b/i, /\bnorteñ/i, /\bbanda\b/i, /\btex[- ]mex\b/i, /\bzouk\b/i, /\bkompa\b/i, /\bchalga\b/i, /\brebetiko\b/i, /\bturkish\b/i, /\bindonesian\b/i, /\bchinese\b/i, /\bgaelic\b/i, /\biranian\b/i, /\bafrican\b/i, /\basian\b/i],
+  },
+  {
+    id: 'ANCHOR_experimental',
+    label: 'Experimental',
+    lastfmTag: 'experimental',
+    match: [/\bexperimental\b/i, /\bnoise\b/i, /\bavant[- ]garde\b/i, /\bdrone\b/i, /\bmusique concr[èe]te\b/i, /\bsound art\b/i, /\bmusical\b/i, /\bacclamatio\b/i, /\bgstanzl\b/i, /\bmashup\b/i, /\bindependent music\b/i, /\bminimalist\b/i, /\bglitch\b/i, /\blowercase\b/i, /\bindustrial\b/i, /\bfilm score\b/i, /\bsoundtrack\b/i],
+  },
+]
+
+const FALLBACK_CHILDREN: Record<string, string[]> = {
+  ANCHOR_rock: ['indie rock', 'post-punk', 'shoegaze', 'garage rock', 'psychedelic rock'],
+  ANCHOR_pop: ['synth-pop', 'dream pop', 'j-pop', 'k-pop', 'bubblegum pop'],
+  ANCHOR_hiphop: ['boom bap', 'cloud rap', 'trap', 'drill', 'grime'],
+  ANCHOR_rnb: ['neo-soul', 'funk', 'motown', 'gospel', 'disco'],
+  ANCHOR_electronic: ['house', 'techno', 'ambient', 'drum and bass', 'dubstep'],
+  ANCHOR_jazz: ['bebop', 'swing', 'fusion', 'bossa nova', 'ragtime'],
+  ANCHOR_classical: ['baroque', 'romantic', 'opera', 'chamber music', 'medieval music'],
+  ANCHOR_metal: ['thrash metal', 'death metal', 'black metal', 'doom metal', 'sludge metal'],
+  ANCHOR_folk: ['bluegrass', 'celtic', 'acoustic', 'singer-songwriter', 'shanty'],
+  ANCHOR_country: ['honky-tonk', 'alt-country', 'americana', 'western', 'outlaw country'],
+  ANCHOR_world: ['reggae', 'salsa', 'afrobeat', 'flamenco', 'bhangra'],
+  ANCHOR_experimental: ['noise', 'avant-garde', 'drone', 'sound art', 'musique concrète'],
+}
 
 function extractQid(uri: string): string {
   return uri.replace('http://www.wikidata.org/entity/', '')
 }
 
 function toLastfmTag(label: string): string {
-  return label.toLowerCase().replace(/\s+/g, '-')
+  return label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
 }
 
-const FALLBACK_NODES: GenreNode[] = [
-  { id: 'Q11399',   label: 'Jazz',         lastfmTag: 'jazz',         parentId: null, children: [] },
-  { id: 'Q11366',   label: 'Rock',         lastfmTag: 'rock',         parentId: null, children: [] },
-  { id: 'Q9778',    label: 'Electronic',   lastfmTag: 'electronic',   parentId: null, children: [] },
-  { id: 'Q11401',   label: 'Hip-Hop',      lastfmTag: 'hip-hop',      parentId: null, children: [] },
-  { id: 'Q41057',   label: 'Folk',         lastfmTag: 'folk',         parentId: null, children: [] },
-  { id: 'Q38848',   label: 'Metal',        lastfmTag: 'metal',        parentId: null, children: [] },
-  { id: 'Q9734',    label: 'Classical',    lastfmTag: 'classical',    parentId: null, children: [] },
-  { id: 'Q8341',    label: 'World',        lastfmTag: 'world',        parentId: null, children: [] },
-  { id: 'Q1191489', label: 'Experimental', lastfmTag: 'experimental', parentId: null, children: [] },
-]
+function matchesAnchor(label: string, anchor: Anchor): boolean {
+  for (const m of anchor.match) {
+    if (typeof m === 'string') {
+      if (label.toLowerCase().includes(m.toLowerCase())) return true
+    } else if (m.test(label)) {
+      return true
+    }
+  }
+  return false
+}
 
-async function fetchGenres(): Promise<GenreNode[]> {
+function assignAnchor(label: string): Anchor | null {
+  for (const anchor of ANCHORS) {
+    if (matchesAnchor(label, anchor)) return anchor
+  }
+  return null
+}
+
+interface RawGenre { id: string; label: string }
+
+async function fetchRawGenres(): Promise<RawGenre[]> {
   const url = new URL(SPARQL_ENDPOINT)
   url.searchParams.set('query', SPARQL_QUERY)
   url.searchParams.set('format', 'json')
@@ -71,41 +173,84 @@ async function fetchGenres(): Promise<GenreNode[]> {
   }
 
   const data = (await response.json()) as SparqlResult
-  const bindings = data.results.bindings
+  const seen = new Set<string>()
+  const out: RawGenre[] = []
+  for (const b of data.results.bindings) {
+    const id = extractQid(b.genre.value)
+    const label = b.genreLabel.value
+    if (!label || label === id || seen.has(id)) continue
+    seen.add(id)
+    out.push({ id, label })
+  }
+  return out
+}
 
-  // Build flat map
-  const map = new Map<string, GenreNode>()
-  for (const binding of bindings) {
-    const id = extractQid(binding.genre.value)
-    const label = binding.genreLabel.value
-    if (!map.has(id)) {
-      map.set(id, {
-        id,
-        label,
-        lastfmTag: toLastfmTag(label),
-        parentId: null,
-        children: [],
-      })
-    }
-    // Set parentId if present
-    if (binding.parent) {
-      const node = map.get(id)!
-      node.parentId = extractQid(binding.parent.value)
-    }
+function buildAnchoredTree(raw: RawGenre[]): { nodes: GenreNode[]; assigned: number; dropped: string[] } {
+  const anchorNodes = new Map<string, GenreNode>()
+  for (const a of ANCHORS) {
+    anchorNodes.set(a.id, {
+      id: a.id,
+      label: a.label,
+      lastfmTag: a.lastfmTag,
+      parentId: null,
+      children: [],
+    })
   }
 
-  // Link children to parents, collect roots
-  const roots: GenreNode[] = []
-  for (const node of map.values()) {
-    if (node.parentId && map.has(node.parentId)) {
-      map.get(node.parentId)!.children.push(node)
-    } else {
-      node.parentId = null
-      roots.push(node)
+  const childrenSeenTags = new Map<string, Set<string>>()
+  for (const a of ANCHORS) childrenSeenTags.set(a.id, new Set([a.lastfmTag]))
+
+  let assigned = 0
+  const dropped: string[] = []
+
+  for (const g of raw) {
+    const anchor = assignAnchor(g.label)
+    if (!anchor) {
+      dropped.push(g.label)
+      continue
     }
+    const tag = toLastfmTag(g.label)
+    const seen = childrenSeenTags.get(anchor.id)!
+    if (seen.has(tag)) continue
+    seen.add(tag)
+    anchorNodes.get(anchor.id)!.children.push({
+      id: g.id,
+      label: g.label,
+      lastfmTag: tag,
+      parentId: anchor.id,
+      children: [],
+    })
+    assigned++
   }
 
-  return roots
+  // Hand-seed starved anchors (<3 children) from FALLBACK_CHILDREN.
+  for (const a of ANCHORS) {
+    const node = anchorNodes.get(a.id)!
+    const seen = childrenSeenTags.get(a.id)!
+    if (node.children.length < 3) {
+      const fallback = FALLBACK_CHILDREN[a.id] ?? []
+      for (const label of fallback) {
+        const tag = toLastfmTag(label)
+        if (seen.has(tag)) continue
+        seen.add(tag)
+        node.children.push({
+          id: `${a.id}_seed_${tag}`,
+          label,
+          lastfmTag: tag,
+          parentId: a.id,
+          children: [],
+        })
+        if (node.children.length >= 6) break
+      }
+    }
+    node.children.sort((x, y) => x.label.localeCompare(y.label))
+  }
+
+  return { nodes: Array.from(anchorNodes.values()), assigned, dropped }
+}
+
+function fallbackTree(): GenreNode[] {
+  return buildAnchoredTree([]).nodes
 }
 
 async function main() {
@@ -115,13 +260,20 @@ async function main() {
 
   try {
     console.log('Fetching genre taxonomy from Wikidata SPARQL...')
-    nodes = await fetchGenres()
-    source = 'wikidata'
-    console.log(`Fetched ${nodes.length} root genre nodes from Wikidata.`)
+    const raw = await fetchRawGenres()
+    console.log(`Fetched ${raw.length} raw genre labels from Wikidata.`)
+    const { nodes: tree, assigned, dropped } = buildAnchoredTree(raw)
+    nodes = tree
+    source = 'wikidata+anchored'
+    console.log(`Assigned ${assigned} sub-genres across ${tree.length} anchors.`)
+    console.log(`Dropped ${dropped.length} unmatched labels (first 20): ${dropped.slice(0, 20).join(', ')}`)
+    for (const a of tree) {
+      console.log(`  ${a.label}: ${a.children.length} sub-genres`)
+    }
   } catch (err) {
-    console.warn('Wikidata unreachable or returned an error — using fallback genres.')
+    console.warn('Wikidata unreachable or returned an error — using fallback anchors only.')
     console.warn(err instanceof Error ? err.message : String(err))
-    nodes = FALLBACK_NODES
+    nodes = fallbackTree()
     source = 'fallback'
   }
 


### PR DESCRIPTION
## Summary

Accumulated work on the `Nick` branch since it diverged from `main`. Ships the open-discovery pivot end-to-end:

- **Auth pivot** — username-only HMAC credentials, new sign-in page (social removal).
- **Onboarding redesign** — seed pipeline expansion, path-card layout (Artists / Genres / Last.fm), and as of this PR a hierarchical genre picker with 12 curated anchors + drill-down rather than a flat 200+ pill list.
- **Genre taxonomy** — Wikidata build script rewritten to bucket ~1000 labels under the 12 anchors via regex matchers.
- **Engine & provider** — spotify-provider updates, recommendation engine improvements, cold-start seeds.
- **Settings** — delete-account flow + API, underground mode, stats page.
- **Hardening** — security fixes, RLS migrations, rate limiter, login-attempts tracking, dead-code removal.

## Test plan

- [ ] `npm test` — 466 tests passing locally at tip.
- [ ] Sign in with a new username → reach `/onboarding` → confirm stacked genre anchors render, drill-down works, parent + child tags can be picked independently, 20-tag cap enforced.
- [ ] Complete onboarding → verify `/feed` loads recommendations seeded from the selected tags.
- [ ] Settings → delete-account round-trip.
- [ ] Underground mode toggle affects feed composition.
- [ ] Stats page renders.

## Follow-ups

- Genre picker UX — the anchor drill-down works but a 112-item Rock list is too much. Needs a more elegant sub-navigation (search-within-anchor, popular-first + "show all", or a second hierarchy level). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)