### PR TITLE
Discovery engine: username-only auth, onboarding redesign, hardening, discovery settings

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -13,7 +13,7 @@ export default async function SettingsPage() {
   const supabase = createServiceClient()
   const { data: user } = await supabase
     .from("users")
-    .select("id, play_threshold, lastfm_username, statsfm_username, underground_mode, selected_genres")
+    .select("id, play_threshold, popularity_curve, lastfm_username, statsfm_username, underground_mode, selected_genres")
     .eq("id", userId)
     .maybeSingle()
 
@@ -41,16 +41,69 @@ export default async function SettingsPage() {
     popularity: 0,
   }))
 
+  // Pull recent recs to build distinct example artists at anchor popularities
+  const { data: recRows } = await supabase
+    .from("recommendation_cache")
+    .select("artist_data")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(200)
+
+  type FeedArtist = { name: string; popularity: number }
+  const userArtists: FeedArtist[] = []
+  for (const row of recRows ?? []) {
+    const data = row.artist_data as { name?: string; popularity?: number } | null
+    const pop = typeof data?.popularity === "number" ? data.popularity : null
+    if (pop === null || !data?.name) continue
+    userArtists.push({ name: data.name, popularity: pop })
+  }
+
+  // Hardcode mainstream anchors so the curve preview is an honest reference
+  // regardless of the user's (niche-skewed) cache. Niche anchors still prefer
+  // a real cached pick when one falls within tolerance of the target.
+  const HARDCODED_ANCHORS: Record<number, string> = {
+    30: "Hana Vu",
+    70: "Phoebe Bridgers",
+    100: "Taylor Swift",
+  }
+  const TOLERANCE = 7
+  // Anchors the curve preview renders at (popularity 0–100).
+  const anchors = [0, 30, 70, 100]
+  const used = new Set<string>()
+  const exampleArtists = anchors.map((target) => {
+    const hardcoded = HARDCODED_ANCHORS[target]
+    if (hardcoded) {
+      return { popularity: target, artist: { name: hardcoded, popularity: target } }
+    }
+    let best: FeedArtist | null = null
+    let bestDiff = Infinity
+    for (const a of userArtists) {
+      if (used.has(a.name)) continue
+      const diff = Math.abs(a.popularity - target)
+      if (diff < bestDiff) {
+        bestDiff = diff
+        best = a
+      }
+    }
+    if (best && bestDiff <= TOLERANCE) {
+      used.add(best.name)
+      return { popularity: target, artist: best }
+    }
+    return { popularity: target, artist: null }
+  })
+
   return (
     <SettingsForm
       userSeed={userId}
       initialPlayThreshold={user?.play_threshold ?? 5}
+      initialPopularityCurve={user?.popularity_curve ?? 0.95}
       initialLastfmUsername={user?.lastfm_username ?? null}
       initialStatsfmUsername={user?.statsfm_username ?? null}
       initialLastfmArtistCount={lastfmArtistCount}
       initialUndergroundMode={user?.underground_mode ?? false}
       initialSelectedGenres={(user?.selected_genres as string[] | null) ?? []}
       initialSeedArtists={seedArtists}
+      exampleArtists={exampleArtists}
     />
   )
 }

