### PR TITLE
Taste anchors settings, stats.fm pipeline, DiceBear avatar

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -13,7 +13,7 @@ export default async function SettingsPage() {
   const supabase = createServiceClient()
   const { data: user } = await supabase
     .from("users")
-    .select("id, play_threshold, lastfm_username, underground_mode")
+    .select("id, play_threshold, lastfm_username, statsfm_username, underground_mode, selected_genres")
     .eq("id", userId)
     .maybeSingle()
 
@@ -27,15 +27,30 @@ export default async function SettingsPage() {
     lastfmArtistCount = count ?? 0
   }
 
-  const userSeed = userId
+  const { data: seedArtistsData } = await supabase
+    .from("seed_artists")
+    .select("spotify_artist_id, name, image_url, added_at")
+    .eq("user_id", userId)
+    .order("added_at", { ascending: true })
+
+  const seedArtists = (seedArtistsData ?? []).map((r) => ({
+    id: r.spotify_artist_id,
+    name: r.name,
+    genres: [] as string[],
+    imageUrl: r.image_url,
+    popularity: 0,
+  }))
 
   return (
     <SettingsForm
-      userSeed={userSeed}
+      userSeed={userId}
       initialPlayThreshold={user?.play_threshold ?? 5}
       initialLastfmUsername={user?.lastfm_username ?? null}
+      initialStatsfmUsername={user?.statsfm_username ?? null}
       initialLastfmArtistCount={lastfmArtistCount}
       initialUndergroundMode={user?.underground_mode ?? false}
+      initialSelectedGenres={(user?.selected_genres as string[] | null) ?? []}
+      initialSeedArtists={seedArtists}
     />
   )
 }

--- a/app/(marketing)/onboarding/page.tsx
+++ b/app/(marketing)/onboarding/page.tsx
@@ -1,46 +1,16 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
-import { Search, X, Music, ChevronDown, ChevronUp, Lock } from "lucide-react"
-import genreData from "@/data/genres.json"
+import { Music, ChevronDown, ChevronUp, Lock } from "lucide-react"
 import type { GenreNode } from "@/lib/types"
+import { GenrePicker } from "@/components/onboarding/genre-picker"
+import { ArtistSearch, type SpotifyArtist } from "@/components/onboarding/artist-search"
 
-// ── Types ────────────────────────────────────────────────────────────────────
-
-interface SpotifyArtist {
-  id: string
-  name: string
-  genres: string[]
-  imageUrl: string | null
-  popularity: number
-}
-
-// ── Genre helpers ─────────────────────────────────────────────────────────────
-
-const ALL_GENRES: GenreNode[] = (genreData as { nodes: GenreNode[] }).nodes
-
-// ── Sub-components ────────────────────────────────────────────────────────────
-
-function Chip({ label, onRemove }: { label: string; onRemove: () => void }) {
-  return (
-    <div
-      className="chip selected"
-      style={{ display: "flex", alignItems: "center", gap: 6 }}
-    >
-      <span>{label}</span>
-      <button
-        type="button"
-        onClick={onRemove}
-        aria-label={`Remove ${label}`}
-        style={{ background: "none", border: 0, cursor: "pointer", color: "inherit", padding: 0, display: "flex" }}
-      >
-        <X size={11} />
-      </button>
-    </div>
-  )
-}
+const SPOTIFY_VISIBLE = false
+const ARTIST_CAP = 200
+const GENRE_CAP = 200
 
 // ── Main component ────────────────────────────────────────────────────────────
 
@@ -51,38 +21,10 @@ export default function OnboardingPage() {
   // Active paths (can expand multiple)
   const [openPaths, setOpenPaths] = useState<Set<string>>(new Set())
 
-  // Artist search state
-  const [artistQuery, setArtistQuery] = useState("")
-  const [artistResults, setArtistResults] = useState<SpotifyArtist[]>([])
-  const [artistSearching, setArtistSearching] = useState(false)
   const [selectedArtists, setSelectedArtists] = useState<SpotifyArtist[]>([])
-  const artistDebounceRef = useRef<NodeJS.Timeout | null>(null)
-
-  // Genre state
   const [selectedGenres, setSelectedGenres] = useState<GenreNode[]>([])
-  const [openAnchors, setOpenAnchors] = useState<Set<string>>(new Set())
-  const [openClusters, setOpenClusters] = useState<Set<string>>(new Set())
-
-  const toggleAnchor = (id: string) => {
-    setOpenAnchors((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
-
-  const toggleCluster = (id: string) => {
-    setOpenClusters((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }
-
-  // Last.fm state
   const [lastfmUsername, setLastfmUsername] = useState("")
+  const [statsfmUsername, setStatsfmUsername] = useState("")
 
   const togglePath = (key: string) => {
     setOpenPaths((prev) => {
@@ -93,54 +35,32 @@ export default function OnboardingPage() {
     })
   }
 
-  // Artist search debounce
-  useEffect(() => {
-    if (artistDebounceRef.current) clearTimeout(artistDebounceRef.current)
-    if (!artistQuery.trim()) { setArtistResults([]); return }
-
-    artistDebounceRef.current = setTimeout(async () => {
-      setArtistSearching(true)
-      try {
-        const res = await fetch(`/api/onboarding/search?q=${encodeURIComponent(artistQuery.trim())}`)
-        if (res.ok) {
-          const data = await res.json()
-          setArtistResults(data.artists ?? [])
-        }
-      } finally {
-        setArtistSearching(false)
-      }
-    }, 350)
-
-    return () => { if (artistDebounceRef.current) clearTimeout(artistDebounceRef.current) }
-  }, [artistQuery])
-
-  const selectedArtistIds = new Set(selectedArtists.map((a) => a.id))
   const selectedGenreIds = new Set(selectedGenres.map((g) => g.id))
 
   function addArtist(artist: SpotifyArtist) {
-    if (!selectedArtistIds.has(artist.id) && selectedArtists.length < 10) {
-      setSelectedArtists((prev) => [...prev, artist])
-    }
+    setSelectedArtists((prev) => {
+      if (prev.some((a) => a.id === artist.id) || prev.length >= ARTIST_CAP) return prev
+      return [...prev, artist]
+    })
   }
 
   function removeArtist(id: string) {
     setSelectedArtists((prev) => prev.filter((a) => a.id !== id))
   }
 
-  function addGenre(genre: GenreNode) {
-    if (!selectedGenreIds.has(genre.id) && selectedGenres.length < 20) {
-      setSelectedGenres((prev) => [...prev, genre])
+  function toggleGenre(node: GenreNode) {
+    if (selectedGenreIds.has(node.id)) {
+      setSelectedGenres((prev) => prev.filter((g) => g.id !== node.id))
+    } else {
+      setSelectedGenres((prev) => (prev.length < GENRE_CAP ? [...prev, node] : prev))
     }
-  }
-
-  function removeGenre(id: string) {
-    setSelectedGenres((prev) => prev.filter((g) => g.id !== id))
   }
 
   const hasAnyInput =
     selectedArtists.length > 0 ||
     selectedGenres.length > 0 ||
-    lastfmUsername.trim().length > 0
+    lastfmUsername.trim().length > 0 ||
+    statsfmUsername.trim().length > 0
 
   async function handleContinue(skip = false) {
     if (saving) return
@@ -149,31 +69,28 @@ export default function OnboardingPage() {
     try {
       const promises: Promise<Response>[] = []
 
-      // 1. Save Last.fm username
-      if (!skip && lastfmUsername.trim()) {
-        promises.push(fetch("/api/settings", {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ lastfmUsername: lastfmUsername.trim() }),
-        }))
-      }
-
-      // 2. Save selected genres
+      const settingsPayload: Record<string, unknown> = {}
+      if (!skip && lastfmUsername.trim()) settingsPayload.lastfmUsername = lastfmUsername.trim()
+      if (!skip && statsfmUsername.trim()) settingsPayload.statsfmUsername = statsfmUsername.trim()
       if (!skip && selectedGenres.length > 0) {
+        settingsPayload.selectedGenres = selectedGenres.map((g) => g.lastfmTag)
+      }
+      if (Object.keys(settingsPayload).length > 0) {
         promises.push(fetch("/api/settings", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ selectedGenres: selectedGenres.map((g) => g.lastfmTag) }),
+          body: JSON.stringify(settingsPayload),
         }))
       }
 
-      // 3. Save seed artists
-      const artistsToSave = selectedArtists.slice(0, 5)
+      const artistsToSave = selectedArtists.slice(0, ARTIST_CAP)
       if (!skip && artistsToSave.length >= 3) {
         promises.push(fetch("/api/onboarding/seeds", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ artistIds: artistsToSave.map((a) => a.id) }),
+          body: JSON.stringify({
+            artists: artistsToSave.map((a) => ({ id: a.id, name: a.name, imageUrl: a.imageUrl })),
+          }),
         }))
       }
 
@@ -244,93 +161,12 @@ export default function OnboardingPage() {
             onToggle={() => togglePath("artists")}
             chipCount={selectedArtists.length}
           >
-            <div className="col gap-10">
-              {selectedArtists.length > 0 && (
-                <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                  {selectedArtists.map((a) => (
-                    <Chip key={a.id} label={a.name} onRemove={() => removeArtist(a.id)} />
-                  ))}
-                </div>
-              )}
-              <div className="field" style={{ height: 40, position: "relative" }}>
-                <Search
-                  size={14}
-                  style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: "var(--text-muted)", pointerEvents: "none" }}
-                />
-                <input
-                  type="text"
-                  placeholder="Search artists…"
-                  value={artistQuery}
-                  onChange={(e) => setArtistQuery(e.target.value)}
-                  style={{ paddingLeft: 32 }}
-                />
-              </div>
-              {artistSearching && (
-                <div className="mono muted" style={{ fontSize: 11 }}>Searching…</div>
-              )}
-              {artistResults.length > 0 && (
-                <div
-                  style={{
-                    maxHeight: 220,
-                    overflowY: "auto",
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 2,
-                    borderRadius: 10,
-                    border: "1px solid var(--border)",
-                    background: "var(--bg-card)",
-                  }}
-                >
-                  {artistResults.map((artist) => {
-                    const already = selectedArtistIds.has(artist.id)
-                    return (
-                      <button
-                        key={artist.id}
-                        type="button"
-                        disabled={already || selectedArtists.length >= 10}
-                        onClick={() => addArtist(artist)}
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 10,
-                          padding: "9px 12px",
-                          background: already ? "rgba(139,92,246,0.08)" : "transparent",
-                          border: 0,
-                          cursor: already ? "default" : "pointer",
-                          textAlign: "left",
-                          borderBottom: "1px solid var(--border)",
-                        }}
-                      >
-                        {artist.imageUrl ? (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img src={artist.imageUrl} alt="" style={{ width: 32, height: 32, borderRadius: 6, objectFit: "cover", flexShrink: 0 }} />
-                        ) : (
-                          <div style={{ width: 32, height: 32, borderRadius: 6, background: "rgba(255,255,255,0.06)", flexShrink: 0 }} />
-                        )}
-                        <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                            {artist.name}
-                          </div>
-                          {artist.genres[0] && (
-                            <div className="mono" style={{ fontSize: 10, color: "var(--text-muted)", textTransform: "uppercase" }}>
-                              {artist.genres[0]}
-                            </div>
-                          )}
-                        </div>
-                        {already && (
-                          <span style={{ fontSize: 11, color: "var(--accent)", flexShrink: 0 }}>added</span>
-                        )}
-                      </button>
-                    )
-                  })}
-                </div>
-              )}
-              {selectedArtists.length > 0 && selectedArtists.length < 3 && (
-                <div className="muted" style={{ fontSize: 11 }}>
-                  Add {3 - selectedArtists.length} more to use this path
-                </div>
-              )}
-            </div>
+            <ArtistSearch
+              selected={selectedArtists}
+              onAdd={addArtist}
+              onRemove={removeArtist}
+              cap={ARTIST_CAP}
+            />
           </PathCard>
 
           {/* ── Genre picker ────────────────────────────────────────── */}
@@ -342,23 +178,11 @@ export default function OnboardingPage() {
             onToggle={() => togglePath("genres")}
             chipCount={selectedGenres.length}
           >
-            <div className="col gap-6">
-              {ALL_GENRES.map((anchor) => (
-                <GenreAnchor
-                  key={anchor.id}
-                  anchor={anchor}
-                  expanded={openAnchors.has(anchor.id)}
-                  onToggleExpand={() => toggleAnchor(anchor.id)}
-                  openClusters={openClusters}
-                  onToggleCluster={toggleCluster}
-                  selectedIds={selectedGenreIds}
-                  atCap={selectedGenres.length >= 20}
-                  onToggleSelect={(node) =>
-                    selectedGenreIds.has(node.id) ? removeGenre(node.id) : addGenre(node)
-                  }
-                />
-              ))}
-            </div>
+            <GenrePicker
+              selected={selectedGenres}
+              onToggle={toggleGenre}
+              cap={GENRE_CAP}
+            />
           </PathCard>
 
           {/* ── Last.fm ─────────────────────────────────────────────── */}
@@ -386,29 +210,56 @@ export default function OnboardingPage() {
             </div>
           </PathCard>
 
-          {/* ── Spotify (locked) ────────────────────────────────────── */}
-          <div
-            className="fs-card"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 14,
-              opacity: 0.45,
-              cursor: "default",
-            }}
+          {/* ── stats.fm ────────────────────────────────────────────── */}
+          <PathCard
+            icon={<span style={{ fontSize: 15 }}>📊</span>}
+            title="stats.fm history"
+            subtitle="Import your Spotify listening stats"
+            open={openPaths.has("statsfm")}
+            onToggle={() => togglePath("statsfm")}
+            chipCount={statsfmUsername.trim() ? 1 : 0}
           >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="var(--spotify)" style={{ flexShrink: 0 }}>
-              <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
-            </svg>
-            <div style={{ flex: 1 }}>
-              <div style={{ fontSize: 14, fontWeight: 600 }}>Spotify</div>
-              <div className="mono" style={{ fontSize: 11, color: "var(--text-muted)" }}>restricted access</div>
+            <div className="col gap-8">
+              <div className="field" style={{ height: 40 }}>
+                <input
+                  type="text"
+                  placeholder="your-statsfm-username"
+                  value={statsfmUsername}
+                  onChange={(e) => setStatsfmUsername(e.target.value)}
+                  spellCheck={false}
+                />
+              </div>
+              <div className="muted" style={{ fontSize: 11.5, lineHeight: 1.5 }}>
+                Your stats.fm profile must be public. We&rsquo;ll pull top artists to filter familiars.
+              </div>
             </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 6, color: "var(--text-faint)" }}>