--- a/app/(app)/stats/page.tsx
+++ b/app/(app)/stats/page.tsx
@@ -13,7 +13,7 @@ export default async function StatsPage() {
   const supabase = createServiceClient()
 
   // Run all queries in parallel
-  const [seenResult, savesResult, likesResult, dislikesResult, genreResult] =
+  const [seenResult, savesResult, likesResult, dislikesResult, genreResult, savedArtistRows] =
     await Promise.all([
       supabase
         .from("recommendation_cache")
@@ -46,6 +46,11 @@ export default async function StatsPage() {
         .eq("user_id", userId)
         .eq("signal", "thumbs_up")
         .is("deleted_at", null),
+
+      supabase
+        .from("saves")
+        .select("spotify_artist_id")
+        .eq("user_id", userId),
     ])
 
   // Build top genres from liked artists
@@ -76,6 +81,27 @@ export default async function StatsPage() {
     }
   }
 
+  // Resolve saved artists → { name, popularity } via recommendation_cache join
+  const savedIds = Array.from(new Set((savedArtistRows.data ?? []).map((r) => r.spotify_artist_id)))
+  const savedArtists: { name: string; popularity: number }[] = []
+  if (savedIds.length > 0) {
+    const { data: cachedArtistData } = await supabase
+      .from("recommendation_cache")
+      .select("spotify_artist_id, artist_data")
+      .eq("user_id", userId)
+      .in("spotify_artist_id", savedIds)
+
+    const seen = new Set<string>()
+    for (const row of cachedArtistData ?? []) {
+      if (seen.has(row.spotify_artist_id)) continue
+      seen.add(row.spotify_artist_id)
+      const data = row.artist_data as { name?: string; popularity?: number } | null
+      if (!data?.name) continue
+      const pop = typeof data.popularity === "number" ? data.popularity : 0
+      savedArtists.push({ name: data.name, popularity: pop })
+    }
+  }
+
   return (
     <StatsClient
       totalDiscovered={seenResult.count ?? 0}
@@ -83,6 +109,7 @@ export default async function StatsPage() {
       totalLikes={likesResult.count ?? 0}
       totalDislikes={dislikesResult.count ?? 0}
       topGenres={topGenres}
+      savedArtists={savedArtists}
     />
   )
 }

--- a/app/api/recommendations/generate/route.ts
+++ b/app/api/recommendations/generate/route.ts
@@ -7,7 +7,7 @@ import { buildRecommendations } from "@/lib/recommendation/engine"
 import { extractArtistColor } from "@/lib/colour-extraction"
 import { searchTracksByArtist } from "@/lib/music-provider/itunes"
 import { musicProvider } from "@/lib/music-provider/provider"
-import { type NextRequest } from "next/server"
+import { after, type NextRequest } from "next/server"
 import type { Artist } from "@/lib/music-provider/types"
 
 /** Run an array of async tasks with a maximum concurrency of `limit`. */
@@ -33,6 +33,132 @@ async function pLimit<T>(
   return results
 }
 
+type CachedRec = { spotify_artist_id: string; artist_data: unknown }
+type SupabaseServiceClient = ReturnType<typeof createServiceClient>
+
+async function runColorExtraction(
+  supabase: SupabaseServiceClient,
+  userId: string,
+  cachedRecs: CachedRec[],
+  artistIds: string[]
+): Promise<void> {
+  const { data: cacheRows } = await supabase
+    .from("artist_search_cache")
+    .select("spotify_artist_id, artist_color")
+    .in("spotify_artist_id", artistIds)
+
+  const colorMap = new Map<string, string | null>()
+  for (const row of cacheRows ?? []) {
+    colorMap.set(row.spotify_artist_id, row.artist_color ?? null)
+  }
+
+  const needsColor = cachedRecs.filter((r) => {
+    const c = colorMap.get(r.spotify_artist_id)
+    return !c || c.toLowerCase() === "#8b5cf6"
+  })
+
+  if (needsColor.length > 0) {
+    const colorTasks = needsColor.map((r) => async () => {
+      const artistData = r.artist_data as Artist | null
+      const imageUrl = artistData?.imageUrl
+      if (!imageUrl) return
+
+      const color = await extractArtistColor(imageUrl)
+      colorMap.set(r.spotify_artist_id, color)
+
+      const { error: colorErr } = await supabase
+        .from("artist_search_cache")
+        .update({ artist_color: color })
+        .eq("spotify_artist_id", r.spotify_artist_id)
+
+      if (colorErr) {
+        console.log(`[generate] color-update-fail id=${r.spotify_artist_id} err=${colorErr.message}`)
+      }
+    })
+    await pLimit(colorTasks, 5)
+  }
+
+  await Promise.all(
+    cachedRecs.map(async (r) => {
+      const color = colorMap.get(r.spotify_artist_id)
+      if (!color) return
+      await supabase
+        .from("recommendation_cache")
+        .update({ artist_data: { ...(r.artist_data as object), artist_color: color } })
+        .eq("user_id", userId)
+        .eq("spotify_artist_id", r.spotify_artist_id)
+    })
+  )
+}
+
+async function runTrackPrewarm(
+  supabase: SupabaseServiceClient,
+  accessToken: string,
+  cachedRecs: CachedRec[],
+  artistIds: string[]
+): Promise<void> {
+  const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+  const { data: freshTracks } = await supabase
+    .from("artist_tracks_cache")
+    .select("spotify_artist_id, fetched_at")
+    .in("spotify_artist_id", artistIds)
+    .gt("fetched_at", twentyFourHoursAgo)
+
+  const freshTrackIds = new Set((freshTracks ?? []).map((r) => r.spotify_artist_id))
+
+  // Pre-warm all 20 artists now that we're in after() and off the critical path.
+  const staleArtists = cachedRecs.filter((r) => !freshTrackIds.has(r.spotify_artist_id))
+  if (staleArtists.length === 0) return
+
+  const tasks = staleArtists.map((r) => async () => {
+    const artistData = r.artist_data as Artist | null
+    const artistName = artistData?.name
+    if (!artistName) return
+
+    const itunesTracks = await searchTracksByArtist(artistName, "US", 5)
+    if (itunesTracks && itunesTracks.length > 0) {
+      await supabase.from("artist_tracks_cache").upsert(
+        {
+          spotify_artist_id: r.spotify_artist_id,
+          tracks: itunesTracks,
+          source: "itunes",
+          fetched_at: new Date().toISOString(),
+        },
+        { onConflict: "spotify_artist_id" }
+      )
+      console.log(`[generate] prewarm-itunes artistId=${r.spotify_artist_id} count=${itunesTracks.length}`)
+      return
+    }
+
+    try {
+      const spotifyTracks = await musicProvider.getArtistTopTracks(
+        accessToken,
+        r.spotify_artist_id,
+        5,
+        "US"
+      )
+      if (spotifyTracks.length > 0) {
+        await supabase.from("artist_tracks_cache").upsert(
+          {
+            spotify_artist_id: r.spotify_artist_id,
+            tracks: spotifyTracks,
+            source: "spotify",
+            fetched_at: new Date().toISOString(),
+          },
+          { onConflict: "spotify_artist_id" }
+        )
+        console.log(`[generate] prewarm-spotify artistId=${r.spotify_artist_id} count=${spotifyTracks.length}`)
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.log(`[generate] prewarm-fail artistId=${r.spotify_artist_id} err="${msg}"`)
+    }
+  })
+
+  await pLimit(tasks, 5)
+}
+
 export async function POST(req: NextRequest): Promise<Response> {
   console.log(`[generate] POST`)
   const session = await auth()
@@ -48,7 +174,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   // Read user row including play_threshold
   const { data: user, error: userError } = await supabase
     .from("users")
-    .select("id, play_threshold, underground_mode, last_generated_at")
+    .select("id, play_threshold, popularity_curve, underground_mode, last_generated_at")
     .eq("id", userId)
     .maybeSingle()
 
@@ -56,6 +182,8 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   // Default to 5 if the column is null (pre-migration rows)
   const playThreshold: number = user.play_threshold ?? 5
+  // Default to 0.95 (legacy hardcoded value) for pre-migration rows
+  const popularityCurve: number = user.popularity_curve ?? 0.95
 
   // Per-user cooldown: 30 seconds between generate requests
   if (user.last_generated_at) {
@@ -111,145 +239,46 @@ export async function POST(req: NextRequest): Promise<Response> {
     const rawGenre = req.nextUrl.searchParams.get("genre")
     const genre = rawGenre && rawGenre.length <= 80 ? rawGenre : undefined
 
-    const recCount = await buildRecommendations({
+    const { count: recCount, runSecondary } = await buildRecommendations({
       userId: user.id,
       accessToken,
       playThreshold,
+      popularityCurve,
       genre,
       undergroundMode: user.underground_mode ?? false,
     })
 
-    // ── Colour extraction ──────────────────────────────────────────────────
-    // Fetch the ranked artists from recommendation_cache (just written).
-    const { data: cachedRecs } = await supabase
-      .from("recommendation_cache")
-      .select("spotify_artist_id, artist_data")
-      .eq("user_id", user.id)
-      .is("seen_at", null)
+    // Decorations (colour extraction + track pre-warming) and secondary
+    // candidate resolution run AFTER the response returns so the feed
+    // renders as soon as the initial cache is written. Cards degrade
+    // gracefully: missing colours fall back to a deterministic name-hash
+    // hue, missing tracks are fetched per-card on mount.
+    after(async () => {
+      // Run secondary resolution first so freshly-added rows get decorated
+      // in the same background pass.
+      if (runSecondary) {
+        try {
+          await runSecondary()
+        } catch (err) {
+          console.log(`[generate] secondary-fail err=${err instanceof Error ? err.message : err}`)
+        }
+      }
 
-    if (cachedRecs && cachedRecs.length > 0) {
-      // Gather artist IDs so we can look up existing colours in batch.
+      const { data: cachedRecs } = await supabase
+        .from("recommendation_cache")
+        .select("spotify_artist_id, artist_data")
+        .eq("user_id", user.id)
+        .is("seen_at", null)
+
+      if (!cachedRecs || cachedRecs.length === 0) return
+
       const artistIds = cachedRecs.map((r) => r.spotify_artist_id)
 
-      const { data: cacheRows } = await supabase
-        .from("artist_search_cache")
-        .select("spotify_artist_id, artist_color")
-        .in("spotify_artist_id", artistIds)
-
-      const colorMap = new Map<string, string | null>()
-      for (const row of cacheRows ?? []) {
-        colorMap.set(row.spotify_artist_id, row.artist_color ?? null)
-      }
-
-      // Identify artists missing a colour, OR stuck with the broken legacy purple fallback "#8b5cf6"
-      const needsColor = cachedRecs.filter((r) => {
-        const c = colorMap.get(r.spotify_artist_id)
-        return !c || c.toLowerCase() === "#8b5cf6"
-      })
-
-      if (needsColor.length > 0) {
-        const colorTasks = needsColor.map((r) => async () => {
-          const artistData = r.artist_data as Artist | null
-          const imageUrl = artistData?.imageUrl
-          if (!imageUrl) return
-
-          const color = await extractArtistColor(imageUrl)
-          colorMap.set(r.spotify_artist_id, color)
-
-          // Write back to artist_search_cache (keyed by spotify_artist_id)
-          const { error: colorErr } = await supabase
-            .from("artist_search_cache")
-            .update({ artist_color: color })
-            .eq("spotify_artist_id", r.spotify_artist_id)
-
-          if (colorErr) {
-            console.log(`[generate] color-update-fail id=${r.spotify_artist_id} err=${colorErr.message}`)
-          }
-        })
-        await pLimit(colorTasks, 5)
-      }
-
-      // Write artist_color into recommendation_cache rows.
-      await Promise.all(
-        cachedRecs.map(async (r) => {
-          const color = colorMap.get(r.spotify_artist_id)
-          if (!color) return
-          await supabase
-            .from("recommendation_cache")
-            .update({ artist_data: { ...(r.artist_data as object), artist_color: color } })
-            .eq("user_id", user.id)
-            .eq("spotify_artist_id", r.spotify_artist_id)
-        })
-      )
-
-      // ── Track pre-warming ────────────────────────────────────────────────
-      // For each ranked artist, ensure artist_tracks_cache has a fresh entry
-      // (fetched within the last 24 hours). Fetch stale/missing with concurrency 5.
-      const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
-
-      const { data: freshTracks } = await supabase
-        .from("artist_tracks_cache")
-        .select("spotify_artist_id, fetched_at")
-        .in("spotify_artist_id", artistIds)
-        .gt("fetched_at", twentyFourHoursAgo)
-
-      const freshTrackIds = new Set((freshTracks ?? []).map((r) => r.spotify_artist_id))
-
-      const staleArtists = cachedRecs.filter(
-        (r) => !freshTrackIds.has(r.spotify_artist_id)
-      ).slice(0, 8) // Limit to top 8 explicitly strictly to prevent Vercel Free-Tier 10s Serverless timeout
-
-      if (staleArtists.length > 0) {
-        const tasks = staleArtists.map((r) => async () => {
-          const artistData = r.artist_data as Artist | null
-          const artistName = artistData?.name
-          if (!artistName) return
-
-          // Try iTunes first (free, no auth)
-          const itunesTracks = await searchTracksByArtist(artistName, "US", 5)
-          if (itunesTracks && itunesTracks.length > 0) {
-            await supabase.from("artist_tracks_cache").upsert(
-              {
-                spotify_artist_id: r.spotify_artist_id,
-                tracks: itunesTracks,
-                source: "itunes",
-                fetched_at: new Date().toISOString(),
-              },
-              { onConflict: "spotify_artist_id" }
-            )
-            console.log(`[generate] prewarm-itunes artistId=${r.spotify_artist_id} count=${itunesTracks.length}`)
-            return
-          }
-
-          // Fall back to Spotify
-          try {
-            const spotifyTracks = await musicProvider.getArtistTopTracks(
-              accessToken,
-              r.spotify_artist_id,
-              5,
-              "US"
-            )
-            if (spotifyTracks.length > 0) {
-              await supabase.from("artist_tracks_cache").upsert(
-                {
-                  spotify_artist_id: r.spotify_artist_id,
-                  tracks: spotifyTracks,
-                  source: "spotify",
-                  fetched_at: new Date().toISOString(),
-                },
-                { onConflict: "spotify_artist_id" }
-              )
-              console.log(`[generate] prewarm-spotify artistId=${r.spotify_artist_id} count=${spotifyTracks.length}`)
-            }
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err)
-            console.log(`[generate] prewarm-fail artistId=${r.spotify_artist_id} err="${msg}"`)
-          }
-        })
-
-        await pLimit(tasks, 5)
-      }
-    }
+      await Promise.all([
+        runColorExtraction(supabase, user.id, cachedRecs, artistIds),
+        runTrackPrewarm(supabase, accessToken, cachedRecs, artistIds),
+      ])
+    })
 
     return Response.json({ success: true, count: recCount })
   } catch (err) {

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -10,6 +10,7 @@ export async function PATCH(request: Request) {
 
   let body: {
     playThreshold?: number
+    popularityCurve?: number
     lastfmUsername?: string
     statsfmUsername?: string
     selectedGenres?: string[]
@@ -29,6 +30,15 @@ export async function PATCH(request: Request) {
       return apiError("playThreshold must be an integer between 0 and 100", 400)
     }
     update.play_threshold = threshold
+  }
+
+  if (body.popularityCurve !== undefined) {
+    const curve = body.popularityCurve
+    if (typeof curve !== "number" || !Number.isFinite(curve) || curve < 0.9 || curve > 1.0) {
+      return apiError("popularityCurve must be a number between 0.9 and 1.0", 400)
+    }
+    // Clamp to 3 decimals to match the column definition
+    update.popularity_curve = Math.round(curve * 1000) / 1000
   }
 
   if (body.lastfmUsername !== undefined) {

--- a/components/feed/artist-card.tsx
+++ b/components/feed/artist-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react"
 import { motion } from "framer-motion"
-import { SkipForward, Bookmark, Check, Share2, ChevronDown, ChevronUp } from "lucide-react"
+import { SkipForward, Bookmark, Check, Share2 } from "lucide-react"
 import { toast } from "sonner"
 import { TrackStrip } from "@/components/feed/track-strip"
 import { useAudio } from "@/lib/audio-context"
@@ -66,7 +66,6 @@ export function ArtistCard({
 
   const [localTracks, setLocalTracks] = useState<Track[]>(artist_data.topTracks)
   const [isFetchingTracks, setIsFetchingTracks] = useState(false)
-  const [showWhy, setShowWhy] = useState(false)
 
   useEffect(() => {
     if (artist_data.topTracks.length === 0 && localTracks.length === 0 && !isFetchingTracks) {
@@ -106,8 +105,6 @@ export function ArtistCard({
       : why.genres.length > 0
         ? `Because you like ${why.genres.join(", ")}`
         : null
-
-  const hasWhyDetails = why.sourceArtists.length > 0 || why.genres.length > 0 || why.friendBoost.length > 0
 
   // ------------------------------------------------------------------
   // Collapsed (slim bar) state — no emoji, colour-coded labels
@@ -286,52 +283,7 @@ export function ArtistCard({
           </div>
         )}
 
-        {/* Why this artist? — expandable */}
-        {hasWhyDetails && (
-          <div style={{ marginTop: 18 }}>
-            <button
-              onClick={(e) => { e.stopPropagation(); setShowWhy(!showWhy) }}
-              className="btn btn-block"
-              style={{
-                background: "rgba(255,255,255,0.025)",
-                justifyContent: "space-between",
-                fontSize: 13,
-                color: "var(--text-secondary)",
-              }}
-            >
-              <span className="serif" style={{ fontStyle: "italic" }}>
-                {reasonText ?? "Why this artist?"}
-              </span>
-              {showWhy ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-            </button>
-            {showWhy && (
-              <div
-                style={{
-                  marginTop: 6,
-                  padding: "12px 14px",
-                  background: "rgba(255,255,255,0.02)",
-                  borderRadius: 10,
-                  border: "1px solid var(--border)",
-                  display: "flex",
-                  flexWrap: "wrap",
-                  gap: 6,
-                }}
-              >
-                {why.sourceArtists.map((a) => (
-                  <span key={a} className="chip selected">{a}</span>
-                ))}
-                {why.genres.map((g) => (
-                  <span key={g} className="chip" style={{ color: artistColor, borderColor: hexToRgba(artistColor, 0.3) }}>{g}</span>
-                ))}
-                {why.friendBoost.map((f) => (
-                  <span key={f} className="chip" style={{ color: "var(--accent)" }}>via {f}</span>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-        {/* Show reason text only when no expandable why panel */}
-        {!hasWhyDetails && reasonText && (
+        {reasonText && (
           <div
             className="serif"
             style={{

--- a/components/feed/feed-client.tsx
+++ b/components/feed/feed-client.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react"
 import { useRouter } from "next/navigation"
 import { toast } from "sonner"
 import { ArtistCard } from "@/components/feed/artist-card"
-import { hexToRgba, stringToVibrantHex, sanitizeHex } from "@/lib/color-utils"
+import { hexToRgba, sanitizeHex } from "@/lib/color-utils"
 
 interface Track {
   id: string
@@ -43,189 +43,13 @@ interface FeedClientProps {
 }
 
 // ---------------------------------------------------------------------------
-// Magazine rhythm components
-// ---------------------------------------------------------------------------
-
-function FullBleedSpread({ rec }: { rec: Recommendation }) {
-  const { artist_data, artist_color } = rec
-  const color = sanitizeHex(artist_color) === "#8b5cf6" ? stringToVibrantHex(artist_data.name) : sanitizeHex(artist_color)
-  return (
-    <div
-      className="fadein"
-      style={{
-        width: "100%",
-        height: 480,
-        position: "relative",
-        overflow: "hidden",
-        borderRadius: "var(--radius-xl)",
-        boxShadow: "0 30px 80px rgba(0,0,0,0.6)",
-      }}
-    >
-      {artist_data.imageUrl ? (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img
-          src={artist_data.imageUrl}
-          alt={artist_data.name}
-          style={{ width: "100%", height: "100%", objectFit: "cover", filter: "saturate(0.85) contrast(1.05)" }}
-        />
-      ) : (
-        <div
-          style={{
-            width: "100%",
-            height: "100%",
-            background: `linear-gradient(135deg, ${hexToRgba(color, 0.4)}, ${hexToRgba(color, 0.15)} 60%, #0a0a0a)`,
-          }}
-        />
-      )}
-      <div
-        style={{
-          position: "absolute",
-          inset: 0,
-          background: "linear-gradient(180deg, rgba(0,0,0,0.5) 0%, transparent 30%, transparent 60%, rgba(0,0,0,0.85) 100%)",
-        }}
-      />
-      <div
-        style={{
-          position: "absolute",
-          left: 28, right: 28, top: 24,
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
-        <div className="mono" style={{ fontSize: 10, letterSpacing: "0.24em", textTransform: "uppercase", color: "rgba(255,255,255,0.7)" }}>
-          Editor&apos;s pick · No. 03
-        </div>
-        <div className="mono" style={{ fontSize: 10, letterSpacing: "0.18em", textTransform: "uppercase", color }}>
-          {artist_data.genres[0] ?? "Uncategorized"}
-        </div>
-      </div>
-      <div style={{ position: "absolute", left: 28, right: 28, bottom: 28 }}>
-        <div className="serif" style={{ fontSize: 14, color: "rgba(255,255,255,0.75)", marginBottom: 8, fontStyle: "italic" }}>
-          this week, on the flipside —
-        </div>
-        <div
-          className="display"
-          style={{ fontSize: "clamp(48px, 10vw, 80px)", lineHeight: 0.88, color: "#fff", textShadow: "0 6px 30px rgba(0,0,0,0.5)" }}
-        >
-          {artist_data.name}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const PULL_QUOTES = [
-  { q: "Three nights of Khruangbin and you\u2019re still hungry. Try this.", k: "tonight\u2019s mood" },
-  { q: "Quiet records for loud rooms.", k: "a small theory" },
-  { q: "The deeper you go, the more the algorithm gets out of the way.", k: "house rules" },
-  { q: "Some artists arrive sideways.", k: "field notes" },
-]
-
-function PullQuote({ index }: { index: number }) {
-  const q = PULL_QUOTES[index % PULL_QUOTES.length]
-  return (
-    <div className="fadein" style={{ padding: "40px 8px 32px", textAlign: "center", position: "relative" }}>
-      <div className="mono" style={{ fontSize: 9.5, letterSpacing: "0.28em", textTransform: "uppercase", color: "var(--text-muted)", marginBottom: 18 }}>
-        — {q.k} —
-      </div>
-      <div className="serif" style={{ fontSize: "clamp(22px, 4.5vw, 30px)", lineHeight: 1.2, color: "var(--text-primary)", maxWidth: 440, margin: "0 auto", fontStyle: "italic" }}>
-        &ldquo;{q.q}&rdquo;
-      </div>
-    </div>
-  )
-}
-
-function VsCard({ recA, recB }: { recA: Recommendation; recB: Recommendation }) {
-  const colorA = sanitizeHex(recA.artist_color) === "#8b5cf6" ? stringToVibrantHex(recA.artist_data.name) : sanitizeHex(recA.artist_color)
-  const colorB = sanitizeHex(recB.artist_color) === "#8b5cf6" ? stringToVibrantHex(recB.artist_data.name) : sanitizeHex(recB.artist_color)
-  return (
-    <div
-      className="fadein"
-      style={{
-        borderRadius: "var(--radius-xl)",
-        overflow: "hidden",
-        border: "1px solid var(--border)",
-        background: "var(--bg-card)",
-      }}
-    >
-      <div
-        style={{
-          padding: "14px 20px",
-          borderBottom: "1px solid var(--border)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
-        <div className="mono" style={{ fontSize: 10, letterSpacing: "0.24em", textTransform: "uppercase", color: "var(--text-muted)" }}>
-          A side-by-side
-        </div>
-        <div className="serif" style={{ fontSize: 13, fontStyle: "italic", color: "var(--text-secondary)" }}>
-          which one tonight?
-        </div>
-      </div>
-      <div style={{ display: "grid", gridTemplateColumns: "1fr auto 1fr" }}>
-        <VsHalf rec={recA} color={colorA} />
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "0 4px",
-            borderLeft: "1px solid var(--border)",
-            borderRight: "1px solid var(--border)",
-          }}
-        >
-          <div className="serif" style={{ fontSize: 32, color: "var(--text-muted)", fontStyle: "italic" }}>vs</div>
-        </div>
-        <VsHalf rec={recB} color={colorB} />
-      </div>
-    </div>
-  )
-}
-
-function VsHalf({ rec, color }: { rec: Recommendation; color: string }) {
-  const { artist_data } = rec
-  return (
-    <div style={{ padding: 16, display: "flex", flexDirection: "column", gap: 10 }}>
-      <div style={{ width: "100%", aspectRatio: "1", borderRadius: 12, overflow: "hidden" }}>
-        {artist_data.imageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={artist_data.imageUrl} alt={artist_data.name} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-        ) : (
-          <div style={{ width: "100%", height: "100%", background: `linear-gradient(135deg, ${hexToRgba(color, 0.4)}, #0a0a0a)` }} />
-        )}
-      </div>
-      <div className="display" style={{ fontSize: 22, lineHeight: 1.0 }}>{artist_data.name}</div>
-      <div className="mono" style={{ fontSize: 9.5, color, letterSpacing: "0.16em", textTransform: "uppercase" }}>
-        {artist_data.genres[0] ?? "Uncategorized"}
-      </div>
-    </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Feed sequence builder
 // ---------------------------------------------------------------------------
 
-type FeedItem =
-  | { kind: "card"; rec: Recommendation; key: string }
-  | { kind: "spread"; rec: Recommendation; key: string }
-  | { kind: "quote"; index: number; key: string }
-  | { kind: "vs"; recA: Recommendation; recB: Recommendation; key: string }
+type FeedItem = { kind: "card"; rec: Recommendation; key: string }
 
-function buildSequence(recs: Recommendation[], magazine: boolean): FeedItem[] {
-  const out: FeedItem[] = []
-  recs.forEach((rec, i) => {
-    out.push({ kind: "card", rec, key: `c-${rec.spotify_artist_id}` })
-    if (magazine) {
-      if (i === 1) out.push({ kind: "spread", rec: recs[Math.min(2, recs.length - 1)], key: `s-${i}` })
-      if (i === 3) out.push({ kind: "quote", index: i, key: `q-${i}` })
-      if (i === 4 && recs[5]) out.push({ kind: "vs", recA: recs[4], recB: recs[5], key: `vs-${i}` })
-    }
-  })
-  return out
+function buildSequence(recs: Recommendation[]): FeedItem[] {
+  return recs.map((rec) => ({ kind: "card", rec, key: `c-${rec.spotify_artist_id}` }))
 }
 
 // ---------------------------------------------------------------------------
@@ -261,7 +85,7 @@ export function FeedClient({ recommendations }: FeedClientProps) {
   const activeAuraColor = sanitizeHex(activeRec?.artist_color)
 
   const sequence = useMemo(
-    () => buildSequence(filteredRecs, true),
+    () => buildSequence(filteredRecs),
     [filteredRecs]
   )
 
@@ -386,24 +210,18 @@ export function FeedClient({ recommendations }: FeedClientProps) {
       {/* Feed sequence */}
       <div className="col" style={{ gap: 24, marginTop: 8 }}>
         {sequence.map((item) => {
-          if (item.kind === "card") {
-            const { rec } = item
-            return (
-              <ArtistCard
-                key={item.key}
-                recommendation={rec}
-                onSave={() => handleSave(rec.spotify_artist_id)}
-                isSaved={savedIds.has(rec.spotify_artist_id)}
-                onFeedback={(signal) => handleFeedback(rec.spotify_artist_id, signal)}
-                isDismissed={dismissedSignals.has(rec.spotify_artist_id)}
-                dismissSignal={dismissedSignals.get(rec.spotify_artist_id) ?? null}
-              />
-            )
-          }
-          if (item.kind === "spread") return <FullBleedSpread key={item.key} rec={item.rec} />
-          if (item.kind === "quote") return <PullQuote key={item.key} index={item.index} />
-          if (item.kind === "vs") return <VsCard key={item.key} recA={item.recA} recB={item.recB} />
-          return null
+          const { rec } = item
+          return (
+            <ArtistCard
+              key={item.key}
+              recommendation={rec}
+              onSave={() => handleSave(rec.spotify_artist_id)}
+              isSaved={savedIds.has(rec.spotify_artist_id)}
+              onFeedback={(signal) => handleFeedback(rec.spotify_artist_id, signal)}
+              isDismissed={dismissedSignals.has(rec.spotify_artist_id)}
+              dismissSignal={dismissedSignals.get(rec.spotify_artist_id) ?? null}
+            />
+          )
         })}
 
         {/* Load more */}

--- a/components/settings/curve-preview.tsx
+++ b/components/settings/curve-preview.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useMemo } from "react"
+
+export interface CurvePreviewProps {
+  /** Base `k` of the scoring curve k^popularity. Range 0.90–1.00. */
+  popularityCurve: number
+  /** When true, overlays the ((100-pop)/100)^2 extra-obscurity penalty. */
+  undergroundMode: boolean
+  /**
+   * Distinct example artists at anchor popularity values. Render order matches
+   * input order. Artist may be null when the user's cache has no good match
+   * near that anchor.
+   */
+  exampleArtists: { popularity: number; artist: { name: string; popularity: number } | null }[]
+}
+
+const ANCHORS = [0, 30, 70, 100]
+
+const svgX = (pop: number) => 20 + (pop / 100) * 360
+const svgY = (score: number) => 170 - score * 160
+
+export function CurvePreview({ popularityCurve, undergroundMode, exampleArtists }: CurvePreviewProps) {
+  const { defaultPath, defaultFill, undergroundPath } = useMemo(() => {
+    const defaultPoints = Array.from({ length: 51 }, (_, i) => {
+      const p = i * 2
+      const y = Math.pow(popularityCurve, p)
+      return `${svgX(p)},${svgY(y)}`
+    })
+
+    const undergroundPoints = Array.from({ length: 51 }, (_, i) => {
+      const p = i * 2
+      const y = Math.pow(popularityCurve, p) * Math.pow((100 - p) / 100, 2)
+      return `${svgX(p)},${svgY(y)}`
+    })
+
+    const defaultPath = `M ${defaultPoints.join(" L ")}`
+    const undergroundPath = `M ${undergroundPoints.join(" L ")}`
+    const defaultFill = `${defaultPath} L ${svgX(100)} ${svgY(0)} L ${svgX(0)} ${svgY(0)} Z`
+
+    return { defaultPath, defaultFill, undergroundPath }
+  }, [popularityCurve])
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <div style={{ position: "relative", width: "100%" }}>
+        <svg
+          viewBox="0 0 400 210"
+          width="100%"
+          style={{ display: "block" }}
+          aria-label="Popularity scoring curve"
+        >
+          <defs>
+            <linearGradient id="curvePreviewFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.4" />
+              <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
+            </linearGradient>
+          </defs>
+
+          <line x1="20" y1="170" x2="380" y2="170" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+
+          {[0, 20, 40, 60, 80, 100].map((tick) => (
+            <g key={tick}>
+              <line x1={svgX(tick)} y1="170" x2={svgX(tick)} y2="174" stroke="rgba(255,255,255,0.2)" strokeWidth="1" />
+              <text x={svgX(tick)} y="188" textAnchor="middle" fill="var(--text-muted)" fontSize="10" className="mono">
+                {tick}
+              </text>
+            </g>
+          ))}
+          <text x="200" y="205" textAnchor="middle" fill="var(--text-muted)" fontSize="10">
+            popularity
+          </text>
+
+          <path d={defaultFill} fill="url(#curvePreviewFill)" style={{ transition: "d 0.15s ease" }} />
+          <path
+            d={defaultPath}
+            fill="none"
+            stroke="var(--accent)"
+            strokeWidth="2"
+            strokeLinejoin="round"
+            style={{ transition: "d 0.15s ease" }}
+          />
+
+          <path
+            d={undergroundPath}
+            fill="none"
+            stroke="#a78bfa"
+            strokeWidth="2"
+            strokeDasharray="4 4"
+            strokeLinejoin="round"
+            style={{
+              opacity: undergroundMode ? 1 : 0,
+              transition: "opacity 0.4s ease, d 0.15s ease",
+            }}
+          />
+
+          {ANCHORS.map((a) => {
+            const y = Math.pow(popularityCurve, a)
+            return (
+              <circle
+                key={a}
+                cx={svgX(a)}
+                cy={svgY(y)}
+                r="4"
+                fill="var(--accent)"
+                stroke="var(--bg-card)"
+                strokeWidth="2"
+                style={{ transition: "cy 0.15s ease" }}
+              />
+            )
+          })}
+        </svg>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 6 }}>
+        {exampleArtists.map(({ popularity, artist }) => (
+          <div key={popularity} style={{ display: "flex", flexDirection: "column", gap: 2, alignItems: "center", minWidth: 0 }}>
+            <span className="mono" style={{ fontSize: 10, color: "var(--text-muted)" }}>
+              pop. {popularity}
+            </span>
+            <span
+              style={{
+                fontSize: 12,
+                color: "var(--text-primary)",
+                textAlign: "center",
+                lineHeight: 1.2,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                maxWidth: "100%",
+              }}
+              title={artist?.name ?? undefined}
+            >
+              {artist?.name ?? "—"}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -6,17 +6,20 @@ import { signOut } from "next-auth/react"
 import { toast } from "sonner"
 import { IdenticonAvatar } from "@/components/ui/identicon-avatar"
 import { LibraryEditor } from "@/components/settings/library-editor"
+import { CurvePreview } from "@/components/settings/curve-preview"
 import type { SpotifyArtist } from "@/components/onboarding/artist-search"
 
 interface SettingsFormProps {
   userSeed: string
   initialPlayThreshold: number
+  initialPopularityCurve: number
   initialLastfmUsername: string | null
   initialStatsfmUsername: string | null
   initialLastfmArtistCount: number
   initialUndergroundMode: boolean
   initialSelectedGenres: string[]
   initialSeedArtists: SpotifyArtist[]
+  exampleArtists: { popularity: number; artist: { name: string; popularity: number } | null }[]
 }
 
 async function patchSettings(payload: Record<string, unknown>) {
@@ -34,15 +37,18 @@ async function patchSettings(payload: Record<string, unknown>) {
 export function SettingsForm({
   userSeed,
   initialPlayThreshold,
+  initialPopularityCurve,
   initialLastfmUsername,
   initialStatsfmUsername,
   initialLastfmArtistCount,
   initialUndergroundMode,
   initialSelectedGenres,
   initialSeedArtists,
+  exampleArtists,
 }: SettingsFormProps) {
   const router = useRouter()
   const [threshold, setThreshold] = useState(initialPlayThreshold)
+  const [popularityCurve, setPopularityCurve] = useState(initialPopularityCurve)
   const [lastfmUsername, setLastfmUsername] = useState(initialLastfmUsername ?? "")
   const [statsfmUsername, setStatsfmUsername] = useState(initialStatsfmUsername ?? "")
   const [undergroundMode, setUndergroundMode] = useState(initialUndergroundMode)
@@ -54,16 +60,16 @@ export function SettingsForm({
   const isConnected = lastfmUsername.trim().length > 0
   const isStatsfmConnected = statsfmUsername.trim().length > 0
 
-  const sliderPct = Math.round((threshold / 50) * 100)
-  const sliderBg = `linear-gradient(to right, var(--accent) ${sliderPct}%, rgba(255,255,255,0.10) ${sliderPct}%)`
+  const familiarPct = Math.round((threshold / 50) * 100)
+  const familiarBg = `linear-gradient(to right, var(--accent) ${familiarPct}%, rgba(255,255,255,0.10) ${familiarPct}%)`
 
-  const obscurityLabel =
-    threshold < 5  ? "Deep underground"
-    : threshold < 15 ? "Adventurous"
-    : threshold < 30 ? "Curious"
-    : "Familiar"
+  const familiarityLabel =
+    threshold < 5  ? "Nothing familiar"
+    : threshold < 15 ? "Mostly new"
+    : threshold < 30 ? "Some favorites"
+    : "All familiar"
 
-  const obscurityHelp =
+  const familiarityHelp =
     threshold < 5
       ? "Almost nothing you\u2019ve heard before will appear."
       : threshold < 15
@@ -72,11 +78,42 @@ export function SettingsForm({
       ? "A balanced mix \u2014 some discovery, some comfort."
       : "Includes artists you already play often."
 
+  // Popularity curve slider: store as 0.90–1.00 (k value).
+  // Smaller k = steeper curve = stronger niche preference.
+  const curvePct = Math.round(((popularityCurve - 0.9) / 0.1) * 100)
+  const curveBg = `linear-gradient(to right, var(--accent) ${curvePct}%, rgba(255,255,255,0.10) ${curvePct}%)`
+
+  const curveLabel =
+    popularityCurve < 0.92 ? "Niche only"
+    : popularityCurve < 0.95 ? "Mostly niche"
+    : popularityCurve < 0.97 ? "Balanced"
+    : popularityCurve < 0.99 ? "Mostly popular"
+    : "Mainstream"
+
+  const curveHelp =
+    popularityCurve < 0.92
+      ? "The steepest curve — popularity is punished hard. Expect deep cuts only."
+      : popularityCurve < 0.95
+      ? "Obscurity is strongly preferred, with room for a few less-obvious names."
+      : popularityCurve < 0.97
+      ? "Default mix \u2014 obscurity wins, but not by a landslide."
+      : popularityCurve < 0.99
+      ? "Popularity barely hurts. Expect familiar names alongside some discoveries."
+      : "The curve flattens — popularity is nearly ignored."
+
   async function handleThresholdRelease() {
     try {
       await patchSettings({ playThreshold: threshold })
     } catch {
-      toast.error("Failed to save play threshold")
+      toast.error("Failed to save familiarity")
+    }
+  }
+
+  async function handleCurveRelease() {
+    try {
+      await patchSettings({ popularityCurve })
+    } catch {
+      toast.error("Failed to save popularity preference")
     }
   }
 
@@ -173,7 +210,7 @@ export function SettingsForm({
 
   return (
     <>
-      {/* Slider CSS */}
+      {/* Slider CSS — shared by familiarity and popularity dials */}
       <style>{`
         .obs-slider {
           -webkit-appearance: none;
@@ -223,18 +260,17 @@ export function SettingsForm({
                   your account
                 </div>
                 <div
-                  className="mono"
-                  style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}
+                  style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 3, lineHeight: 1.45 }}
                 >
-                  zero PII stored
+                  your username is your only login — we store a hash, not the name itself
                 </div>
               </div>
             </div>
           </div>
 
-          {/* ── How underground? ─────────────────────────────────────── */}
+          {/* ── How familiar? ─────────────────────────────────────── */}
           <div>
-            <div className="eyebrow" style={{ marginBottom: 10 }}>How underground?</div>
+            <div className="eyebrow" style={{ marginBottom: 10 }}>How familiar?</div>
             <div className="fs-card">
               <div
                 style={{
@@ -245,7 +281,7 @@ export function SettingsForm({
                 }}
               >
                 <div className="serif" style={{ fontSize: 22, color: "var(--accent)" }}>
-                  {obscurityLabel}
+                  {familiarityLabel}
                 </div>
                 <div className="mono" style={{ fontSize: 12, color: "var(--text-muted)" }}>
                   hide if played &gt; {threshold}&times;
@@ -261,7 +297,7 @@ export function SettingsForm({
                 onChange={(e) => setThreshold(Number(e.target.value))}
                 onPointerUp={handleThresholdRelease}
                 onKeyUp={handleThresholdRelease}
-                style={{ background: sliderBg }}
+                style={{ background: familiarBg }}
               />
               <div
                 style={{
@@ -275,64 +311,11 @@ export function SettingsForm({
                   letterSpacing: "0.1em",
                 }}
               >
-                <span>&larr; deep underground</span>
-                <span>familiar &rarr;</span>
+                <span>&larr; nothing familiar</span>
+                <span>all familiar &rarr;</span>
               </div>
               <div className="muted" style={{ fontSize: 12, marginTop: 10, lineHeight: 1.5 }}>
-                {obscurityHelp}
-              </div>
-            </div>
-          </div>
-
-          {/* ── Deep underground mode ──────────────────────────────── */}
-          <div>
-            <div className="eyebrow" style={{ marginBottom: 10 }}>Deep underground mode</div>
-            <div className="fs-card">
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  gap: 16,
-                }}
-              >
-                <div style={{ flex: 1 }}>
-                  <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
-                    Extra obscure
-                  </div>
-                  <div className="muted" style={{ fontSize: 12, lineHeight: 1.5 }}>
-                    Aggressively deprioritize anything remotely popular. Only for listeners who want the absolute deepest cuts.
-                  </div>
-                </div>
-                <button
-                  onClick={handleUndergroundToggle}
-                  role="switch"
-                  aria-checked={undergroundMode}
-                  style={{
-                    width: 48,
-                    height: 28,
-                    borderRadius: 14,
-                    border: 0,
-                    cursor: "pointer",
-                    flexShrink: 0,
-                    background: undergroundMode ? "var(--accent)" : "rgba(255,255,255,0.10)",
-                    position: "relative",
-                    transition: "background 0.2s",
-                  }}
-                >
-                  <div
-                    style={{
-                      width: 22,
-                      height: 22,
-                      borderRadius: "50%",
-                      background: "#fff",
-                      position: "absolute",
-                      top: 3,
-                      left: undergroundMode ? 23 : 3,
-                      transition: "left 0.2s",
-                    }}
-                  />
-                </button>
+                {familiarityHelp}
               </div>
             </div>
           </div>
@@ -438,6 +421,120 @@ export function SettingsForm({
               >
                 {isGenerating ? "Generating…" : "Generate my feed →"}
               </button>
+            </div>
+          </div>
+
+          {/* ── Discovery ────────────────────────────────────────────── */}
+          <div>
+            <div className="eyebrow" style={{ marginBottom: 10 }}>Discovery</div>
+            <div className="fs-card col gap-16">
+              {/* Popularity preference dial */}
+              <div>
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "baseline",
+                    justifyContent: "space-between",
+                    marginBottom: 14,
+                  }}
+                >
+                  <div className="serif" style={{ fontSize: 22, color: "var(--accent)" }}>
+                    {curveLabel}
+                  </div>
+                  <div className="mono" style={{ fontSize: 12, color: "var(--text-muted)" }}>
+                    k = {popularityCurve.toFixed(3)}
+                  </div>
+                </div>
+                <input
+                  type="range"
+                  className="obs-slider"
+                  min={0.9}
+                  max={1.0}
+                  step={0.005}
+                  value={popularityCurve}
+                  onChange={(e) => setPopularityCurve(Number(e.target.value))}
+                  onPointerUp={handleCurveRelease}
+                  onKeyUp={handleCurveRelease}
+                  style={{ background: curveBg }}
+                />
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    marginTop: 8,
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10.5,
+                    color: "var(--text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.1em",
+                  }}
+                >
+                  <span>&larr; niche</span>
+                  <span>mainstream &rarr;</span>
+                </div>
+                <div className="muted" style={{ fontSize: 12, marginTop: 10, lineHeight: 1.5 }}>
+                  {curveHelp}
+                </div>
+              </div>
+
+              <div className="divider" />
+
+              {/* Live curve preview */}
+              <CurvePreview
+                popularityCurve={popularityCurve}
+                undergroundMode={undergroundMode}
+                exampleArtists={exampleArtists}
+              />
+
+              <div className="divider" />
+
+              {/* Extra obscure toggle */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 16,
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+                    Extra obscure
+                  </div>
+                  <div className="muted" style={{ fontSize: 12, lineHeight: 1.5 }}>
+                    Applies an extra penalty on top of the curve above. The dashed overlay shows the combined effect.
+                  </div>
+                </div>
+                <button
+                  onClick={handleUndergroundToggle}
+                  role="switch"
+                  aria-checked={undergroundMode}
+                  style={{
+                    width: 48,
+                    height: 28,
+                    borderRadius: 14,
+                    border: 0,
+                    cursor: "pointer",
+                    flexShrink: 0,
+                    background: undergroundMode ? "var(--accent)" : "rgba(255,255,255,0.10)",
+                    position: "relative",
+                    transition: "background 0.2s",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: "50%",
+                      background: "#fff",
+                      position: "absolute",
+                      top: 3,
+                      left: undergroundMode ? 23 : 3,
+                      transition: "left 0.2s",
+                    }}
+                  />
+                </button>
+              </div>
             </div>
           </div>
 

--- a/components/stats/stats-client.tsx
+++ b/components/stats/stats-client.tsx
@@ -1,7 +1,12 @@
 "use client"
 
-import { Disc3, Bookmark, ThumbsUp, ThumbsDown, Music } from "lucide-react"
-import type { ReactNode } from "react"
+import { Disc3, Bookmark, ThumbsUp, ThumbsDown, Music, ArrowUpDown } from "lucide-react"
+import { useMemo, useState, type ReactNode } from "react"
+
+interface SavedArtist {
+  name: string
+  popularity: number
+}
 
 interface StatsClientProps {
   totalDiscovered: number
@@ -9,6 +14,7 @@ interface StatsClientProps {
   totalLikes: number
   totalDislikes: number
   topGenres: { genre: string; count: number }[]
+  savedArtists: SavedArtist[]
 }
 
 function StatCard({
@@ -101,12 +107,200 @@ function GenreCard({ genres }: { genres: { genre: string; count: number }[] }) {
   )
 }
 
+function popularityTier(pop: number): string {
+  if (pop < 20) return "Obscure"
+  if (pop < 40) return "Niche"
+  if (pop < 60) return "Emerging"
+  if (pop < 80) return "Popular"
+  return "Mainstream"
+}
+
+function hashSeed(str: string): number {
+  let h = 2166136261
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return (h >>> 0) / 4294967295
+}
+
+function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) {
+  const [sortDesc, setSortDesc] = useState(false)
+
+  const sorted = useMemo(
+    () => [...savedArtists].sort((a, b) => (sortDesc ? b.popularity - a.popularity : a.popularity - b.popularity)),
+    [savedArtists, sortDesc]
+  )
+
+  const svgHeight = 110
+  const svgPad = { left: 20, right: 20, top: 20, bottom: 30 }
+  const plotW = 400 - svgPad.left - svgPad.right
+  const plotH = svgHeight - svgPad.top - svgPad.bottom
+
+  return (
+    <div
+      style={{
+        background: "var(--bg-card)",
+        border: "1px solid var(--border)",
+        borderRadius: 16,
+        padding: "24px 20px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 16,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Bookmark size={16} style={{ color: "var(--accent)" }} />
+        <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-secondary)" }}>
+          Your saved artists
+        </span>
+      </div>
+
+      {savedArtists.length === 0 ? (
+        <p style={{ fontSize: 14, color: "var(--text-muted)" }}>
+          Save some artists to see where they fall on the popularity scale.
+        </p>
+      ) : (
+        <>
+          <svg
+            viewBox={`0 0 400 ${svgHeight}`}
+            width="100%"
+            style={{ display: "block" }}
+            aria-label="Saved artists popularity distribution"
+          >
+            <line
+              x1={svgPad.left}
+              y1={svgHeight - svgPad.bottom}
+              x2={400 - svgPad.right}
+              y2={svgHeight - svgPad.bottom}
+              stroke="rgba(255,255,255,0.12)"
+              strokeWidth="1"
+            />
+
+            {[0, 20, 40, 60, 80, 100].map((tick) => {
+              const x = svgPad.left + (tick / 100) * plotW
+              return (
+                <g key={tick}>
+                  <line
+                    x1={x}
+                    y1={svgHeight - svgPad.bottom}
+                    x2={x}
+                    y2={svgHeight - svgPad.bottom + 4}
+                    stroke="rgba(255,255,255,0.2)"
+                    strokeWidth="1"
+                  />
+                  <text
+                    x={x}
+                    y={svgHeight - svgPad.bottom + 16}
+                    textAnchor="middle"
+                    fill="var(--text-muted)"
+                    fontSize="10"
+                    className="mono"
+                  >
+                    {tick}
+                  </text>
+                </g>
+              )
+            })}
+
+            {savedArtists.map((a) => {
+              const cx = svgPad.left + (a.popularity / 100) * plotW
+              const jitter = hashSeed(a.name)
+              const cy = svgPad.top + jitter * plotH
+              return (
+                <circle
+                  key={a.name}
+                  cx={cx}
+                  cy={cy}
+                  r="4"
+                  fill="var(--accent)"
+                  fillOpacity="0.7"
+                  stroke="var(--bg-card)"
+                  strokeWidth="1"
+                >
+                  <title>{`${a.name} · popularity ${a.popularity}`}</title>
+                </circle>
+              )
+            })}
+          </svg>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
+            <button
+              type="button"
+              onClick={() => setSortDesc((v) => !v)}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 80px 90px",
+                gap: 8,
+                padding: "8px 0",
+                background: "transparent",
+                border: 0,
+                borderBottom: "1px solid var(--border)",
+                color: "var(--text-muted)",
+                fontSize: 11,
+                fontWeight: 500,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                textAlign: "left",
+                cursor: "pointer",
+              }}
+            >
+              <span>Artist</span>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 4, justifyContent: "flex-end" }}>
+                Popularity
+                <ArrowUpDown size={11} />
+              </span>
+              <span style={{ textAlign: "right" }}>Tier</span>
+            </button>
+
+            <div style={{ maxHeight: 320, overflowY: "auto" }}>
+              {sorted.map((a) => (
+                <div
+                  key={a.name}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr 80px 90px",
+                    gap: 8,
+                    padding: "10px 0",
+                    borderBottom: "1px solid rgba(255,255,255,0.04)",
+                    alignItems: "center",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 13,
+                      color: "var(--text-primary)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                    title={a.name}
+                  >
+                    {a.name}
+                  </span>
+                  <span className="mono" style={{ fontSize: 12, color: "var(--text-secondary)", textAlign: "right" }}>
+                    {a.popularity}
+                  </span>
+                  <span style={{ fontSize: 12, color: "var(--text-muted)", textAlign: "right" }}>
+                    {popularityTier(a.popularity)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
 export function StatsClient({
   totalDiscovered,
   totalSaves,
   totalLikes,
   totalDislikes,
   topGenres,
+  savedArtists,
 }: StatsClientProps) {
   return (
     <div>
@@ -122,7 +316,10 @@ export function StatsClient({
         <StatCard icon={<ThumbsDown size={16} />} label="Passed" value={totalDislikes} accentColor="#ff4b4b" />
       </div>
 
-      <GenreCard genres={topGenres} />
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <GenreCard genres={topGenres} />
+        <SavedPopularityView savedArtists={savedArtists} />
+      </div>
     </div>
   )
 }

--- a/docs/superpowers/specs/2026-04-19-discovery-settings-redesign-prd.md
+++ b/docs/superpowers/specs/2026-04-19-discovery-settings-redesign-prd.md
@@ -1,0 +1,100 @@
+# PRD — Discovery Settings Redesign + Saved-Artists Popularity View
+
+**Date**: 2026-04-19
+**Branch**: Nick
+**Author**: TenNineteenOne
+
+## Problem
+
+1. The current `play_threshold` slider is labeled **"How underground?"** — this clashes conceptually with the separate **"Deep underground mode"** toggle below it. They sound like the same control but do unrelated things (one filters already-heard artists, the other bends the popularity curve). Users get confused.
+2. The algorithm that ranks artists by obscurity is opaque. We have an algorithm-explainer card on the stats page (built earlier today), but (a) it lives on the wrong page given users want to *tune* the algorithm, not just read about it, and (b) obscurity preference is currently binary (on/off) — no fine-grained control.
+3. The stats page should surface something *specific to what the user has saved* — not the same explainer that belongs in Settings.
+
+## Solution overview
+
+### Settings page
+
+1. **Rename** the `play_threshold` slider from "How underground?" → **"How familiar?"** (package #1 from naming discussion). New endpoint labels: `NOTHING FAMILIAR ← → ALL FAMILIAR`. New value labels: "Nothing familiar" / "Mostly new" / "Some favorites" / "All familiar".
+2. **Reorder** sections: Profile → **How familiar?** → **Taste anchors** → **Discovery** (new) → Account.
+3. **New Discovery section** containing:
+   - A new **Popularity preference dial** (continuous, 0–100). Controls the base `k` of the scoring curve `k^popularity`. Endpoints: `NICHE ← → MAINSTREAM`. Value labels at 20/40/60/80 thresholds: "Niche only" / "Mostly niche" / "Balanced" / "Mostly popular" / "Mainstream".
+   - The **Extra obscure toggle** (moved from its current standalone section into Discovery). It keeps its existing independent job — applies a `((100-pop)/100)^2` multiplier *on top* of the curve.
+   - A **live curve preview** that redraws in real time as the dial moves and the toggle flips. Both the curve shape (`k^pop`) and the dashed underground overlay (`k^pop × ((100-pop)/100)^2`) animate accurately.
+   - **Four anchor dots** at popularity 0, 30, 70, 100 with *distinct* example artists drawn from the user's own feed (nearest-match but deduplicated).
+
+### Stats page
+
+4. **Remove** the algorithm-explainer card and the 5-bucket feed-popularity histogram (both move to Settings, merged into the live curve preview).
+5. **Add** a **"Your saved artists"** visualization:
+   - **Dot plot** along a 0–100 popularity axis: each saved artist renders as a dot (jittered vertically to avoid stacking). Tap/hover shows the artist name.
+   - **Table** below: columns `Artist | Popularity | Tier`. Tier maps to the five popularity buckets. Sortable by popularity.
+   - Data source: `saves` table joined to `recommendation_cache.artist_data` (or `artist_search_cache`) for popularity values.
+
+## Data model changes
+
+New column:
+
+```sql
+alter table users
+  add column popularity_curve numeric(4,3) not null default 0.95
+  check (popularity_curve >= 0.90 and popularity_curve <= 1.00);
+```
+
+- Range **0.90 – 1.00**. Smaller = steeper curve (strong obscurity preference). Larger = flatter (popularity barely matters).
+- Default **0.95** (matches the current hardcoded value in the engine — zero behavior change for existing users).
+- Stored with 3 decimals (0.901 … 1.000), so the slider has ~100 distinct positions.
+
+Migration file: `0018_users_popularity_curve.sql`.
+
+## API changes
+
+- `app/api/settings/route.ts` PATCH handler: accept `popularityCurve: number`. Validate `0.90 ≤ value ≤ 1.00`. Map to `users.popularity_curve`.
+- `app/api/recommendations/generate/route.ts`: read `users.popularity_curve` (default 0.95) and pass into `buildRecommendations` input.
+
+## Engine changes
+
+- `lib/recommendation/types.ts`: add `popularityCurve: number` to `RecommendationInput`.
+- `lib/recommendation/engine.ts`: replace hardcoded `Math.pow(0.95, popularity)` with `Math.pow(popularityCurve, popularity)`.
+- The underground_mode `((100-pop)/100)^2` penalty **remains independent and unchanged** — it multiplies on top of the curve, same as today.
+
+## UI components
+
+- **New**: `components/settings/popularity-dial.tsx` — continuous range input styled like the existing familiarity slider.
+- **New**: `components/settings/curve-preview.tsx` — client-side SVG. Takes `{ popularityCurve, undergroundMode, exampleArtists }` as props, redraws on prop change. Reuses the SVG math from today's `AlgorithmExplainerCard` but parameterized by `k` and extended to 4 anchors.
+- **New**: `components/stats/saved-popularity-view.tsx` — dot plot + table. Takes `{ savedArtists: { name, popularity }[] }`.
+- **Modified**: `components/settings/settings-form.tsx` — reorder sections, rename slider, absorb the "Extra obscure" toggle and the new dial into a single Discovery card.
+- **Modified**: `components/stats/stats-client.tsx` — remove `PopularityHistogramCard` and `AlgorithmExplainerCard`, add `<SavedPopularityView>`.
+- **Modified**: `app/(app)/stats/page.tsx` — drop the histogram+anchor queries (no longer needed), add a query for saved-artists-with-popularity.
+
+## Acceptance criteria
+
+- [ ] Settings page renders with new section order: Profile → How familiar? → Taste anchors → Discovery → Account.
+- [ ] "How familiar?" slider shows new title + endpoint labels + value labels. Saving still updates `users.play_threshold`.
+- [ ] Discovery section contains: popularity dial, Extra obscure toggle, live curve preview with 4 anchor dots.
+- [ ] Dragging the popularity dial re-renders the curve live without a network round-trip. Saving on release persists `users.popularity_curve`.
+- [ ] Toggling "Extra obscure" live-redraws the dashed overlay on the curve.
+- [ ] Each of the 4 anchor dots shows a distinct artist name (from user's cache, nearest-match with dedup). Fallback text if the user has no recs yet.
+- [ ] Stats page no longer shows the histogram or algorithm-explainer cards.
+- [ ] Stats page shows saved-artists dot plot + sortable table. Empty state when user has 0 saves.
+- [ ] Generating recommendations uses the user's `popularity_curve` value (observable in the scoring formula).
+- [ ] All 466 existing tests still pass. `npx tsc --noEmit` clean.
+
+## Rollout order
+
+1. **Migration** — add `users.popularity_curve` column. Deploy-safe because existing code still references the hardcoded 0.95 at this point.
+2. **Engine + types** — plumb `popularityCurve` through `RecommendationInput`, read from users table in generate route. Behavior unchanged (default 0.95 matches hardcoded).
+3. **Settings API** — add `popularityCurve` field to PATCH handler.
+4. **Settings UI** — rename slider, reorder sections, add Discovery card with dial + toggle + live curve preview.
+5. **Stats page** — remove old cards, add saved-artists view.
+6. **Verify** — typecheck + tests + preview smoke test of both pages.
+
+## Out of scope
+
+- Onboarding changes (the new dial is Settings-only for now; new users get default 0.95).
+- Progress bar for cold-start generation (previously deferred per earlier plan; still deferred).
+- Genre-based filters for the curve.
+- Modifying the `((100-pop)/100)^2` underground penalty formula itself (user confirmed toggle stays independent of the dial).
+
+## Open questions
+
+None remaining — all clarifying questions resolved in the design conversation.

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -1,16 +1,21 @@
 import { musicProvider } from '@/lib/music-provider/provider'
 import type { Artist } from '@/lib/music-provider/types'
 import { createServiceClient } from '@/lib/supabase/server'
-import type { RecommendationInput, ScoredArtist } from './types'
+import type { BuildResult, RecommendationInput, ScoredArtist } from './types'
 import { ArtistNameCache } from './artist-name-cache'
 import { resolveArtistsByName } from './resolve-candidates'
 import coldStartData from '@/data/cold-start-seeds.json'
 
 const LASTFM_BASE = "https://ws.audioscrobbler.com/2.0"
 
-/** Return the popularity-tier multiplier for a Spotify popularity value (0–100). */
-export function tierMultiplier(popularity: number): number {
-  return Math.pow(0.95, popularity)
+/**
+ * Return the popularity-tier multiplier for a Spotify popularity value (0–100).
+ * `curveK` is the base of the exponential (users.popularity_curve). Smaller =
+ * steeper = stronger obscurity preference. Defaults to 0.95 for callers that
+ * haven't been plumbed through yet.
+ */
+export function tierMultiplier(popularity: number, curveK = 0.95): number {
+  return Math.pow(curveK, popularity)
 }
 
 /** Fetch artist names for a Last.fm genre tag. */
@@ -101,16 +106,22 @@ async function gatherSeedNames(userId: string, supabase: SupabaseClient): Promis
 
 // ── Core pipeline ───────────────────────────────────────────────────────────
 
+// Primary/secondary split: resolve this many names on the critical path
+// (blocks the response), resolve the rest in the background via runSecondary.
+const PRIMARY_RESOLVE_CAP = 20
+const SECONDARY_RESOLVE_CAP = 30
+
 async function runPipeline(
   seedNames: string[],
   accessToken: string,
   userId: string,
   playThreshold: number,
+  popularityCurve: number,
   supabase: SupabaseClient,
   source: string,
   genre?: string,
   undergroundMode?: boolean
-): Promise<number> {
+): Promise<BuildResult> {
   const capSeedNames = seedNames.slice(0, 10)
   console.log(`[engine] seeds-post-shuffle source=${source} seeds=${JSON.stringify(capSeedNames)}`)
 
@@ -132,13 +143,15 @@ async function runPipeline(
     }
   }
 
-  // Cap to 50 to prevent excessive sequential Spotify API calls on cold caches
-  const uniqueNames = [...nameToSeeds.keys()].slice(0, 50)
+  // Split: first chunk resolves synchronously (20), second chunk runs in after()
+  const allNames = [...nameToSeeds.keys()]
+  const uniqueNames = allNames.slice(0, PRIMARY_RESOLVE_CAP)
+  const secondaryNames = allNames.slice(PRIMARY_RESOLVE_CAP, PRIMARY_RESOLVE_CAP + SECONDARY_RESOLVE_CAP)
   const lfmTotal = lfmResults.reduce((sum, r) => sum + r.names.length, 0)
 
   if (uniqueNames.length === 0) {
     console.error(`[engine] FAIL no_unique seeds=${capSeedNames.length} lfm=${lfmTotal} source=${source}`)
-    return 0
+    return { count: 0, runSecondary: null }
   }
 
   // Step B: Resolve names → Spotify artists (cache-first)
@@ -206,7 +219,7 @@ async function runPipeline(
     // Reduces compounding when one artist appears in many seeds' similar
     // lists — a 3-match candidate no longer blows past a 1-match.
     const seedRelevance = Math.min(Math.sqrt(seedArtists.length) / Math.sqrt(6), 1)
-    const tier = tierMultiplier(artist.popularity)
+    const tier = tierMultiplier(artist.popularity, popularityCurve)
     // Underground mode: apply additional discoveryScore penalty for extra obscurity
     const discoveryPenalty = undergroundMode
       ? Math.pow((100 - artist.popularity) / 100, 2)
@@ -268,7 +281,7 @@ async function runPipeline(
       `uniq=${uniqueNames.length} ok=${resolved.searchOk} fail=${resolved.searchFail} ` +
       `filtListened=${filtListened} cands=${candidateMap.size} source=${source}`
     )
-    return 0
+    return { count: 0, runSecondary: null }
   }
 
   // Step E: Write to cache — only check cooldown for artists we're about to write
@@ -312,15 +325,15 @@ async function runPipeline(
       }
     })
 
-  if (rows.length === 0) return 0
-
-  const { error } = await supabase
-    .from('recommendation_cache')
-    .upsert(rows, { onConflict: 'user_id,spotify_artist_id' })
+  const { error } = rows.length === 0
+    ? { error: null }
+    : await supabase
+        .from('recommendation_cache')
+        .upsert(rows, { onConflict: 'user_id,spotify_artist_id' })
 
   if (error) {
     console.error(`[engine] upsert_error source=${source} err=${error.message}`)
-    return 0
+    return { count: 0, runSecondary: null }
   }
 
   console.log(
@@ -328,13 +341,88 @@ async function runPipeline(
     `ok=${resolved.searchOk} fail=${resolved.searchFail} filtListened=${filtListened} ` +
     `cands=${candidateMap.size} top=${top.length} written=${rows.length} source=${source}`
   )
-  return rows.length
+
+  const writtenIds = new Set(rows.map((r) => r.spotify_artist_id))
+
+  const runSecondary = secondaryNames.length === 0
+    ? null
+    : async (): Promise<number> => {
+        const secondaryResolved = await resolveArtistsByName(secondaryNames, {
+          cache: nameCache,
+          searchArtists: (name) => musicProvider.searchArtists(accessToken, name),
+        })
+
+        const secondaryCandidates: Array<{ artist: Artist; seedArtists: string[] }> = []
+        for (const [name, artist] of secondaryResolved.resolved) {
+          if (writtenIds.has(artist.id)) continue
+          if (thumbsDownIds.has(artist.id)) continue
+          if (overThresholdIds.has(artist.id)) continue
+          if (genre && !artist.genres.some((g) => g.toLowerCase().includes(genre.toLowerCase()))) continue
+          const seedArtists = nameToSeeds.get(name) ?? []
+          secondaryCandidates.push({ artist, seedArtists })
+        }
+
+        if (secondaryCandidates.length === 0) {
+          console.log(`[engine] secondary_empty source=${source}`)
+          return 0
+        }
+
+        const secondaryScored: ScoredArtist[] = secondaryCandidates.map(({ artist, seedArtists }) => {
+          const seedRelevance = Math.min(Math.sqrt(seedArtists.length) / Math.sqrt(6), 1)
+          const tier = tierMultiplier(artist.popularity, popularityCurve)
+          const discoveryPenalty = undergroundMode
+            ? Math.pow((100 - artist.popularity) / 100, 2)
+            : 1
+          const baseScore = tier * 0.80 + seedRelevance * 0.20
+          const score = baseScore * discoveryPenalty
+          return {
+            artist: { ...artist, topTracks: [] },
+            score,
+            why: {
+              sourceArtists: seedArtists.slice(0, 2),
+              genres: artist.genres.slice(0, 2),
+              friendBoost: [],
+            },
+            source: `${source}_secondary`,
+          }
+        })
+
+        secondaryScored.sort((a, b) => b.score - a.score)
+
+        const secondaryRows = secondaryScored.map((item) => ({
+          user_id: userId,
+          spotify_artist_id: item.artist.id,
+          artist_data: item.artist,
+          score: item.score,
+          why: item.why,
+          source: item.source,
+          expires_at: expiresAt.toISOString(),
+          seen_at: null,
+        }))
+
+        const { error: secErr } = await supabase
+          .from('recommendation_cache')
+          .upsert(secondaryRows, { onConflict: 'user_id,spotify_artist_id' })
+
+        if (secErr) {
+          console.error(`[engine] secondary_upsert_error source=${source} err=${secErr.message}`)
+          return 0
+        }
+
+        console.log(
+          `[engine] secondary-OK source=${source} names=${secondaryNames.length} ` +
+          `resolved=${secondaryResolved.resolved.size} written=${secondaryRows.length}`
+        )
+        return secondaryRows.length
+      }
+
+  return { count: rows.length, runSecondary }
 }
 
 // ── Main entry point ────────────────────────────────────────────────────────
 
-export async function buildRecommendations(input: RecommendationInput): Promise<number> {
-  const { userId, accessToken, playThreshold, genre, undergroundMode } = input
+export async function buildRecommendations(input: RecommendationInput): Promise<BuildResult> {
+  const { userId, accessToken, playThreshold, popularityCurve, genre, undergroundMode } = input
   const supabase = createServiceClient()
 
   // Gather seeds from all configured sources
@@ -342,7 +430,7 @@ export async function buildRecommendations(input: RecommendationInput): Promise<
 
   if (seedNames.length > 0) {
     console.log(`[engine] start userId=${userId} seeds=${seedNames.length}${genre ? ` genre=${genre}` : ""}`)
-    return runPipeline(seedNames, accessToken, userId, playThreshold, supabase, 'multi_source', genre, undergroundMode)
+    return runPipeline(seedNames, accessToken, userId, playThreshold, popularityCurve, supabase, 'multi_source', genre, undergroundMode)
   }
 
   // Cold-start: no seeds configured — pick random artists from curated list
@@ -354,5 +442,5 @@ export async function buildRecommendations(input: RecommendationInput): Promise<
     ;[pool[i], pool[j]] = [pool[j], pool[i]]
   }
   const coldSeeds = pool.slice(0, 5).map((s) => s.name)
-  return runPipeline(coldSeeds, accessToken, userId, playThreshold, supabase, 'cold_start', genre, undergroundMode)
+  return runPipeline(coldSeeds, accessToken, userId, playThreshold, popularityCurve, supabase, 'cold_start', genre, undergroundMode)
 }

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -83,8 +83,20 @@ async function gatherSeedNames(userId: string, supabase: SupabaseClient): Promis
     for (const batch of genreResults) names.push(...batch)
   }
 
-  // Deduplicate
-  return [...new Set(names)]
+  console.log(
+    `[engine] gather userId=${userId} selected_genres=${JSON.stringify(genres)} ` +
+    `dbSeeds=${dbSeeds.length} thumbsUp=${thumbsUpRows.length} totalPooled=${names.length}`
+  )
+
+  // Deduplicate then shuffle (Fisher–Yates) so each generation surfaces a
+  // different mix of sources — prevents any single over-fertile seed source
+  // (a popular genre's Last.fm tag list) from monopolizing the 10-slice below.
+  const deduped = [...new Set(names)]
+  for (let i = deduped.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[deduped[i], deduped[j]] = [deduped[j], deduped[i]]
+  }
+  return deduped
 }
 
 // ── Core pipeline ───────────────────────────────────────────────────────────
@@ -100,6 +112,7 @@ async function runPipeline(
   undergroundMode?: boolean
 ): Promise<number> {
   const capSeedNames = seedNames.slice(0, 10)
+  console.log(`[engine] seeds-post-shuffle source=${source} seeds=${JSON.stringify(capSeedNames)}`)
 
   // Step A: Fetch Last.fm similar artists for all seeds in parallel
   const lfmResults = await Promise.all(
@@ -189,7 +202,10 @@ async function runPipeline(
 
   // Step D: Score
   const scored: ScoredArtist[] = filteredCandidates.map(({ artist, seedArtists }) => {
-    const seedRelevance = Math.min(seedArtists.length / 3, 1)
+    // Diminishing-returns seedRelevance: sqrt curve instead of linear/3.
+    // Reduces compounding when one artist appears in many seeds' similar
+    // lists — a 3-match candidate no longer blows past a 1-match.
+    const seedRelevance = Math.min(Math.sqrt(seedArtists.length) / Math.sqrt(6), 1)
     const tier = tierMultiplier(artist.popularity)
     // Underground mode: apply additional discoveryScore penalty for extra obscurity
     const discoveryPenalty = undergroundMode
@@ -211,7 +227,40 @@ async function runPipeline(
   })
 
   scored.sort((a, b) => b.score - a.score)
-  const top = scored.slice(0, 20)
+
+  // Soft genre novelty: greedy selection with a small penalty per existing
+  // rep of a genre. Not a hard cap — if the entire candidate pool is one
+  // genre, all slots still fill. Only kicks in when the pool is diverse.
+  const pool = scored.slice(0, 40)
+  const poolGenreDist = new Map<string, number>()
+  for (const s of pool) {
+    const g = s.artist.genres[0] ?? "unknown"
+    poolGenreDist.set(g, (poolGenreDist.get(g) ?? 0) + 1)
+  }
+  console.log(
+    `[engine] top40-genre-dist source=${source} ` +
+    JSON.stringify([...poolGenreDist.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10))
+  )
+
+  const top: ScoredArtist[] = []
+  const genreCounts = new Map<string, number>()
+  while (top.length < 20 && pool.length > 0) {
+    let bestIdx = 0
+    let bestAdjusted = -Infinity
+    for (let i = 0; i < pool.length; i++) {
+      const primary = pool[i].artist.genres[0] ?? "unknown"
+      const count = genreCounts.get(primary) ?? 0
+      const adjusted = pool[i].score - count * 0.02
+      if (adjusted > bestAdjusted) {
+        bestAdjusted = adjusted
+        bestIdx = i
+      }
+    }
+    const picked = pool.splice(bestIdx, 1)[0]
+    const primary = picked.artist.genres[0] ?? "unknown"
+    genreCounts.set(primary, (genreCounts.get(primary) ?? 0) + 1)
+    top.push(picked)
+  }
 
   if (top.length === 0) {
     console.error(

--- a/lib/recommendation/resolve-candidates.ts
+++ b/lib/recommendation/resolve-candidates.ts
@@ -10,7 +10,7 @@ export interface ResolveDeps {
    * array on no-match, or a `RateLimited` sentinel on 429.
    */
   searchArtists: (name: string) => Promise<Artist[] | RateLimited>
-  /** Delay between successful searches (ms). Default 2000. Pass 0 in tests. */
+  /** Delay between successful searches (ms). Default 200. Pass 0 in tests. */
   delayMs?: number
   /** Max single-retry backoff (ms). Default 20_000. */
   maxRetryBackoffMs?: number
@@ -57,7 +57,7 @@ export async function resolveArtistsByName(
   deps: ResolveDeps
 ): Promise<ResolveResult> {
   const sleep = deps.sleep ?? defaultSleep
-  const delayMs = deps.delayMs ?? 2000
+  const delayMs = deps.delayMs ?? 200
   const maxRetryBackoffMs = deps.maxRetryBackoffMs ?? 20_000
   const totalBackoffBudgetMs = deps.totalBackoffBudgetMs ?? 90_000
   const maxAttempts = deps.maxAttemptsPerName ?? 3

--- a/lib/recommendation/types.ts
+++ b/lib/recommendation/types.ts
@@ -4,6 +4,7 @@ export interface RecommendationInput {
   userId: string        // Supabase UUID
   accessToken: string   // Spotify access token (empty string if user has no Spotify)
   playThreshold: number // from users.play_threshold
+  popularityCurve: number // from users.popularity_curve — base `k` of k^popularity scoring
   genre?: string        // optional genre filter for targeted generation
   undergroundMode?: boolean // when true, applies additional discoveryScore penalty
 }
@@ -13,4 +14,14 @@ export interface ScoredArtist {
   score: number
   why: { sourceArtists: string[]; genres: string[]; friendBoost: string[] }
   source: string
+}
+
+export interface BuildResult {
+  count: number
+  /**
+   * When present, callers should invoke this inside `after()` to resolve
+   * the remaining candidate pool in the background. Adds more unseen recs
+   * to `recommendation_cache` without blocking the initial response.
+   */
+  runSecondary: (() => Promise<number>) | null
 }

--- a/supabase/migrations/0018_users_popularity_curve.sql
+++ b/supabase/migrations/0018_users_popularity_curve.sql
@@ -1,0 +1,6 @@
+-- Add per-user popularity curve steepness.
+-- Controls the base `k` of the scoring curve `k^popularity`.
+-- Range 0.90 – 1.00. Default 0.95 matches the previously hardcoded value.
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS popularity_curve NUMERIC(4,3) NOT NULL DEFAULT 0.95
+  CHECK (popularity_curve >= 0.900 AND popularity_curve <= 1.000);


### PR DESCRIPTION
## Summary
- Rebuilds the feed-discovery product on top of username-only HMAC auth (no email, no password, no social features) and a new hierarchical genre taxonomy + onboarding flow.
- Adds taste-anchor settings (seed artists, genres, Last.fm/stats.fm scrobble import) and a new Discovery card with a live-updating popularity curve — including an "Extra obscure" toggle and per-user popularity_curve tuning.
- Replaces the stats histogram with a saved-artists dot plot + sortable table, updates profile copy to reflect the username-hash reality, and ships hardening (security fixes, RLS, de-biased recommendations, dead-code removal).

## Test plan
- [ ] Apply all pending migrations (`0010`–`0018`) to remote Supabase; verify `users.popularity_curve` and `users.username_hash` exist.
- [ ] Sign-up flow: new username → HMAC'd → account created with UUID; sign-in with same name succeeds, wrong name fails.
- [ ] Onboarding: hierarchical genre picker rolls up to anchors; seed artists populate taste anchors.
- [ ] Settings → Discovery: dial moves the curve live, Extra obscure overlays the dashed penalty curve, save returns 200 and persists across reload.
- [ ] Settings → profile card shows hash-aware copy ("your username is your only login — we store a hash…").
- [ ] Stats page: saved-artists dot plot + sortable table render; empty-state copy shows for new accounts.
- [ ] Feed generation cold-start completes and scores respect the user's popularity_curve + underground_mode.
- [ ] Delete-account flow fully wipes user rows (Phase 6 / Phase 7).
- [ ] `npx tsc --noEmit` clean · `npm test` passes (426/426).

🤖 Generated with [Claude Code](https://claude.com/claude-code)