-              <Lock size={12} />
-              <span style={{ fontSize: 10.5, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em" }}>locked</span>
+          </PathCard>
+
+          {/* ── Spotify (locked) — hidden for now ──────────────────── */}
+          {SPOTIFY_VISIBLE && (
+            <div
+              className="fs-card"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 14,
+                opacity: 0.45,
+                cursor: "default",
+              }}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="var(--spotify)" style={{ flexShrink: 0 }}>
+                <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+              </svg>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 14, fontWeight: 600 }}>Spotify</div>
+                <div className="mono" style={{ fontSize: 11, color: "var(--text-muted)" }}>restricted access</div>
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6, color: "var(--text-faint)" }}>
+                <Lock size={12} />
+                <span style={{ fontSize: 10.5, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em" }}>locked</span>
+              </div>
             </div>
-          </div>
+          )}
 
         </div>
 
@@ -532,274 +383,5 @@ function PathCard({
         </div>
       )}
     </div>
-  )
-}
-
-// ── GenreAnchor (level 1) ─────────────────────────────────────────────────────
-
-function countSelectedInTree(node: GenreNode, selectedIds: Set<string>): number {
-  let n = selectedIds.has(node.id) ? 1 : 0
-  for (const child of node.children) n += countSelectedInTree(child, selectedIds)
-  return n
-}
-
-function countLeaves(node: GenreNode): number {
-  if (node.children.length === 0) return 1
-  return node.children.reduce((n, c) => n + countLeaves(c), 0)
-}
-
-function GenreAnchor({
-  anchor,
-  expanded,
-  onToggleExpand,
-  openClusters,
-  onToggleCluster,
-  selectedIds,
-  atCap,
-  onToggleSelect,
-}: {
-  anchor: GenreNode
-  expanded: boolean
-  onToggleExpand: () => void
-  openClusters: Set<string>
-  onToggleCluster: (id: string) => void
-  selectedIds: Set<string>
-  atCap: boolean
-  onToggleSelect: (node: GenreNode) => void
-}) {
-  const anchorSelected = selectedIds.has(anchor.id)
-  const totalSelected = countSelectedInTree(anchor, selectedIds)
-  const totalLeaves = anchor.children.reduce((n, c) => n + countLeaves(c), 0)
-
-  return (
-    <div
-      style={{
-        borderRadius: 10,
-        border: "1px solid var(--border)",
-        background: expanded ? "rgba(255,255,255,0.02)" : "transparent",
-        overflow: "hidden",
-        transition: "background 0.15s",
-      }}
-    >
-      <button
-        type="button"
-        onClick={onToggleExpand}
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 10,
-          width: "100%",
-          padding: "10px 12px",
-          background: "none",
-          border: 0,
-          cursor: "pointer",
-          textAlign: "left",
-        }}
-      >
-        <div style={{ flex: 1 }}>
-          <div style={{ fontSize: 13.5, fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
-            {anchor.label}
-            {totalSelected > 0 && (
-              <span
-                className="mono"
-                style={{
-                  fontSize: 10,
-                  fontWeight: 700,
-                  padding: "1px 6px",
-                  borderRadius: 4,
-                  background: "rgba(139,92,246,0.2)",
-                  color: "var(--accent)",
-                }}
-              >
-                {totalSelected}
-              </span>
-            )}
-          </div>
-          <div className="mono" style={{ fontSize: 10.5, color: "var(--text-muted)", marginTop: 2 }}>
-            {anchor.children.length} groups · {totalLeaves} sub-genres
-          </div>
-        </div>
-        <div style={{ color: "var(--text-faint)", flexShrink: 0 }}>
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div style={{ padding: "6px 8px 10px", borderTop: "1px solid var(--border)" }}>
-          <GenreRow
-            label={`Select all of ${anchor.label}`}
-            selected={anchorSelected}
-            disabled={!anchorSelected && atCap}
-            onClick={() => onToggleSelect(anchor)}
-            emphasis
-          />
-          <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 6 }}>
-            {anchor.children.map((cluster) => (
-              <GenreCluster
-                key={cluster.id}
-                cluster={cluster}
-                expanded={openClusters.has(cluster.id)}
-                onToggleExpand={() => onToggleCluster(cluster.id)}
-                selectedIds={selectedIds}
-                atCap={atCap}
-                onToggleSelect={onToggleSelect}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── GenreCluster (level 2) ────────────────────────────────────────────────────
-
-function GenreCluster({
-  cluster,
-  expanded,
-  onToggleExpand,
-  selectedIds,
-  atCap,
-  onToggleSelect,
-}: {
-  cluster: GenreNode
-  expanded: boolean
-  onToggleExpand: () => void
-  selectedIds: Set<string>
-  atCap: boolean
-  onToggleSelect: (node: GenreNode) => void
-}) {
-  const clusterSelected = selectedIds.has(cluster.id)
-  const totalSelected = countSelectedInTree(cluster, selectedIds)
-
-  return (
-    <div
-      style={{
-        borderRadius: 8,
-        border: "1px solid var(--border)",
-        background: expanded ? "rgba(255,255,255,0.03)" : "transparent",
-        overflow: "hidden",
-      }}
-    >
-      <button
-        type="button"
-        onClick={onToggleExpand}
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          width: "100%",
-          padding: "8px 10px",
-          background: "none",
-          border: 0,
-          cursor: "pointer",
-          textAlign: "left",
-        }}
-      >
-        <div style={{ flex: 1 }}>
-          <div style={{ fontSize: 12.5, fontWeight: 600, display: "flex", alignItems: "center", gap: 6 }}>
-            {cluster.label}
-            {totalSelected > 0 && (
-              <span
-                className="mono"
-                style={{
-                  fontSize: 9.5,
-                  fontWeight: 700,
-                  padding: "1px 5px",
-                  borderRadius: 3,
-                  background: "rgba(139,92,246,0.2)",
-                  color: "var(--accent)",
-                }}
-              >
-                {totalSelected}
-              </span>
-            )}
-          </div>
-          <div className="mono" style={{ fontSize: 10, color: "var(--text-muted)", marginTop: 1 }}>
-            {cluster.children.length} sub-genres
-          </div>
-        </div>
-        <div style={{ color: "var(--text-faint)", flexShrink: 0 }}>
-          {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-        </div>
-      </button>
-
-      {expanded && (
-        <div style={{ padding: "4px 6px 8px", borderTop: "1px solid var(--border)" }}>
-          <GenreRow
-            label={`Select all of ${cluster.label}`}
-            selected={clusterSelected}
-            disabled={!clusterSelected && atCap}
-            onClick={() => onToggleSelect(cluster)}
-            emphasis
-          />
-          {cluster.children.map((leaf) => {
-            const sel = selectedIds.has(leaf.id)
-            return (
-              <GenreRow
-                key={leaf.id}
-                label={leaf.label}
-                selected={sel}
-                disabled={!sel && atCap}
-                onClick={() => onToggleSelect(leaf)}
-              />
-            )
-          })}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ── GenreRow ──────────────────────────────────────────────────────────────────
-
-function GenreRow({
-  label,
-  selected,
-  disabled,
-  onClick,
-  emphasis,
-}: {
-  label: string
-  selected: boolean
-  disabled?: boolean
-  onClick: () => void
-  emphasis?: boolean
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 10,
-        width: "100%",
-        padding: "8px 10px",
-        background: selected ? "var(--accent-soft)" : "transparent",
-        border: 0,
-        borderRadius: 8,
-        cursor: disabled ? "not-allowed" : "pointer",
-        textAlign: "left",
-        color: disabled ? "var(--text-faint)" : "var(--text-primary)",
-        opacity: disabled ? 0.5 : 1,
-      }}
-    >
-      <span
-        aria-hidden
-        style={{
-          width: 14,
-          height: 14,
-          borderRadius: "50%",
-          border: `1.5px solid ${selected ? "var(--accent)" : "var(--border-strong)"}`,
-          background: selected ? "var(--accent)" : "transparent",
-          flexShrink: 0,
-          boxShadow: selected ? "0 0 8px var(--accent-glow)" : "none",
-          transition: "all 0.12s",
-        }}
-      />
-      <span style={{ fontSize: 13, fontWeight: emphasis ? 600 : 500 }}>{label}</span>
-    </button>
   )
 }

--- a/app/api/history/accumulate/route.ts
+++ b/app/api/history/accumulate/route.ts
@@ -2,18 +2,34 @@ import { auth } from "@/lib/auth"
 import { apiError, apiUnauthorized } from "@/lib/errors"
 import { createServiceClient } from "@/lib/supabase/server"
 import { accumulateLastFmHistory } from "@/lib/listened-artists"
+import { accumulateStatsFmHistory } from "@/lib/statsfm-listened-artists"
 import { getSpotifyClientToken } from "@/lib/spotify-client-token"
 
-export async function POST(): Promise<Response> {
+const COOLDOWN_MS = 15 * 60_000
+type Source = "lastfm" | "statsfm"
+
+export async function POST(request: Request): Promise<Response> {
   const session = await auth()
   if (!session?.user?.id) return apiUnauthorized()
 
   const userId = session.user.id
+
+  let source: Source
+  try {
+    const body = (await request.json().catch(() => ({}))) as { source?: unknown }
+    if (body.source !== "lastfm" && body.source !== "statsfm") {
+      return apiError("source must be 'lastfm' or 'statsfm'", 400)
+    }
+    source = body.source
+  } catch {
+    return apiError("Invalid JSON body", 400)
+  }
+
   const supabase = createServiceClient()
 
   const { data: user, error: userError } = await supabase
     .from("users")
-    .select("lastfm_username, last_accumulated_at")
+    .select("lastfm_username, statsfm_username, last_accumulated_lastfm_at, last_accumulated_statsfm_at")
     .eq("id", userId)
     .maybeSingle()
 
@@ -21,35 +37,43 @@ export async function POST(): Promise<Response> {
     console.error("[history/accumulate] User lookup error:", userError.message)
     return apiError("Failed to load user profile")
   }
-
   if (!user) return apiError("User not found", 404)
 
-  if (!user.lastfm_username) {
-    return apiError("No Last.fm account connected", 400)
+  const username = source === "lastfm" ? user.lastfm_username : user.statsfm_username
+  const cooldownField = source === "lastfm" ? "last_accumulated_lastfm_at" : "last_accumulated_statsfm_at"
+  const lastAt = source === "lastfm" ? user.last_accumulated_lastfm_at : user.last_accumulated_statsfm_at
+
+  if (!username) {
+    return apiError(`No ${source === "lastfm" ? "Last.fm" : "stats.fm"} account connected`, 400)
   }
 
-  // Per-user cooldown: 15 minutes between accumulate requests
-  if (user.last_accumulated_at) {
-    const elapsed = Date.now() - new Date(user.last_accumulated_at).getTime()
-    if (elapsed < 15 * 60_000) {
+  if (lastAt) {
+    const elapsed = Date.now() - new Date(lastAt).getTime()
+    if (elapsed < COOLDOWN_MS) {
       return apiError("Please wait before syncing again", 429)
     }
   }
 
-  // Update cooldown timestamp
-  await supabase.from("users").update({ last_accumulated_at: new Date().toISOString() }).eq("id", userId)
-
   try {
-    const accessToken = await getSpotifyClientToken() ?? ""
-    await accumulateLastFmHistory({
-      userId,
-      lastfmUsername: user.lastfm_username,
-      accessToken,
-    })
+    const accessToken = (await getSpotifyClientToken()) ?? ""
+    if (source === "lastfm") {
+      await accumulateLastFmHistory({ userId, lastfmUsername: username, accessToken })
+    } else {
+      await accumulateStatsFmHistory({ userId, statsfmUsername: username, accessToken })
+    }
   } catch (err) {
     const message = err instanceof Error ? err.message : "Accumulation failed"
-    console.error("[history/accumulate] Error:", message)
-    return apiError("History accumulation failed", 500)
+    console.error(`[history/accumulate] ${source} error:`, message)
+    return apiError(`${source === "lastfm" ? "Last.fm" : "stats.fm"} sync failed`, 500)
+  }
+
+  const now = new Date().toISOString()
+  const { error: updateError } = await supabase
+    .from("users")
+    .update({ [cooldownField]: now, last_accumulated_at: now })
+    .eq("id", userId)
+  if (updateError) {
+    console.error("[history/accumulate] Cooldown update error:", updateError.message)
   }
 
   return Response.json({ success: true })

--- a/app/api/onboarding/seeds/route.ts
+++ b/app/api/onboarding/seeds/route.ts
@@ -1,25 +1,8 @@
 import { type NextRequest } from "next/server"
 import { auth } from "@/lib/auth"
 import { apiError, apiUnauthorized } from "@/lib/errors"
-import { isValidSpotifyId } from "@/lib/spotify-ids"
 import { createServiceClient } from "@/lib/supabase/server"
-import { getSpotifyClientToken } from "@/lib/spotify-client-token"
-
-interface SpotifyArtistImage {
-  url: string
-  height: number
-  width: number
-}
-
-interface SpotifyArtistObject {
-  id: string
-  name: string
-  images: SpotifyArtistImage[]
-}
-
-interface SpotifyArtistsResponse {
-  artists: SpotifyArtistObject[]
-}
+import { validateSeedArtists } from "@/lib/seed-artist-validation"
 
 export async function POST(req: NextRequest) {
   const session = await auth()
@@ -27,44 +10,22 @@ export async function POST(req: NextRequest) {
 
   const userId = session.user.id
 
-  let body: { artistIds?: unknown }
+  let body: { artists?: unknown }
   try {
     body = await req.json()
   } catch {
     return apiError("Invalid JSON body", 400)
   }
 
-  const { artistIds } = body
-  if (
-    !Array.isArray(artistIds) ||
-    artistIds.length < 3 ||
-    artistIds.length > 5 ||
-    !artistIds.every((id) => typeof id === "string" && isValidSpotifyId(id))
-  ) {
-    return apiError("artistIds must be an array of 3–5 valid Spotify artist IDs", 400)
-  }
-
-  const accessToken = await getSpotifyClientToken()
-  if (!accessToken) return apiError("Spotify unavailable", 503)
-
-  const spotifyRes = await fetch(
-    `https://api.spotify.com/v1/artists?ids=${artistIds.join(",")}`,
-    { headers: { Authorization: `Bearer ${accessToken}` } }
-  )
-
-  if (!spotifyRes.ok) {
-    return apiError("Failed to fetch artist details from Spotify", 502)
-  }
-
-  const spotifyData: SpotifyArtistsResponse = await spotifyRes.json()
+  const result = validateSeedArtists(body.artists, { min: 3, max: 200 })
+  if (!result.ok) return apiError(result.error, 400)
 
   const supabase = createServiceClient()
-
-  const rows = spotifyData.artists.map((artist) => ({
+  const rows = result.artists.map((a) => ({
     user_id: userId,
-    spotify_artist_id: artist.id,
-    name: artist.name,
-    image_url: artist.images?.[0]?.url ?? null,
+    spotify_artist_id: a.id,
+    name: a.name,
+    image_url: a.imageUrl,
   }))
 
   const { error } = await supabase
@@ -72,6 +33,7 @@ export async function POST(req: NextRequest) {
     .upsert(rows, { onConflict: "user_id,spotify_artist_id" })
 
   if (error) {
+    console.error("[onboarding/seeds] upsert error:", error.message)
     return apiError("Failed to save seed artists", 500)
   }
 

--- a/app/api/recommendations/generate/route.ts
+++ b/app/api/recommendations/generate/route.ts
@@ -68,25 +68,41 @@ export async function POST(req: NextRequest): Promise<Response> {
   // Update cooldown timestamp
   await supabase.from("users").update({ last_generated_at: new Date().toISOString() }).eq("id", userId)
 
-  // ── [SECURITY PATCH] Algorithmic Queue Capacity DoS limit ──
-  // Restricts bad actors from infinitely looping the background engine, but allows up to 60 unseen artists to queue
-  const { count, error: countErr } = await supabase
-    .from("recommendation_cache")
-    .select("id", { count: "exact", head: true })
-    .eq("user_id", user.id)
-    .is("seen_at", null)
+  // Replace mode: wipe unseen queue before regenerating. Powers the Settings
+  // "Generate my feed" button so newly-added anchors take immediate effect.
+  const replace = req.nextUrl.searchParams.get("replace") === "true"
 
-  if (countErr) {
-    console.error("[generate] failed to check queue limit", countErr)
-  }
+  if (replace) {
+    const { error: wipeErr } = await supabase
+      .from("recommendation_cache")
+      .delete()
+      .eq("user_id", user.id)
+      .is("seen_at", null)
+    if (wipeErr) {
+      console.error("[generate] replace wipe failed", wipeErr.message)
+    }
+  } else {
+    // ── [SECURITY PATCH] Algorithmic Queue Capacity DoS limit ──
+    // Restricts bad actors from infinitely looping the background engine, but allows up to 60 unseen artists to queue
+    const { count, error: countErr } = await supabase
+      .from("recommendation_cache")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", user.id)
+      .is("seen_at", null)
 
-  if (count && count >= 60) {
-    return apiError("Your discovery queue is full. Please review some artists before generating more.", 429)
+    if (countErr) {
+      console.error("[generate] failed to check queue limit", countErr)
+    }
+
+    if (count && count >= 60) {
+      return apiError("Your discovery queue is full. Please review some artists before generating more.", 429)
+    }
   }
 
   try {
-    // Note: We no longer delete the unseen cache entries.
+    // Note: For the normal append path, we no longer delete the unseen cache entries.
     // This allows users to request "more" natively and gracefully append them to their existing batch.
+    // Replace mode (above) wipes unseen first so Settings-driven regen reflects new anchors.
 
     // Use user's Spotify token if available, otherwise fall back to client credentials
     const accessToken = userAccessToken ?? await getSpotifyClientToken() ?? ""

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -8,7 +8,13 @@ export async function PATCH(request: Request) {
 
   const userId = session.user.id
 
-  let body: { playThreshold?: number; lastfmUsername?: string; selectedGenres?: string[]; undergroundMode?: boolean }
+  let body: {
+    playThreshold?: number
+    lastfmUsername?: string
+    statsfmUsername?: string
+    selectedGenres?: string[]
+    undergroundMode?: boolean
+  }
   try {
     body = await request.json()
   } catch {
@@ -33,9 +39,17 @@ export async function PATCH(request: Request) {
     update.lastfm_username = lfmUsername || null
   }
 
+  if (body.statsfmUsername !== undefined) {
+    const sfmUsername = body.statsfmUsername.trim()
+    if (sfmUsername && !/^[a-zA-Z0-9._-]{1,30}$/.test(sfmUsername)) {
+      return apiError("Invalid stats.fm username format", 400)
+    }
+    update.statsfm_username = sfmUsername || null
+  }
+
   if (body.selectedGenres !== undefined) {
-    if (!Array.isArray(body.selectedGenres) || body.selectedGenres.length > 20) {
-      return apiError("selectedGenres must be an array of up to 20 tags", 400)
+    if (!Array.isArray(body.selectedGenres) || body.selectedGenres.length > 50) {
+      return apiError("selectedGenres must be an array of up to 50 tags", 400)
     }
     update.selected_genres = body.selectedGenres.filter((g) => typeof g === "string" && g.length <= 80)
   }

--- a/app/api/settings/seed-artists/route.ts
+++ b/app/api/settings/seed-artists/route.ts
@@ -1,0 +1,97 @@
+import { type NextRequest } from "next/server"
+import { auth } from "@/lib/auth"
+import { apiError, apiUnauthorized, dbError } from "@/lib/errors"
+import { createServiceClient } from "@/lib/supabase/server"
+import { isValidSpotifyId } from "@/lib/spotify-ids"
+import { validateSeedArtists } from "@/lib/seed-artist-validation"
+
+const MAX_SEED_ARTISTS = 200
+
+export async function GET() {
+  const session = await auth()
+  if (!session?.user?.id) return apiUnauthorized()
+
+  const supabase = createServiceClient()
+  const { data, error } = await supabase
+    .from("seed_artists")
+    .select("spotify_artist_id, name, image_url, added_at")
+    .eq("user_id", session.user.id)
+    .order("added_at", { ascending: true })
+
+  if (error) return dbError(error, "settings/seed-artists/list")
+
+  const artists = (data ?? []).map((r) => ({
+    id: r.spotify_artist_id,
+    name: r.name,
+    imageUrl: r.image_url,
+  }))
+  return Response.json({ artists })
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) return apiUnauthorized()
+
+  const userId = session.user.id
+
+  let body: { artists?: unknown }
+  try {
+    body = await req.json()
+  } catch {
+    return apiError("Invalid JSON body", 400)
+  }
+
+  const result = validateSeedArtists(body.artists, { min: 1, max: MAX_SEED_ARTISTS })
+  if (!result.ok) return apiError(result.error, 400)
+
+  const supabase = createServiceClient()
+
+  const { data: existingRows, error: existingError } = await supabase
+    .from("seed_artists")
+    .select("spotify_artist_id")
+    .eq("user_id", userId)
+
+  if (existingError) return dbError(existingError, "settings/seed-artists/list")
+
+  const existingIds = new Set((existingRows ?? []).map((r) => r.spotify_artist_id))
+  const newIds = result.artists.filter((a) => !existingIds.has(a.id))
+  if (existingIds.size + newIds.length > MAX_SEED_ARTISTS) {
+    return apiError(`Cannot exceed ${MAX_SEED_ARTISTS} seed artists`, 400)
+  }
+
+  const rows = result.artists.map((a) => ({
+    user_id: userId,
+    spotify_artist_id: a.id,
+    name: a.name,
+    image_url: a.imageUrl,
+  }))
+
+  const { error } = await supabase
+    .from("seed_artists")
+    .upsert(rows, { onConflict: "user_id,spotify_artist_id" })
+
+  if (error) return dbError(error, "settings/seed-artists/upsert")
+
+  return Response.json({ success: true })
+}
+
+export async function DELETE(req: NextRequest) {
+  const session = await auth()
+  if (!session?.user?.id) return apiUnauthorized()
+
+  const id = req.nextUrl.searchParams.get("id")
+  if (!id || !isValidSpotifyId(id)) {
+    return apiError("Valid Spotify artist id required", 400)
+  }
+
+  const supabase = createServiceClient()
+  const { error } = await supabase
+    .from("seed_artists")
+    .delete()
+    .eq("user_id", session.user.id)
+    .eq("spotify_artist_id", id)
+
+  if (error) return dbError(error, "settings/seed-artists/delete")
+
+  return Response.json({ success: true })
+}

--- a/components/feed/artist-card.tsx
+++ b/components/feed/artist-card.tsx
@@ -405,12 +405,15 @@ export function ArtistCard({
               className="btn"
               style={{
                 flex: 1,
+                minWidth: 0,
+                fontSize: 13,
+                whiteSpace: "nowrap",
                 color: "#ff7b7b",
                 background: "rgba(255,75,75,0.05)",
                 borderColor: "rgba(255,75,75,0.18)",
               }}
             >
-              <span className="mono" style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.04em" }}>
+              <span className="mono" style={{ fontSize: 13, fontWeight: 700 }}>
                 —
               </span>{" "}
               Less like this
@@ -418,7 +421,7 @@ export function ArtistCard({
             <button
               onClick={() => onFeedback("skip")}
               className="btn"
-              style={{ flex: 1 }}
+              style={{ flex: 1, minWidth: 0, fontSize: 13, whiteSpace: "nowrap" }}
             >
               <SkipForward size={15} /> Later
             </button>
@@ -427,12 +430,15 @@ export function ArtistCard({
               className="btn"
               style={{
                 flex: 1.2,
+                minWidth: 0,
+                fontSize: 13,
+                whiteSpace: "nowrap",
                 color: "var(--like)",
                 background: "rgba(34,197,94,0.07)",
                 borderColor: "rgba(34,197,94,0.22)",
               }}
             >
-              <span className="mono" style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.04em" }}>
+              <span className="mono" style={{ fontSize: 13, fontWeight: 700 }}>
                 +
               </span>{" "}
               More like this

--- a/components/onboarding/artist-search.tsx
+++ b/components/onboarding/artist-search.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Search, X } from "lucide-react"
+
+export interface SpotifyArtist {
+  id: string
+  name: string
+  genres: string[]
+  imageUrl: string | null
+  popularity: number
+}
+
+export interface ArtistSearchProps {
+  selected: SpotifyArtist[]
+  onAdd: (artist: SpotifyArtist) => void
+  onRemove: (id: string) => void
+  cap: number
+  minForHint?: number
+}
+
+export function ArtistSearch({ selected, onAdd, onRemove, cap, minForHint = 3 }: ArtistSearchProps) {
+  const [query, setQuery] = useState("")
+  const [results, setResults] = useState<SpotifyArtist[]>([])
+  const [searching, setSearching] = useState(false)
+  const debounceRef = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!query.trim()) { setResults([]); return }
+
+    debounceRef.current = setTimeout(async () => {
+      setSearching(true)
+      try {
+        const res = await fetch(`/api/onboarding/search?q=${encodeURIComponent(query.trim())}`)
+        if (res.ok) {
+          const data = await res.json()
+          setResults(data.artists ?? [])
+        }
+      } finally {
+        setSearching(false)
+      }
+    }, 350)
+
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
+  }, [query])
+
+  const selectedIds = new Set(selected.map((a) => a.id))
+  const atCap = selected.length >= cap
+
+  return (
+    <div className="col gap-10">
+      {selected.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {selected.map((a) => (
+            <div key={a.id} className="chip selected" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <span>{a.name}</span>
+              <button
+                type="button"
+                onClick={() => onRemove(a.id)}
+                aria-label={`Remove ${a.name}`}
+                style={{ background: "none", border: 0, cursor: "pointer", color: "inherit", padding: 0, display: "flex" }}
+              >
+                <X size={11} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="field" style={{ height: 40, position: "relative" }}>
+        <Search
+          size={14}
+          style={{ position: "absolute", left: 12, top: "50%", transform: "translateY(-50%)", color: "var(--text-muted)", pointerEvents: "none" }}
+        />
+        <input
+          type="text"
+          placeholder="Search artists…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          style={{ paddingLeft: 32 }}
+        />
+      </div>
+      {searching && (
+        <div className="mono muted" style={{ fontSize: 11 }}>Searching…</div>
+      )}
+      {results.length > 0 && (
+        <div
+          style={{
+            maxHeight: 220,
+            overflowY: "auto",
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            borderRadius: 10,
+            border: "1px solid var(--border)",
+            background: "var(--bg-card)",
+          }}
+        >
+          {results.map((artist) => {
+            const already = selectedIds.has(artist.id)
+            return (
+              <button
+                key={artist.id}
+                type="button"
+                disabled={already || atCap}
+                onClick={() => onAdd(artist)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "9px 12px",
+                  background: already ? "rgba(139,92,246,0.08)" : "transparent",
+                  border: 0,
+                  cursor: already ? "default" : "pointer",
+                  textAlign: "left",
+                  borderBottom: "1px solid var(--border)",
+                }}
+              >
+                {artist.imageUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={artist.imageUrl} alt="" style={{ width: 32, height: 32, borderRadius: 6, objectFit: "cover", flexShrink: 0 }} />
+                ) : (
+                  <div style={{ width: 32, height: 32, borderRadius: 6, background: "rgba(255,255,255,0.06)", flexShrink: 0 }} />
+                )}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {artist.name}
+                  </div>
+                  {artist.genres[0] && (
+                    <div className="mono" style={{ fontSize: 10, color: "var(--text-muted)", textTransform: "uppercase" }}>
+                      {artist.genres[0]}
+                    </div>
+                  )}
+                </div>
+                {already && (
+                  <span style={{ fontSize: 11, color: "var(--accent)", flexShrink: 0 }}>added</span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+      {selected.length > 0 && selected.length < minForHint && (
+        <div className="muted" style={{ fontSize: 11 }}>
+          Add {minForHint - selected.length} more to use this path
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/onboarding/genre-picker.tsx
+++ b/components/onboarding/genre-picker.tsx
@@ -1,0 +1,321 @@
+"use client"
+
+import { useState } from "react"
+import { ChevronDown, ChevronUp } from "lucide-react"
+import genreData from "@/data/genres.json"
+import type { GenreNode } from "@/lib/types"
+
+export const ALL_GENRES: GenreNode[] = (genreData as { nodes: GenreNode[] }).nodes
+
+function countSelectedInTree(node: GenreNode, selectedIds: Set<string>): number {
+  let n = selectedIds.has(node.id) ? 1 : 0
+  for (const child of node.children) n += countSelectedInTree(child, selectedIds)
+  return n
+}
+
+function countLeaves(node: GenreNode): number {
+  if (node.children.length === 0) return 1
+  return node.children.reduce((n, c) => n + countLeaves(c), 0)
+}
+
+export interface GenrePickerProps {
+  selected: GenreNode[]
+  onToggle: (node: GenreNode) => void
+  cap: number
+}
+
+export function GenrePicker({ selected, onToggle, cap }: GenrePickerProps) {
+  const [openAnchors, setOpenAnchors] = useState<Set<string>>(new Set())
+  const [openClusters, setOpenClusters] = useState<Set<string>>(new Set())
+
+  const selectedIds = new Set(selected.map((g) => g.id))
+  const atCap = selected.length >= cap
+
+  const toggleAnchor = (id: string) => {
+    setOpenAnchors((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const toggleCluster = (id: string) => {
+    setOpenClusters((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  return (
+    <div className="col gap-6">
+      {ALL_GENRES.map((anchor) => (
+        <GenreAnchor
+          key={anchor.id}
+          anchor={anchor}
+          expanded={openAnchors.has(anchor.id)}
+          onToggleExpand={() => toggleAnchor(anchor.id)}
+          openClusters={openClusters}
+          onToggleCluster={toggleCluster}
+          selectedIds={selectedIds}
+          atCap={atCap}
+          onToggleSelect={onToggle}
+        />
+      ))}
+    </div>
+  )
+}
+
+function GenreAnchor({
+  anchor,
+  expanded,
+  onToggleExpand,
+  openClusters,
+  onToggleCluster,
+  selectedIds,
+  atCap,
+  onToggleSelect,
+}: {
+  anchor: GenreNode
+  expanded: boolean
+  onToggleExpand: () => void
+  openClusters: Set<string>
+  onToggleCluster: (id: string) => void
+  selectedIds: Set<string>
+  atCap: boolean
+  onToggleSelect: (node: GenreNode) => void
+}) {
+  const anchorSelected = selectedIds.has(anchor.id)
+  const totalSelected = countSelectedInTree(anchor, selectedIds)
+  const totalLeaves = anchor.children.reduce((n, c) => n + countLeaves(c), 0)
+
+  return (
+    <div
+      style={{
+        borderRadius: 10,
+        border: "1px solid var(--border)",
+        background: expanded ? "rgba(255,255,255,0.02)" : "transparent",
+        overflow: "hidden",
+        transition: "background 0.15s",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          width: "100%",
+          padding: "10px 12px",
+          background: "none",
+          border: 0,
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+      >
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
+            {anchor.label}
+            {totalSelected > 0 && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  padding: "1px 6px",
+                  borderRadius: 4,
+                  background: "rgba(139,92,246,0.2)",
+                  color: "var(--accent)",
+                }}
+              >
+                {totalSelected}
+              </span>
+            )}
+          </div>
+          <div className="mono" style={{ fontSize: 10.5, color: "var(--text-muted)", marginTop: 2 }}>
+            {anchor.children.length} groups · {totalLeaves} sub-genres
+          </div>
+        </div>
+        <div style={{ color: "var(--text-faint)", flexShrink: 0 }}>
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </div>
+      </button>
+
+      {expanded && (
+        <div style={{ padding: "6px 8px 10px", borderTop: "1px solid var(--border)" }}>
+          <GenreRow
+            label={`Select all of ${anchor.label}`}
+            selected={anchorSelected}
+            disabled={!anchorSelected && atCap}
+            onClick={() => onToggleSelect(anchor)}
+            emphasis
+          />
+          <div style={{ display: "flex", flexDirection: "column", gap: 4, marginTop: 6 }}>
+            {anchor.children.map((cluster) => (
+              <GenreCluster
+                key={cluster.id}
+                cluster={cluster}
+                expanded={openClusters.has(cluster.id)}
+                onToggleExpand={() => onToggleCluster(cluster.id)}
+                selectedIds={selectedIds}
+                atCap={atCap}
+                onToggleSelect={onToggleSelect}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GenreCluster({
+  cluster,
+  expanded,
+  onToggleExpand,
+  selectedIds,
+  atCap,
+  onToggleSelect,
+}: {
+  cluster: GenreNode
+  expanded: boolean
+  onToggleExpand: () => void
+  selectedIds: Set<string>
+  atCap: boolean
+  onToggleSelect: (node: GenreNode) => void
+}) {
+  const clusterSelected = selectedIds.has(cluster.id)
+  const totalSelected = countSelectedInTree(cluster, selectedIds)
+
+  return (
+    <div
+      style={{
+        borderRadius: 8,
+        border: "1px solid var(--border)",
+        background: expanded ? "rgba(255,255,255,0.03)" : "transparent",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          width: "100%",
+          padding: "8px 10px",
+          background: "none",
+          border: 0,
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+      >
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 12.5, fontWeight: 600, display: "flex", alignItems: "center", gap: 6 }}>
+            {cluster.label}
+            {totalSelected > 0 && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 9.5,
+                  fontWeight: 700,
+                  padding: "1px 5px",
+                  borderRadius: 3,
+                  background: "rgba(139,92,246,0.2)",
+                  color: "var(--accent)",
+                }}
+              >
+                {totalSelected}
+              </span>
+            )}
+          </div>
+          <div className="mono" style={{ fontSize: 10, color: "var(--text-muted)", marginTop: 1 }}>
+            {cluster.children.length} sub-genres
+          </div>
+        </div>
+        <div style={{ color: "var(--text-faint)", flexShrink: 0 }}>
+          {expanded ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        </div>
+      </button>
+
+      {expanded && (
+        <div style={{ padding: "4px 6px 8px", borderTop: "1px solid var(--border)" }}>
+          <GenreRow
+            label={`Select all of ${cluster.label}`}
+            selected={clusterSelected}
+            disabled={!clusterSelected && atCap}
+            onClick={() => onToggleSelect(cluster)}
+            emphasis
+          />
+          {cluster.children.map((leaf) => {
+            const sel = selectedIds.has(leaf.id)
+            return (
+              <GenreRow
+                key={leaf.id}
+                label={leaf.label}
+                selected={sel}
+                disabled={!sel && atCap}
+                onClick={() => onToggleSelect(leaf)}
+              />
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GenreRow({
+  label,
+  selected,
+  disabled,
+  onClick,
+  emphasis,
+}: {
+  label: string
+  selected: boolean
+  disabled?: boolean
+  onClick: () => void
+  emphasis?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        width: "100%",
+        padding: "8px 10px",
+        background: selected ? "var(--accent-soft)" : "transparent",
+        border: 0,
+        borderRadius: 8,
+        cursor: disabled ? "not-allowed" : "pointer",
+        textAlign: "left",
+        color: disabled ? "var(--text-faint)" : "var(--text-primary)",
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <span
+        aria-hidden
+        style={{
+          width: 14,
+          height: 14,
+          borderRadius: "50%",
+          border: `1.5px solid ${selected ? "var(--accent)" : "var(--border-strong)"}`,
+          background: selected ? "var(--accent)" : "transparent",
+          flexShrink: 0,
+          boxShadow: selected ? "0 0 8px var(--accent-glow)" : "none",
+          transition: "all 0.12s",
+        }}
+      />
+      <span style={{ fontSize: 13, fontWeight: emphasis ? 600 : 500 }}>{label}</span>
+    </button>
+  )
+}

--- a/components/settings/library-editor.tsx
+++ b/components/settings/library-editor.tsx
@@ -1,0 +1,238 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
+import { ChevronDown, ChevronUp } from "lucide-react"
+import type { GenreNode } from "@/lib/types"
+import { GenrePicker, ALL_GENRES } from "@/components/onboarding/genre-picker"
+import { ArtistSearch, type SpotifyArtist } from "@/components/onboarding/artist-search"
+
+const GENRE_CAP = 200
+const ARTIST_CAP = 200
+const GENRE_SAVE_DEBOUNCE_MS = 400
+
+function buildTagLookup(nodes: GenreNode[], acc = new Map<string, GenreNode>()): Map<string, GenreNode> {
+  for (const node of nodes) {
+    acc.set(node.lastfmTag, node)
+    if (node.children.length) buildTagLookup(node.children, acc)
+  }
+  return acc
+}
+
+export interface LibraryEditorProps {
+  initialGenreTags: string[]
+  initialSeedArtists: SpotifyArtist[]
+  flat?: boolean
+}
+
+export function LibraryEditor({ initialGenreTags, initialSeedArtists, flat = false }: LibraryEditorProps) {
+  const tagLookup = useMemo(() => buildTagLookup(ALL_GENRES), [])
+
+  const initialGenreNodes = useMemo(
+    () => initialGenreTags.map((tag) => tagLookup.get(tag)).filter((g): g is GenreNode => !!g),
+    [initialGenreTags, tagLookup],
+  )
+
+  const [genres, setGenres] = useState<GenreNode[]>(initialGenreNodes)
+  const [artists, setArtists] = useState<SpotifyArtist[]>(initialSeedArtists)
+  const [genresOpen, setGenresOpen] = useState(false)
+  const [artistsOpen, setArtistsOpen] = useState(false)
+
+  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const saveAborter = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (saveTimer.current) clearTimeout(saveTimer.current)
+      saveAborter.current?.abort()
+    }
+  }, [])
+
+  function scheduleGenreSave(next: GenreNode[]) {
+    if (saveTimer.current) clearTimeout(saveTimer.current)
+    saveTimer.current = setTimeout(async () => {
+      saveAborter.current?.abort()
+      const aborter = new AbortController()
+      saveAborter.current = aborter
+      try {
+        const res = await fetch("/api/settings", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ selectedGenres: next.map((g) => g.lastfmTag) }),
+          signal: aborter.signal,
+        })
+        if (!res.ok) throw new Error("save failed")
+      } catch (err) {
+        if ((err as { name?: string } | null)?.name === "AbortError") return
+        toast.error("Couldn't save genres")
+      }
+    }, GENRE_SAVE_DEBOUNCE_MS)
+  }
+
+  function toggleGenre(node: GenreNode) {
+    const has = genres.some((g) => g.id === node.id)
+    const next = has ? genres.filter((g) => g.id !== node.id) : genres.length < GENRE_CAP ? [...genres, node] : genres
+    if (next === genres) return
+    setGenres(next)
+    scheduleGenreSave(next)
+  }
+
+  async function addArtist(artist: SpotifyArtist) {
+    if (artists.some((a) => a.id === artist.id) || artists.length >= ARTIST_CAP) return
+    const next = [...artists, artist]
+    setArtists(next)
+    try {
+      const res = await fetch("/api/settings/seed-artists", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          artists: [{ id: artist.id, name: artist.name, imageUrl: artist.imageUrl }],
+        }),
+      })
+      if (!res.ok) throw new Error("add failed")
+    } catch {
+      setArtists((prev) => prev.filter((a) => a.id !== artist.id))
+      toast.error("Couldn't add artist")
+    }
+  }
+
+  async function removeArtist(id: string) {
+    const prev = artists
+    setArtists((cur) => cur.filter((a) => a.id !== id))
+    try {
+      const res = await fetch(`/api/settings/seed-artists?id=${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      })
+      if (!res.ok) throw new Error("remove failed")
+    } catch {
+      setArtists(prev)
+      toast.error("Couldn't remove artist")
+    }
+  }
+
+  const collapsibles = (
+    <>
+      <Collapsible
+        title="Artists"
+        subtitle="The starting points for your feed"
+        count={artists.length}
+        open={artistsOpen}
+        onToggle={() => setArtistsOpen((v) => !v)}
+        flat={flat}
+      >
+        <ArtistSearch
+          selected={artists}
+          onAdd={addArtist}
+          onRemove={removeArtist}
+          cap={ARTIST_CAP}
+          minForHint={0}
+        />
+      </Collapsible>
+
+      <Collapsible
+        title="Genres"
+        subtitle="Steer the feed toward what you love"
+        count={genres.length}
+        open={genresOpen}
+        onToggle={() => setGenresOpen((v) => !v)}
+        flat={flat}
+      >
+        <GenrePicker selected={genres} onToggle={toggleGenre} cap={GENRE_CAP} />
+      </Collapsible>
+    </>
+  )
+
+  if (flat) return collapsibles
+
+  return (
+    <div>
+      <div className="eyebrow" style={{ marginBottom: 10 }}>Your library</div>
+      <div className="col gap-10">{collapsibles}</div>
+    </div>
+  )
+}
+
+function Collapsible({
+  title,
+  subtitle,
+  count,
+  open,
+  onToggle,
+  children,
+  flat,
+}: {
+  title: string
+  subtitle: string
+  count: number
+  open: boolean
+  onToggle: () => void
+  children: React.ReactNode
+  flat?: boolean
+}) {
+  const cardStyle: React.CSSProperties = flat
+    ? { padding: 0, overflow: "hidden", background: "transparent", border: 0 }
+    : {
+        padding: 0,
+        overflow: "hidden",
+        borderColor: open ? "rgba(139,92,246,0.4)" : "var(--border)",
+        background: open ? "rgba(139,92,246,0.04)" : "var(--bg-card)",
+        transition: "border-color 0.15s, background 0.15s",
+      }
+
+  return (
+    <div className={flat ? undefined : "fs-card"} style={cardStyle}>
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          width: "100%",
+          padding: flat ? "6px 0" : "14px 16px",
+          background: "none",
+          border: 0,
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+      >
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
+            {title}
+            {count > 0 && (
+              <span
+                className="mono"
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  padding: "1px 6px",
+                  borderRadius: 4,
+                  background: "rgba(139,92,246,0.2)",
+                  color: "var(--accent)",
+                }}
+              >
+                {count}
+              </span>
+            )}
+          </div>
+          <div className="muted" style={{ fontSize: 11.5, marginTop: 2 }}>{subtitle}</div>
+        </div>
+        <div style={{ color: "var(--text-faint)", flexShrink: 0 }}>
+          {open ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        </div>
+      </button>
+
+      {open && (
+        <div
+          style={
+            flat
+              ? { paddingTop: 10 }
+              : { padding: "0 16px 16px", borderTop: "1px solid var(--border)" }
+          }
+        >
+          <div style={{ paddingTop: flat ? 0 : 14 }}>{children}</div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -1,16 +1,22 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { signOut } from "next-auth/react"
 import { toast } from "sonner"
 import { IdenticonAvatar } from "@/components/ui/identicon-avatar"
+import { LibraryEditor } from "@/components/settings/library-editor"
+import type { SpotifyArtist } from "@/components/onboarding/artist-search"
 
 interface SettingsFormProps {
   userSeed: string
   initialPlayThreshold: number
   initialLastfmUsername: string | null
+  initialStatsfmUsername: string | null
   initialLastfmArtistCount: number
   initialUndergroundMode: boolean
+  initialSelectedGenres: string[]
+  initialSeedArtists: SpotifyArtist[]
 }
 
 async function patchSettings(payload: Record<string, unknown>) {
@@ -29,17 +35,24 @@ export function SettingsForm({
   userSeed,
   initialPlayThreshold,
   initialLastfmUsername,
+  initialStatsfmUsername,
   initialLastfmArtistCount,
   initialUndergroundMode,
+  initialSelectedGenres,
+  initialSeedArtists,
 }: SettingsFormProps) {
+  const router = useRouter()
   const [threshold, setThreshold] = useState(initialPlayThreshold)
   const [lastfmUsername, setLastfmUsername] = useState(initialLastfmUsername ?? "")
+  const [statsfmUsername, setStatsfmUsername] = useState(initialStatsfmUsername ?? "")
   const [undergroundMode, setUndergroundMode] = useState(initialUndergroundMode)
-  const [isSyncing, setIsSyncing] = useState(false)
+  const [syncingSource, setSyncingSource] = useState<null | "lastfm" | "statsfm">(null)
+  const [isGenerating, setIsGenerating] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteConfirm, setDeleteConfirm] = useState(false)
 
   const isConnected = lastfmUsername.trim().length > 0
+  const isStatsfmConnected = statsfmUsername.trim().length > 0
 
   const sliderPct = Math.round((threshold / 50) * 100)
   const sliderBg = `linear-gradient(to right, var(--accent) ${sliderPct}%, rgba(255,255,255,0.10) ${sliderPct}%)`
@@ -89,6 +102,17 @@ export function SettingsForm({
     }
   }
 
+  async function handleStatsfmBlur() {
+    const trimmed = statsfmUsername.trim()
+    if (trimmed === (initialStatsfmUsername ?? "")) return
+    try {
+      await patchSettings({ statsfmUsername: trimmed })
+      toast.success("stats.fm username saved")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save stats.fm username")
+    }
+  }
+
   async function handleDeleteAccount() {
     if (!deleteConfirm) {
       setDeleteConfirm(true)
@@ -108,20 +132,42 @@ export function SettingsForm({
     }
   }
 
-  async function handleSyncNow() {
-    if (isSyncing || !isConnected) return
-    setIsSyncing(true)
+  async function handleGenerate() {
+    if (isGenerating) return
+    setIsGenerating(true)
     try {
-      const res = await fetch("/api/history/accumulate", { method: "POST" })
+      const res = await fetch("/api/recommendations/generate?replace=true", { method: "POST" })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error((data as { error?: string }).error ?? "Generate failed")
+      }
+      router.push("/feed")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Couldn't generate")
+      setIsGenerating(false)
+    }
+  }
+
+  async function handleSync(source: "lastfm" | "statsfm") {
+    if (syncingSource) return
+    if (source === "lastfm" && !isConnected) return
+    if (source === "statsfm" && !isStatsfmConnected) return
+    setSyncingSource(source)
+    try {
+      const res = await fetch("/api/history/accumulate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source }),
+      })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
         throw new Error((data as { error?: string }).error ?? "Sync failed")
       }
-      toast.success("Sync complete")
+      toast.success(`${source === "lastfm" ? "Last.fm" : "stats.fm"} sync complete`)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Sync failed")
     } finally {
-      setIsSyncing(false)
+      setSyncingSource(null)
     }
   }
 
@@ -291,10 +337,25 @@ export function SettingsForm({
             </div>
           </div>
 
-          {/* ── Connected sources ────────────────────────────────────── */}
+          {/* ── Taste anchors ────────────────────────────────────────── */}
           <div>
-            <div className="eyebrow" style={{ marginBottom: 10 }}>Connected sources</div>
-            <div className="fs-card col gap-12">
+            <div className="eyebrow" style={{ marginBottom: 10 }}>Taste anchors</div>
+            <div
+              className="fs-card col gap-14"
+              style={{
+                borderColor: "rgba(139,92,246,0.45)",
+                borderWidth: 2,
+                background: "rgba(139,92,246,0.04)",
+              }}
+            >
+              <LibraryEditor
+                initialGenreTags={initialSelectedGenres}
+                initialSeedArtists={initialSeedArtists}
+                flat
+              />
+
+              <div className="divider" />
+
               {/* Last.fm */}
               <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
                 <div style={{ fontSize: 18, flexShrink: 0 }}>♫</div>
@@ -323,48 +384,60 @@ export function SettingsForm({
                 </div>
                 <button
                   className="btn btn-sm"
-                  onClick={handleSyncNow}
-                  disabled={isSyncing || !isConnected}
+                  onClick={() => handleSync("lastfm")}
+                  disabled={syncingSource !== null || !isConnected}
                   style={{ flexShrink: 0, opacity: !isConnected ? 0.4 : 1 }}
                 >
-                  {isSyncing ? "Syncing…" : "Sync now"}
+                  {syncingSource === "lastfm" ? "Syncing…" : "Sync now"}
                 </button>
               </div>
 
               <div className="divider" />
 
-              {/* Spotify — restricted */}
-              <div style={{ display: "flex", alignItems: "center", gap: 12, opacity: 0.55 }}>
-                <svg
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="var(--spotify)"
-                  style={{ flexShrink: 0 }}
-                >
-                  <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
-                </svg>
+              {/* stats.fm */}
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <div style={{ fontSize: 18, flexShrink: 0 }}>📊</div>
                 <div style={{ flex: 1 }}>
-                  <div style={{ fontSize: 14, fontWeight: 600 }}>Spotify</div>
-                  <div className="mono" style={{ fontSize: 11, color: "var(--text-muted)" }}>
-                    restricted access
+                  <div style={{ fontSize: 14, fontWeight: 600 }}>stats.fm</div>
+                  <div
+                    className="mono"
+                    style={{
+                      fontSize: 11,
+                      color: isStatsfmConnected ? "var(--like)" : "var(--text-muted)",
+                    }}
+                  >
+                    {isStatsfmConnected
+                      ? `connected · @${statsfmUsername.trim()}`
+                      : "not connected"}
+                  </div>
+                  <div className="field" style={{ height: 40, marginTop: 8 }}>
+                    <input
+                      type="text"
+                      placeholder="your-statsfm-username"
+                      value={statsfmUsername}
+                      onChange={(e) => setStatsfmUsername(e.target.value)}
+                      onBlur={handleStatsfmBlur}
+                    />
                   </div>
                 </div>
-                <span
-                  style={{
-                    fontSize: 9.5,
-                    fontWeight: 700,
-                    padding: "2px 7px",
-                    borderRadius: 4,
-                    background: "rgba(255,255,255,0.06)",
-                    color: "var(--text-muted)",
-                    letterSpacing: "0.08em",
-                    textTransform: "uppercase",
-                  }}
+                <button
+                  className="btn btn-sm"
+                  onClick={() => handleSync("statsfm")}
+                  disabled={syncingSource !== null || !isStatsfmConnected}
+                  style={{ flexShrink: 0, opacity: !isStatsfmConnected ? 0.4 : 1 }}
                 >
-                  locked
-                </span>
+                  {syncingSource === "statsfm" ? "Syncing…" : "Sync now"}
+                </button>
               </div>
+
+              <button
+                className="btn btn-primary"
+                onClick={handleGenerate}
+                disabled={isGenerating}
+                style={{ width: "100%", marginTop: 4 }}
+              >
+                {isGenerating ? "Generating…" : "Generate my feed →"}
+              </button>
             </div>
           </div>
 

--- a/components/ui/identicon-avatar.tsx
+++ b/components/ui/identicon-avatar.tsx
@@ -1,37 +1,17 @@
-import React from "react"
+import { useMemo } from "react"
+import { createAvatar } from "@dicebear/core"
+import { shapes } from "@dicebear/collection"
 
-// Deterministic 5×5 symmetric identicon seeded from a string (user UUID)
 interface IdenticonAvatarProps {
   seed: string
   size?: number
 }
 
 export function IdenticonAvatar({ seed = "user", size = 40 }: IdenticonAvatarProps) {
-  // Hash the seed to a number
-  let h = 0
-  for (let i = 0; i < seed.length; i++) {
-    h = seed.charCodeAt(i) + ((h << 5) - h)
-  }
-  const hue = Math.abs(h) % 360
-
-  // Build 5×5 symmetric grid (only need to compute left half + center)
-  const rects: Array<React.ReactElement> = []
-  let r = Math.abs(h)
-  for (let y = 0; y < 5; y++) {
-    for (let x = 0; x < 3; x++) {
-      r = (r * 1103515245 + 12345) & 0x7fffffff
-      if ((r & 1) === 1) {
-        rects.push(
-          <rect key={`${x}-${y}`} x={x * 20} y={y * 20} width="20" height="20" />
-        )
-        if (x < 2) {
-          rects.push(
-            <rect key={`${4 - x}-${y}`} x={(4 - x) * 20} y={y * 20} width="20" height="20" />
-          )
-        }
-      }
-    }
-  }
+  const svg = useMemo(
+    () => createAvatar(shapes, { seed, size, radius: 50 }).toString(),
+    [seed, size],
+  )
 
   return (
     <div
@@ -40,22 +20,10 @@ export function IdenticonAvatar({ seed = "user", size = 40 }: IdenticonAvatarPro
         height: size,
         borderRadius: "50%",
         overflow: "hidden",
-        background: `hsl(${(hue + 30) % 360} 18% 14%)`,
         border: "1px solid var(--border-strong)",
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
         flexShrink: 0,
       }}
-    >
-      <svg
-        width={size * 0.7}
-        height={size * 0.7}
-        viewBox="0 0 100 100"
-        style={{ color: `hsl(${hue} 70% 65%)`, fill: "currentColor" }}
-      >
-        {rects}
-      </svg>
-    </div>
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
   )
 }

--- a/lib/listened-artists.ts
+++ b/lib/listened-artists.ts
@@ -177,7 +177,7 @@ interface UnresolvedRow {
  * Processed in batches of RESOLUTION_BATCH_SIZE to stay within Spotify rate limits.
  * Never throws — all errors are logged so the parent sync call is not disrupted.
  */
-async function resolveLastFmArtistIds(params: {
+export async function resolveUnresolvedArtistIds(params: {
   supabase: ReturnType<typeof createServiceClient>
   userId: string
   accessToken: string
@@ -212,16 +212,68 @@ async function resolveLastFmArtistIds(params: {
   // 2. Process in batches
   for (let i = 0; i < unresolved.length; i += RESOLUTION_BATCH_SIZE) {
     const batch = unresolved.slice(i, i + RESOLUTION_BATCH_SIZE)
-    await resolveLastFmBatch({ supabase, accessToken, batch })
+    await resolveLastFmBatch({ supabase, userId, accessToken, batch })
   }
+}
+
+/**
+ * Try to set spotify_artist_id on `orphanId`. If a row with the same
+ * (user_id, spotify_artist_id) already exists (unique constraint 23505),
+ * merge the orphan's play_count into the existing row and delete the orphan.
+ */
+async function resolveOrMergeRow(params: {
+  supabase: ReturnType<typeof createServiceClient>
+  userId: string
+  orphanId: string
+  spotifyArtistId: string
+  now: string
+}): Promise<{ merged: boolean; error?: string }> {
+  const { supabase, userId, orphanId, spotifyArtistId, now } = params
+
+  const { error: updateErr } = await supabase
+    .from("listened_artists")
+    .update({ spotify_artist_id: spotifyArtistId, id_resolution_attempted_at: now })
+    .eq("id", orphanId)
+
+  if (!updateErr) return { merged: false }
+  if (updateErr.code !== "23505") return { merged: false, error: updateErr.message }
+
+  const { data: orphan } = await supabase
+    .from("listened_artists")
+    .select("play_count, last_seen_at")
+    .eq("id", orphanId)
+    .maybeSingle()
+
+  const { data: target } = await supabase
+    .from("listened_artists")
+    .select("id, play_count, last_seen_at")
+    .eq("user_id", userId)
+    .eq("spotify_artist_id", spotifyArtistId)
+    .maybeSingle()
+
+  if (target && orphan) {
+    const mergedPlays = (target.play_count ?? 0) + (orphan.play_count ?? 0)
+    const mergedLastSeen =
+      new Date(target.last_seen_at).getTime() >= new Date(orphan.last_seen_at).getTime()
+        ? target.last_seen_at
+        : orphan.last_seen_at
+    await supabase
+      .from("listened_artists")
+      .update({ play_count: mergedPlays, last_seen_at: mergedLastSeen })
+      .eq("id", target.id)
+  }
+
+  await supabase.from("listened_artists").delete().eq("id", orphanId)
+  return { merged: true }
 }
 
 async function resolveLastFmBatch(params: {
   supabase: ReturnType<typeof createServiceClient>
+  userId: string
   accessToken: string
   batch: UnresolvedRow[]
 }): Promise<void> {
-  const { supabase, accessToken, batch } = params
+  const { supabase, userId, accessToken, batch } = params
   const now = new Date().toISOString()
 
   // 2a. Batch-read artist_search_cache for all names in this batch
@@ -256,23 +308,24 @@ async function resolveLastFmBatch(params: {
     const cached = cacheByLower.get(nameLower)
 
     if (cached) {
-      // Cache hit — write spotify_artist_id back to listened_artists
-      const { error: updateErr } = await supabase
-        .from("listened_artists")
-        .update({
-          spotify_artist_id: cached.spotify_artist_id,
-          id_resolution_attempted_at: now,
-        })
-        .eq("id", row.id)
-
-      if (updateErr) {
+      // Cache hit — write spotify_artist_id back to listened_artists, merging
+      // into an existing row for this user+artist if the unique constraint
+      // (user_id, spotify_artist_id) trips.
+      const res = await resolveOrMergeRow({
+        supabase,
+        userId,
+        orphanId: row.id,
+        spotifyArtistId: cached.spotify_artist_id,
+        now,
+      })
+      if (res.error) {
         console.error(
           `[resolveLastFmArtistIds] Cache-hit update failed for "${row.lastfm_artist_name}":`,
-          updateErr.message
+          res.error
         )
       } else {
         console.log(
-          `[resolveLastFmArtistIds] cache-hit name="${row.lastfm_artist_name}" id=${cached.spotify_artist_id}`
+          `[resolveLastFmArtistIds] cache-hit name="${row.lastfm_artist_name}" id=${cached.spotify_artist_id}${res.merged ? " (merged)" : ""}`
         )
       }
       continue
@@ -345,20 +398,42 @@ async function resolveLastFmBatch(params: {
       )
     }
 
-    // Write result (resolved ID or null) + update timestamp
-    const { error: updateErr } = await supabase
-      .from("listened_artists")
-      .update({
-        spotify_artist_id: resolvedId,  // null stays null — retry via id_resolution_attempted_at window
-        id_resolution_attempted_at: now,
+    // Write result (resolved ID or null) + update timestamp.
+    // When resolvedId is set, the update may trip the (user_id, spotify_artist_id)
+    // unique constraint if another source already owns that artist — merge in that case.
+    if (resolvedId) {
+      const res = await resolveOrMergeRow({
+        supabase,
+        userId,
+        orphanId: row.id,
+        spotifyArtistId: resolvedId,
+        now,
       })
-      .eq("id", row.id)
+      if (res.error) {
+        console.error(
+          `[resolveLastFmArtistIds] Update failed for "${row.lastfm_artist_name}":`,
+          res.error
+        )
+      } else if (res.merged) {
+        console.log(
+          `[resolveLastFmArtistIds] merged orphan name="${row.lastfm_artist_name}" into existing id=${resolvedId}`
+        )
+      }
+    } else {
+      const { error: updateErr } = await supabase
+        .from("listened_artists")
+        .update({
+          spotify_artist_id: null,  // null stays null — retry via id_resolution_attempted_at window
+          id_resolution_attempted_at: now,
+        })
+        .eq("id", row.id)
 
-    if (updateErr) {
-      console.error(
-        `[resolveLastFmArtistIds] Update failed for "${row.lastfm_artist_name}":`,
-        updateErr.message
-      )
+      if (updateErr) {
+        console.error(
+          `[resolveLastFmArtistIds] Timestamp update failed for "${row.lastfm_artist_name}":`,
+          updateErr.message
+        )
+      }
     }
   }
 }
@@ -469,7 +544,7 @@ export async function accumulateLastFmHistory(params: {
   // that still have NULL.  Runs non-blocking (no throw) so a Spotify hiccup
   // does not break the sync response for the user.
   try {
-    await resolveLastFmArtistIds({ supabase, userId, accessToken })
+    await resolveUnresolvedArtistIds({ supabase, userId, accessToken })
   } catch (err) {
     console.error(
       "[accumulateLastFmHistory] Resolution pass failed:",
@@ -538,7 +613,18 @@ async function batchUpsertLastFmArtists(
       .from("listened_artists")
       .insert(toInsert)
     if (insertError) {
-      console.error("[accumulateLastFmHistory] Batch insert error:", insertError.message)
+      if (insertError.code === "23505") {
+        // Concurrent sync from another source inserted a name-only row first.
+        // Fall back to per-row insert so one conflict doesn't drop the batch.
+        for (const row of toInsert) {
+          const { error: rowErr } = await supabase.from("listened_artists").insert(row)
+          if (rowErr && rowErr.code !== "23505") {
+            console.error("[accumulateLastFmHistory] Row insert error:", rowErr.message)
+          }
+        }
+      } else {
+        console.error("[accumulateLastFmHistory] Batch insert error:", insertError.message)
+      }
     }
   }
 

--- a/lib/seed-artist-validation.ts
+++ b/lib/seed-artist-validation.ts
@@ -1,0 +1,54 @@
+import { isValidSpotifyId } from "@/lib/spotify-ids"
+
+export interface SeedArtistInput {
+  id: string
+  name: string
+  imageUrl: string | null
+}
+
+export interface ValidatedSeedArtist {
+  id: string
+  name: string
+  imageUrl: string | null
+}
+
+const HTTP_URL = /^https?:\/\//
+
+export function validateSeedArtists(
+  input: unknown,
+  { min, max }: { min: number; max: number },
+): { ok: true; artists: ValidatedSeedArtist[] } | { ok: false; error: string } {
+  if (!Array.isArray(input)) {
+    return { ok: false, error: `artists must be an array of ${min}–${max} entries` }
+  }
+  if (input.length < min || input.length > max) {
+    return { ok: false, error: `artists must be an array of ${min}–${max} entries` }
+  }
+
+  const out: ValidatedSeedArtist[] = []
+  for (const entry of input) {
+    if (!entry || typeof entry !== "object") {
+      return { ok: false, error: "each artist must be an object" }
+    }
+    const e = entry as Record<string, unknown>
+    if (typeof e.id !== "string" || !isValidSpotifyId(e.id)) {
+      return { ok: false, error: "invalid Spotify artist id" }
+    }
+    if (typeof e.name !== "string") {
+      return { ok: false, error: "artist name must be a string" }
+    }
+    const name = e.name.trim()
+    if (name.length === 0 || name.length > 200) {
+      return { ok: false, error: "artist name must be 1–200 chars" }
+    }
+    let imageUrl: string | null = null
+    if (e.imageUrl !== null && e.imageUrl !== undefined) {
+      if (typeof e.imageUrl !== "string" || e.imageUrl.length > 500 || !HTTP_URL.test(e.imageUrl)) {
+        return { ok: false, error: "imageUrl must be an http(s) URL up to 500 chars, or null" }
+      }
+      imageUrl = e.imageUrl
+    }
+    out.push({ id: e.id, name, imageUrl })
+  }
+  return { ok: true, artists: out }
+}

--- a/lib/statsfm-listened-artists.ts
+++ b/lib/statsfm-listened-artists.ts
@@ -1,0 +1,227 @@
+import { createServiceClient } from "@/lib/supabase/server"
+import { resolveUnresolvedArtistIds } from "@/lib/listened-artists"
+
+interface StatsFmArtist {
+  id: number
+  name: string
+  spotifyIds?: string[]
+}
+
+interface StatsFmTopArtistItem {
+  position?: number
+  streams?: number
+  playedMs?: number
+  artist: StatsFmArtist
+}
+
+interface StatsFmTopArtistsResponse {
+  items?: StatsFmTopArtistItem[]
+}
+
+interface ResolvedEntry {
+  spotifyId: string
+  name: string
+}
+
+export async function accumulateStatsFmHistory(params: {
+  userId: string
+  statsfmUsername: string
+  /** Spotify access token — used for the ID resolution pass after upserting name-only rows. */
+  accessToken: string
+}): Promise<void> {
+  const { userId, statsfmUsername, accessToken } = params
+
+  const url = `https://api.stats.fm/api/v1/users/${encodeURIComponent(statsfmUsername)}/top/artists?range=lifetime`
+  const res = await fetch(url, { signal: AbortSignal.timeout(8000) })
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch stats.fm top artists (HTTP ${res.status})`)
+  }
+
+  const data = (await res.json()) as StatsFmTopArtistsResponse
+  const items = data.items ?? []
+
+  const resolved: ResolvedEntry[] = []
+  const unresolvedNames = new Set<string>()
+
+  for (const item of items) {
+    const name = item.artist?.name?.trim()
+    if (!name) continue
+    const sid = item.artist.spotifyIds?.[0]
+    if (sid) {
+      resolved.push({ spotifyId: sid, name })
+    } else {
+      unresolvedNames.add(name)
+    }
+  }
+
+  const supabase = createServiceClient()
+
+  if (resolved.length > 0) {
+    await batchUpsertStatsFmResolved(supabase, userId, resolved)
+  }
+  if (unresolvedNames.size > 0) {
+    await batchUpsertStatsFmNames(supabase, userId, [...unresolvedNames])
+  }
+
+  try {
+    await resolveUnresolvedArtistIds({ supabase, userId, accessToken })
+  } catch (err) {
+    console.error(
+      "[accumulateStatsFmHistory] Resolution pass failed:",
+      err instanceof Error ? err.message : err
+    )
+  }
+}
+
+async function batchUpsertStatsFmResolved(
+  supabase: ReturnType<typeof createServiceClient>,
+  userId: string,
+  entries: ResolvedEntry[]
+): Promise<void> {
+  const now = new Date().toISOString()
+  const ids = entries.map((e) => e.spotifyId)
+
+  const { data: existingRows, error: selectError } = await supabase
+    .from("listened_artists")
+    .select("id, spotify_artist_id, play_count")
+    .eq("user_id", userId)
+    .in("spotify_artist_id", ids)
+
+  if (selectError) {
+    console.error("[accumulateStatsFmHistory] Batch select error:", selectError.message)
+    return
+  }
+
+  const existingMap = new Map<string, { id: string; play_count: number }>()
+  for (const row of existingRows ?? []) {
+    if (row.spotify_artist_id) {
+      existingMap.set(row.spotify_artist_id, { id: row.id, play_count: row.play_count })
+    }
+  }
+
+  const toInsert: Array<{
+    user_id: string
+    spotify_artist_id: string
+    lastfm_artist_name: null
+    source: string
+    play_count: number
+    last_seen_at: string
+  }> = []
+  const toUpdate: Array<{ id: string; play_count: number; last_seen_at: string }> = []
+
+  for (const entry of entries) {
+    const existing = existingMap.get(entry.spotifyId)
+    if (existing) {
+      toUpdate.push({ id: existing.id, play_count: existing.play_count + 1, last_seen_at: now })
+    } else {
+      toInsert.push({
+        user_id: userId,
+        spotify_artist_id: entry.spotifyId,
+        lastfm_artist_name: null,
+        source: "statsfm",
+        play_count: 1,
+        last_seen_at: now,
+      })
+    }
+  }
+
+  if (toInsert.length > 0) {
+    const { error: insertError } = await supabase.from("listened_artists").insert(toInsert)
+    if (insertError) {
+      console.error("[accumulateStatsFmHistory] Batch insert (resolved) error:", insertError.message)
+    }
+  }
+  if (toUpdate.length > 0) {
+    const { error: updateError } = await supabase
+      .from("listened_artists")
+      .upsert(toUpdate, { onConflict: "id" })
+    if (updateError) {
+      console.error("[accumulateStatsFmHistory] Batch update (resolved) error:", updateError.message)
+    }
+  }
+
+  console.log(
+    `[accumulateStatsFmHistory] resolved batch insert=${toInsert.length} update=${toUpdate.length}`
+  )
+}
+
+async function batchUpsertStatsFmNames(
+  supabase: ReturnType<typeof createServiceClient>,
+  userId: string,
+  artistNames: string[]
+): Promise<void> {
+  const now = new Date().toISOString()
+
+  const { data: existingRows, error: selectError } = await supabase
+    .from("listened_artists")
+    .select("id, lastfm_artist_name, play_count")
+    .eq("user_id", userId)
+    .in("lastfm_artist_name", artistNames)
+
+  if (selectError) {
+    console.error("[accumulateStatsFmHistory] Batch select (names) error:", selectError.message)
+    return
+  }
+
+  const existingMap = new Map<string, { id: string; play_count: number }>()
+  for (const row of existingRows ?? []) {
+    if (row.lastfm_artist_name) {
+      existingMap.set(row.lastfm_artist_name, { id: row.id, play_count: row.play_count })
+    }
+  }
+
+  const toInsert: Array<{
+    user_id: string
+    spotify_artist_id: null
+    lastfm_artist_name: string
+    source: string
+    play_count: number
+    last_seen_at: string
+  }> = []
+  const toUpdate: Array<{ id: string; play_count: number; last_seen_at: string }> = []
+
+  for (const name of artistNames) {
+    const existing = existingMap.get(name)
+    if (existing) {
+      toUpdate.push({ id: existing.id, play_count: existing.play_count + 1, last_seen_at: now })
+    } else {
+      toInsert.push({
+        user_id: userId,
+        spotify_artist_id: null,
+        lastfm_artist_name: name,
+        source: "statsfm",
+        play_count: 1,
+        last_seen_at: now,
+      })
+    }
+  }
+
+  if (toInsert.length > 0) {
+    const { error: insertError } = await supabase.from("listened_artists").insert(toInsert)
+    if (insertError) {
+      if (insertError.code === "23505") {
+        for (const row of toInsert) {
+          const { error: rowErr } = await supabase.from("listened_artists").insert(row)
+          if (rowErr && rowErr.code !== "23505") {
+            console.error("[accumulateStatsFmHistory] Row insert (names) error:", rowErr.message)
+          }
+        }
+      } else {
+        console.error("[accumulateStatsFmHistory] Batch insert (names) error:", insertError.message)
+      }
+    }
+  }
+  if (toUpdate.length > 0) {
+    const { error: updateError } = await supabase
+      .from("listened_artists")
+      .upsert(toUpdate, { onConflict: "id" })
+    if (updateError) {
+      console.error("[accumulateStatsFmHistory] Batch update (names) error:", updateError.message)
+    }
+  }
+
+  console.log(
+    `[accumulateStatsFmHistory] names batch insert=${toInsert.length} update=${toUpdate.length}`
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@dicebear/collection": "^9.4.2",
+        "@dicebear/core": "^9.4.2",
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.101.1",
         "class-variance-authority": "^0.7.1",
@@ -548,6 +550,435 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@dicebear/adventurer": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer/-/adventurer-9.4.2.tgz",
+      "integrity": "sha512-jqYp834ZmGDA9HBBDQAdgF1O2UTCwHF4vVrktXWa2Dppp1JczPL5HnVOWsjtrLmXNn61Wd6OLmBb2e6rhzp3ig==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/adventurer-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer-neutral/-/adventurer-neutral-9.4.2.tgz",
+      "integrity": "sha512-5xgkG/mNL4j3Q4SJGQLBU/KnU90tng8Ze5ofThD+55wi0oeY/nSAUowg6UFCmHrktjifj/MEx3CQqbpcPWtfIA==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars/-/avataaars-9.4.2.tgz",
+      "integrity": "sha512-3x9jKFkOkFSPmpTbt9xvhiU2E1GX7beCSsX0tXRUShj8x6+5Ks9yBRT1VlkySbnXrZ/GglADGg7vJ/D2uIx1Yw==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars-neutral/-/avataaars-neutral-9.4.2.tgz",
+      "integrity": "sha512-/eNrp0YCNJRwQXqOloLm1+3Ss2C+pMpUQIGkbEnGsP1UK+13Ge80ggDDof1HpdqvG9HAZcKa7hnbG/0HSwyDSw==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears/-/big-ears-9.4.2.tgz",
+      "integrity": "sha512-mNfz3ppNA7UBq0IO3nXCiV5pFPG7c1DfzRB0foNU2Wo1XXT8FIcSY2BvDlYqorZTOUOz7dHb0vx06hqvG0HP5w==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears-neutral/-/big-ears-neutral-9.4.2.tgz",
+      "integrity": "sha512-M8Ozmzza4eY4hpLOYULgJxMYmBA0CsBnrE15/xw6LZkEREXnrX5z0NJsf8hUfdyF6BWZ+RBgzoiav32DAC5zcg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-smile": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-smile/-/big-smile-9.4.2.tgz",
+      "integrity": "sha512-hmT5i7rcPPhStjZyg28pbIhdTnnMBzK3RObI0vKCpY30EFrzaPkkdDL6Ck5fAFBdvDIW1EpOJkenyR0XPmhgbQ==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts/-/bottts-9.4.2.tgz",
+      "integrity": "sha512-tsx+dII7EFUCVA8URj66G1GqORCCVduCAx4dY2prEY2IeFianVpkntXuFsWZ9BBGx1NZFndvDith5oTwKMQPbQ==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts-neutral/-/bottts-neutral-9.4.2.tgz",
+      "integrity": "sha512-kFNwWt6j+gzZ5n5Pz7WVwePubREAQOF8ZwWA9ztwVYDVMLnOChWbAofy5FED4j5md2MXFH2EgLCFCMr5K2BmIA==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/collection": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/collection/-/collection-9.4.2.tgz",
+      "integrity": "sha512-KArubv7if8H7j9sIfpDK2hJJqrdNVR5zMPAMOSpIU2JPyXx8TC9o5wsmXb8il5wOHgaS9Q/cla7jUNIiDD7Gsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dicebear/adventurer": "9.4.2",
+        "@dicebear/adventurer-neutral": "9.4.2",
+        "@dicebear/avataaars": "9.4.2",
+        "@dicebear/avataaars-neutral": "9.4.2",
+        "@dicebear/big-ears": "9.4.2",
+        "@dicebear/big-ears-neutral": "9.4.2",
+        "@dicebear/big-smile": "9.4.2",
+        "@dicebear/bottts": "9.4.2",
+        "@dicebear/bottts-neutral": "9.4.2",
+        "@dicebear/croodles": "9.4.2",
+        "@dicebear/croodles-neutral": "9.4.2",
+        "@dicebear/dylan": "9.4.2",
+        "@dicebear/fun-emoji": "9.4.2",
+        "@dicebear/glass": "9.4.2",
+        "@dicebear/icons": "9.4.2",
+        "@dicebear/identicon": "9.4.2",
+        "@dicebear/initials": "9.4.2",
+        "@dicebear/lorelei": "9.4.2",
+        "@dicebear/lorelei-neutral": "9.4.2",
+        "@dicebear/micah": "9.4.2",
+        "@dicebear/miniavs": "9.4.2",
+        "@dicebear/notionists": "9.4.2",
+        "@dicebear/notionists-neutral": "9.4.2",
+        "@dicebear/open-peeps": "9.4.2",
+        "@dicebear/personas": "9.4.2",
+        "@dicebear/pixel-art": "9.4.2",
+        "@dicebear/pixel-art-neutral": "9.4.2",
+        "@dicebear/rings": "9.4.2",
+        "@dicebear/shapes": "9.4.2",
+        "@dicebear/thumbs": "9.4.2",
+        "@dicebear/toon-head": "9.4.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/core": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/core/-/core-9.4.2.tgz",
+      "integrity": "sha512-MF0042+Z3s8PGZKZLySfhft28bUa3B1iq0e5NSjCvY8gfMi5aIH/iRJGRJa1N9Jz1BNkxYb4yvJ/N9KO8Z6Y+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles/-/croodles-9.4.2.tgz",
+      "integrity": "sha512-6VoO0JviIf7dKKMBTL/SMXxWhnXHaZuzufX90G0nXxS77ELG1YkGNMaZzawizN4C09Gbya2gJkozqrWiJN/aGw==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles-neutral/-/croodles-neutral-9.4.2.tgz",
+      "integrity": "sha512-oG5IeUdtiYshQ89gkAVcl5w3xAEi5UZX2fTzIyelpBPCG176l7VuuFzlxi2umnB3E6LVHYy06DXvUo/p+rXB2Q==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/dylan": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/dylan/-/dylan-9.4.2.tgz",
+      "integrity": "sha512-1vQvRu9x9DrwFxhFaIU2rf0EUL04yDTbAt7fHyAjM0mEsKzTD4mRNf95tCRuavCoW6W48u7A/OY6jyIub6kxLQ==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/fun-emoji": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/fun-emoji/-/fun-emoji-9.4.2.tgz",
+      "integrity": "sha512-kqB6LPkdYCdEU/mwbyz34xLzoNUKL6ARcoo3fr5ASq9D6ZE07qIKybC3xv5+CPz7VmspJ1Q3c/VVWVMDRP7Twg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/glass": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/glass/-/glass-9.4.2.tgz",
+      "integrity": "sha512-z5qUogHQ1b6UJ2zCqT848mU2U9DKbVDhiX6GPDjD7tYLisCCJVisH9p6WyNdHvflUd4SHkA6gRqVJIh2v2HnTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/icons": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/icons/-/icons-9.4.2.tgz",
+      "integrity": "sha512-QSMMz0NA03ypSGhXC8HQX8FSj8lYT+/5yqH+/N03OH2IjL0q7wwGZ7nqsrtlRp76O5WqMTwGfSbTUUYPjFr+Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/identicon": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/identicon/-/identicon-9.4.2.tgz",
+      "integrity": "sha512-JVDSmZsv11mSWqwAktK5x9Bslht2xY3TFUn8xzu6slAYe1Z7hEXZ76eb+UJ6F4qEzdwZ7xPWzAS6Nb0Y3A0pww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/initials": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/initials/-/initials-9.4.2.tgz",
+      "integrity": "sha512-yePuIUasmwtl9IrtB6rEzE/zb5fImKP/neW0CdcTC2MwLgMuP1GLHEGRgg1zI8exIh+PMv1YdLGyyUuRTE2Qpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei/-/lorelei-9.4.2.tgz",
+      "integrity": "sha512-YMv6vnriW6VLFDsreKuOnUFFno6SRe7+7X7R7zPY0rZ+MaHX9V3jcioIG+1PSjIHEDfOLUHpr5vd1JBWv8y7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei-neutral/-/lorelei-neutral-9.4.2.tgz",
+      "integrity": "sha512-yspanTthA5vh6iCdeLzn6xZ4yYMYRcfcxblcgSvHTF1ut0bjAXtw5SXzZ6aJTrJWiHkzYOQuTOR6GVYiW80Q7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/micah": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/micah/-/micah-9.4.2.tgz",
+      "integrity": "sha512-e4D3W/OlChSsLo7Llwsy0J18vk0azJqF/uFoY+EKACCNHBc1HGNsqVvu2CTf+OWOA8wTyAK6UkjBN5p01r7D+g==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/miniavs": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/miniavs/-/miniavs-9.4.2.tgz",
+      "integrity": "sha512-wLwyFNNUnDRd3BbhSBhXR0XEpX8sG0/xDA5M/OkDoapLqZnnI48YLUSDd2N5QTAVMmcSEuZOYxkcnj7WW79vlg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists/-/notionists-9.4.2.tgz",
+      "integrity": "sha512-ZCySq+nxcD/x4xyYgytcj2N9uY3gxrL+qpnmOdp2BdA221KacVrxlsUPpIgEMqxS2rMmBQXfxg129Pzn4ycIpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists-neutral/-/notionists-neutral-9.4.2.tgz",
+      "integrity": "sha512-AyD9kEfVxQUwDGf4Op059gVmYIOAkTKg3dtE9h9mEKP7zl/kMy5B67BFFOo7sB0mXCjzAegZ6ekGU02E8+hIHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/open-peeps": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/open-peeps/-/open-peeps-9.4.2.tgz",
+      "integrity": "sha512-i01tLgtp2g937T81sVeAOVlqsCtiTck/Kw20g7hN80+7xrXjOUepz2HPLy3HeiMjwjMGRy5o54kSd0/8Ht4Dqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/personas": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/personas/-/personas-9.4.2.tgz",
+      "integrity": "sha512-NJlkvI5F5gugt6t2+7QrYNTwQC7+4IQZS3vG0dYk2BncxOHax0BuLovdSdiAesTL4ZkytFYIydWmKmV2/xcUwg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art/-/pixel-art-9.4.2.tgz",
+      "integrity": "sha512-peHf7oKICDgBZ8dUyj+txPnS7VZEWgvKE+xW4mNQqBt6dYZIjmva2shOVHn0b1JU+FDxMx3uIkWVixKdUq4WGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art-neutral/-/pixel-art-neutral-9.4.2.tgz",
+      "integrity": "sha512-9e9Lz554uQvWaXV2P17ss+hPa6rTyuAKBtB8zk8ECjHiZzIl61N/KcTVLZ4dILVZwj7gYriaLo16QEqvL2GJCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/rings": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/rings/-/rings-9.4.2.tgz",
+      "integrity": "sha512-Pc3ymWrRDQPJFNrbbLt7RJrzGvUuuxUiDkrfLhoVE+B6mZWEL1PC78DPbS1yUWYLErJOpJuM2GSwXmTbVjWf+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/shapes": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/shapes/-/shapes-9.4.2.tgz",
+      "integrity": "sha512-AFL6jAaiLztvcqyq+ds+lWZu6Vbp3PlGWhJeJRm842jxtiluJpl6r4f6nUXP2fdMz7MNpDzXfLooQK9E04NbUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/thumbs": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/thumbs/-/thumbs-9.4.2.tgz",
+      "integrity": "sha512-ccWvDBqbkWS5uzHbsg5L6uML6vBfX7jT3J3jHCQksvz8haHItxTK02w+6e1UavZUsvza4lG5X/XY3eji3siJ4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/toon-head": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/toon-head/-/toon-head-9.4.2.tgz",
+      "integrity": "sha512-lwFeSXyAnaKnCfMt9TiJwnD1cXQUGkey/0h6i/+4TVHVMCz5/Ri5u1ynovPNHy1SnBf858QwoXHkxilGLwQX/g==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -3460,7 +3891,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dicebear/collection": "^9.4.2",
+    "@dicebear/core": "^9.4.2",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
     "class-variance-authority": "^0.7.1",

--- a/supabase/migrations/0017_statsfm_username.sql
+++ b/supabase/migrations/0017_statsfm_username.sql
@@ -1,0 +1,18 @@
+-- stats.fm integration: add public username column alongside lastfm_username
+-- and allow 'statsfm' as a source in listened_artists.
+alter table users add column statsfm_username text;
+
+-- Per-source cooldown columns (replaces single last_accumulated_at for per-source sync UX).
+-- The legacy column stays populated as a "most recent any-source sync" for backwards compat.
+alter table users add column last_accumulated_lastfm_at timestamptz;
+alter table users add column last_accumulated_statsfm_at timestamptz;
+
+alter table listened_artists drop constraint listened_artists_source_check;
+alter table listened_artists add constraint listened_artists_source_check
+  check (source in ('spotify_recent', 'spotify_top', 'lastfm', 'statsfm'));
+
+-- Prevent duplicate unresolved name-only rows across sources (Last.fm + stats.fm
+-- both feeding the same artist name concurrently would otherwise create dupes).
+create unique index if not exists listened_artists_user_name_unresolved_idx
+  on listened_artists (user_id, lastfm_artist_name)
+  where lastfm_artist_name is not null and spotify_artist_id is null;


### PR DESCRIPTION
## Summary

- **Taste anchors section** — Artists, Genres, Last.fm, and stats.fm moved into one outlined accent-bordered card with a full-width **Generate my feed →** button. Generate calls `POST /api/recommendations/generate?replace=true` (wipes the unseen queue, rebuilds fresh from current anchors + thumbs feedback, navigates to `/feed`). The feed's existing "Load more artists" button keeps append semantics.
- **Raised caps to 200** on artists and genres across onboarding, settings, and API validation (`ARTIST_CAP`, `GENRE_CAP`, `MAX_SEED_ARTISTS`). Ceiling is a safety stop, not a visible UX limit.
- **Dropped the non-functional Spotify "locked" row** from Settings.
- **DiceBear avatar** — replaced hand-rolled 5×5 identicon with `@dicebear/core` + `@dicebear/collection` `shapes` style. Deterministic per user UUID.
- **stats.fm pipeline** — augments play-history filtering via `source='statsfm'` rows in `listened_artists`; does NOT seed generation. Last.fm remains the generation anchor.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 466/466 passing
- [x] Preview: Profile card renders DiceBear shapes avatar
- [x] Preview: "Taste anchors" eyebrow above purple-accent card containing Artists → Genres → Last.fm → stats.fm → Generate button
- [x] Preview: No Spotify row anywhere in Settings
- [x] Preview: No console errors
- [ ] Manual: Add 25+ artists in onboarding/settings — no "X of 20" hint, adding succeeds past 20
- [ ] Manual: Click Generate with unseen queue present → unseen rows wiped, fresh batch written, navigates to `/feed`
- [ ] Manual: Click Generate again within 30s → cooldown toast shown
- [ ] Manual: Thumbs-up an artist, Generate — signal survives in `feedback` table and influences next batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)