### PR TITLE
Security + perf hardening

### DIFF
--- a/app/api/feedback/[artistId]/route.ts
+++ b/app/api/feedback/[artistId]/route.ts
@@ -17,23 +17,12 @@ export async function DELETE(
 
   const supabase = createServiceClient()
 
-  // Soft-delete the feedback row
-  const { error: feedbackError } = await supabase
-    .from("feedback")
-    .update({ deleted_at: new Date().toISOString() })
-    .eq("user_id", userId)
-    .eq("spotify_artist_id", artistId)
+  const { error: rpcError } = await supabase.rpc("rpc_delete_feedback", {
+    p_user_id: userId,
+    p_artist_id: artistId,
+  })
 
-  if (feedbackError) return dbError(feedbackError, "feedback/delete")
-
-  // Clear seen_at in recommendation_cache
-  const { error: cacheError } = await supabase
-    .from("recommendation_cache")
-    .update({ seen_at: null })
-    .eq("user_id", userId)
-    .eq("spotify_artist_id", artistId)
-
-  if (cacheError) return dbError(cacheError, "feedback/cache-clear")
+  if (rpcError) return dbError(rpcError, "feedback/delete-rpc")
 
   return new Response(null, { status: 204 })
 }

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -26,26 +26,13 @@ export async function POST(request: Request): Promise<Response> {
 
   const supabase = createServiceClient()
 
-  // Upsert feedback only if it's an actionable algorithm signal
-  if (signal !== "skip") {
-    const { error: feedbackError } = await supabase
-      .from("feedback")
-      .upsert(
-        { user_id: userId, spotify_artist_id: spotifyArtistId, signal, deleted_at: null },
-        { onConflict: "user_id,spotify_artist_id" }
-      )
+  const { error: rpcError } = await supabase.rpc("rpc_record_feedback", {
+    p_user_id: userId,
+    p_artist_id: spotifyArtistId,
+    p_signal: signal,
+  })
 
-    if (feedbackError) return dbError(feedbackError, "feedback/upsert")
-  }
-
-  // Update seen_at in recommendation_cache
-  const { error: cacheError } = await supabase
-    .from("recommendation_cache")
-    .update({ seen_at: new Date().toISOString() })
-    .eq("user_id", userId)
-    .eq("spotify_artist_id", spotifyArtistId)
-
-  if (cacheError) return dbError(cacheError, "feedback/cache-update")
+  if (rpcError) return dbError(rpcError, "feedback/rpc")
 
   return Response.json({ success: true })
 }

--- a/app/api/spotify/resolve-track/route.ts
+++ b/app/api/spotify/resolve-track/route.ts
@@ -73,7 +73,8 @@ export async function POST(req: NextRequest): Promise<Response> {
     trackName = targetTrack.name
 
     const artistReq = await fetch(`${SPOTIFY_BASE}/artists/${spotifyArtistId}`, {
-      headers: { Authorization: `Bearer ${accessToken}` }
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(8000),
     })
     if (artistReq.ok) {
         const aData = await artistReq.json()
@@ -90,6 +91,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const res = await fetch(url, {
     headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(8000),
   })
 
   if (res.status === 401) return apiError("Spotify session expired", 401)

--- a/lib/colour-extraction.ts
+++ b/lib/colour-extraction.ts
@@ -107,19 +107,29 @@ function lightenToContrast(hex: string): string {
  * Extract dominant vibrant accent colour from `imageUrl`.
  * Ensures WCAG AA contrast against #000000. Falls back to #8b5cf6 on any error.
  */
-const ALLOWED_IMAGE_HOSTS = ["i.scdn.co", "mosaic.scdn.co", "is1-ssl.mzstatic.com", "is2-ssl.mzstatic.com", "is3-ssl.mzstatic.com", "is4-ssl.mzstatic.com", "is5-ssl.mzstatic.com"]
+const ALLOWED_IMAGE_HOSTS = new Set([
+  "i.scdn.co",
+  "mosaic.scdn.co",
+  "is1-ssl.mzstatic.com",
+  "is2-ssl.mzstatic.com",
+  "is3-ssl.mzstatic.com",
+  "is4-ssl.mzstatic.com",
+  "is5-ssl.mzstatic.com",
+])
 
 export async function extractArtistColor(imageUrl: string): Promise<string> {
   try {
-    // SSRF guard: only fetch from known CDN domains
-    const host = new URL(imageUrl).hostname
-    if (!ALLOWED_IMAGE_HOSTS.some((h) => host === h || host.endsWith(`.${h}`))) {
-      console.warn(`[colour] blocked fetch to untrusted host: ${host}`)
+    const parsed = new URL(imageUrl)
+    if (parsed.protocol !== "https:" || !ALLOWED_IMAGE_HOSTS.has(parsed.hostname)) {
+      console.warn(`[colour] blocked fetch to untrusted host: ${parsed.hostname}`)
       return FALLBACK
     }
 
-    // Pre-fetch via node undici to bypass Spotify's legacy strict http header requirements that node-vibrant fails on
-    const res = await fetch(imageUrl, { headers: { "User-Agent": "Mozilla/5.0" } })
+    const res = await fetch(imageUrl, {
+      headers: { "User-Agent": "Mozilla/5.0" },
+      redirect: "error",
+      signal: AbortSignal.timeout(8000),
+    })
     if (!res.ok) throw new Error(`Fetch failed with status ${res.status}`)
     const arrayBuffer = await res.arrayBuffer()
     const buffer = Buffer.from(arrayBuffer)

--- a/lib/music-provider/itunes.ts
+++ b/lib/music-provider/itunes.ts
@@ -33,7 +33,7 @@ export async function searchTracksByArtist(
     const url =
       `${ITUNES_BASE}?term=${encodeURIComponent(artistName)}` +
       `&entity=song&limit=25&country=${encodeURIComponent(market)}`
-    const res = await fetch(url)
+    const res = await fetch(url, { signal: AbortSignal.timeout(8000) })
     if (!res.ok) {
       console.log(`[itunes] ${res.status} artist="${artistName}"`)
       return null

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -4,6 +4,7 @@ import { createServiceClient } from '@/lib/supabase/server'
 import type { BuildResult, RecommendationInput, ScoredArtist } from './types'
 import { ArtistNameCache } from './artist-name-cache'
 import { resolveArtistsByName } from './resolve-candidates'
+import { normalizeArtistName } from '@/lib/listened-artists'
 import coldStartData from '@/data/cold-start-seeds.json'
 
 const LASTFM_BASE = "https://ws.audioscrobbler.com/2.0"
@@ -182,7 +183,7 @@ async function runPipeline(
   const [{ data: listenedData }, { data: thumbsDownData }] = await Promise.all([
     supabase
       .from('listened_artists')
-      .select('spotify_artist_id, play_count')
+      .select('spotify_artist_id, lastfm_artist_name, play_count')
       .eq('user_id', userId),
     supabase
       .from('feedback')
@@ -193,10 +194,16 @@ async function runPipeline(
   ])
 
   const overThresholdIds = new Set<string>()
+  // Also match by normalized name — Last.fm/stats.fm rows with a null
+  // spotify_artist_id (resolver hasn't run yet, or the name didn't match
+  // Spotify's catalog) would otherwise slip past this filter entirely.
+  const overThresholdNames = new Set<string>()
   for (const row of listenedData ?? []) {
-    if (!row.spotify_artist_id) continue
-    if (row.play_count != null && row.play_count > playThreshold) {
+    if (row.play_count == null || row.play_count <= playThreshold) continue
+    if (row.spotify_artist_id) {
       overThresholdIds.add(row.spotify_artist_id)
+    } else if (row.lastfm_artist_name) {
+      overThresholdNames.add(normalizeArtistName(row.lastfm_artist_name))
     }
   }
 
@@ -207,6 +214,7 @@ async function runPipeline(
     .filter(([id, val]) => {
       if (thumbsDownIds.has(id)) return false
       if (overThresholdIds.has(id)) { filtListened++; return false }
+      if (overThresholdNames.has(normalizeArtistName(val.artist.name))) { filtListened++; return false }
       // Genre filter: only include artists matching the requested genre
       if (genre && !val.artist.genres.some((g) => g.toLowerCase().includes(genre.toLowerCase()))) return false
       return true
@@ -357,6 +365,7 @@ async function runPipeline(
           if (writtenIds.has(artist.id)) continue
           if (thumbsDownIds.has(artist.id)) continue
           if (overThresholdIds.has(artist.id)) continue
+          if (overThresholdNames.has(normalizeArtistName(artist.name))) continue
           if (genre && !artist.genres.some((g) => g.toLowerCase().includes(genre.toLowerCase()))) continue
           const seedArtists = nameToSeeds.get(name) ?? []
           secondaryCandidates.push({ artist, seedArtists })

--- a/lib/spotify-client-token.ts
+++ b/lib/spotify-client-token.ts
@@ -8,10 +8,9 @@
 
 let cachedToken: string | null = null
 let tokenExpiresAt = 0
+let inFlight: Promise<string | null> | null = null
 
-export async function getSpotifyClientToken(): Promise<string | null> {
-  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken
-
+async function fetchToken(): Promise<string | null> {
   const clientId = process.env.SPOTIFY_CLIENT_ID
   const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
   if (!clientId || !clientSecret) return null
@@ -23,6 +22,7 @@ export async function getSpotifyClientToken(): Promise<string | null> {
       Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
     },
     body: new URLSearchParams({ grant_type: "client_credentials" }),
+    signal: AbortSignal.timeout(8000),
   })
 
   if (!res.ok) {
@@ -34,4 +34,14 @@ export async function getSpotifyClientToken(): Promise<string | null> {
   cachedToken = data.access_token as string
   tokenExpiresAt = Date.now() + (data.expires_in - 60) * 1000
   return cachedToken
+}
+
+export async function getSpotifyClientToken(): Promise<string | null> {
+  if (cachedToken && Date.now() < tokenExpiresAt) return cachedToken
+  if (inFlight) return inFlight
+
+  inFlight = fetchToken().finally(() => {
+    inFlight = null
+  })
+  return inFlight
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  productionBrowserSourceMaps: false,
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "i.scdn.co" },

--- a/supabase/migrations/0019_cache_user_seen_idx.sql
+++ b/supabase/migrations/0019_cache_user_seen_idx.sql
@@ -1,0 +1,7 @@
+-- Composite index to speed up two hot queries on recommendation_cache:
+--   1. Stats page: count seen artists per user (seen_at IS NOT NULL)
+--   2. Engine cooldown check: look up (user_id, spotify_artist_id) and read seen_at
+-- Existing index is (user_id, expires_at); neither query uses expires_at.
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_cache_user_seen
+  ON recommendation_cache(user_id, seen_at);

--- a/supabase/migrations/0020_rpc_record_feedback.sql
+++ b/supabase/migrations/0020_rpc_record_feedback.sql
@@ -1,0 +1,53 @@
+-- Atomic feedback write: upserts feedback (if actionable) AND marks the cache
+-- row seen in a single transaction. Replaces two sequential awaits in
+-- app/api/feedback/route.ts that could leave the UI/cache out of sync on
+-- partial failure.
+
+CREATE OR REPLACE FUNCTION rpc_record_feedback(
+  p_user_id UUID,
+  p_artist_id TEXT,
+  p_signal TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF p_signal NOT IN ('thumbs_up', 'thumbs_down', 'skip') THEN
+    RAISE EXCEPTION 'invalid signal: %', p_signal;
+  END IF;
+
+  IF p_signal <> 'skip' THEN
+    INSERT INTO feedback (user_id, spotify_artist_id, signal, deleted_at)
+    VALUES (p_user_id, p_artist_id, p_signal, NULL)
+    ON CONFLICT (user_id, spotify_artist_id)
+    DO UPDATE SET
+      signal = EXCLUDED.signal,
+      deleted_at = NULL;
+  END IF;
+
+  UPDATE recommendation_cache
+  SET seen_at = NOW()
+  WHERE user_id = p_user_id
+    AND spotify_artist_id = p_artist_id;
+END;
+$$;
+
+-- Atomic feedback soft-delete: clears feedback + resets seen_at on the cache
+-- row in one transaction, matching the DELETE /api/feedback/[artistId] pattern.
+CREATE OR REPLACE FUNCTION rpc_delete_feedback(
+  p_user_id UUID,
+  p_artist_id TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE feedback
+  SET deleted_at = NOW()
+  WHERE user_id = p_user_id
+    AND spotify_artist_id = p_artist_id;
+
+  UPDATE recommendation_cache
+  SET seen_at = NULL
+  WHERE user_id = p_user_id
+    AND spotify_artist_id = p_artist_id;
+END;
+$$;

--- a/supabase/migrations/0021_rls_policies_user_id.sql
+++ b/supabase/migrations/0021_rls_policies_user_id.sql
@@ -1,0 +1,38 @@
+-- Rewrite RLS policies to key on users.id = auth.uid() instead of
+-- users.spotify_id = auth.uid()::text. Since 0011 made spotify_id nullable,
+-- the old policies silently fail for username-only accounts. All routes use
+-- the service client today (which bypasses RLS), so this is defense-in-depth
+-- for any future anon-client usage.
+--
+-- The dropped policies for groups, group_members, and group_activity are
+-- already moot — those tables were dropped in 0010_remove_social_features.
+
+-- users
+DROP POLICY IF EXISTS "users: own row" ON users;
+CREATE POLICY "users: own row" ON users FOR ALL
+  USING (auth.uid() = id);
+
+-- seed_artists
+DROP POLICY IF EXISTS "seed_artists: own rows" ON seed_artists;
+CREATE POLICY "seed_artists: own rows" ON seed_artists FOR ALL
+  USING (auth.uid() = user_id);
+
+-- listened_artists
+DROP POLICY IF EXISTS "listened_artists: own rows" ON listened_artists;
+CREATE POLICY "listened_artists: own rows" ON listened_artists FOR ALL
+  USING (auth.uid() = user_id);
+
+-- recommendation_cache
+DROP POLICY IF EXISTS "recommendation_cache: own rows" ON recommendation_cache;
+CREATE POLICY "recommendation_cache: own rows" ON recommendation_cache FOR ALL
+  USING (auth.uid() = user_id);
+
+-- feedback
+DROP POLICY IF EXISTS "feedback: own rows" ON feedback;
+CREATE POLICY "feedback: own rows" ON feedback FOR ALL
+  USING (auth.uid() = user_id);
+
+-- saves
+DROP POLICY IF EXISTS "saves: own rows" ON saves;
+CREATE POLICY "saves: own rows" ON saves FOR ALL
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

- **SSRF hardening** in `colour-extraction`: exact-host allow-list (`i.scdn.co`, `mosaic.scdn.co`, `*.mzstatic.com`), https-only, `redirect: error`, 8s timeout. Previous `endsWith()` check allowed attacker-controlled suffix bypass.
- **Atomic feedback writes** via new Postgres RPCs (`rpc_record_feedback`, `rpc_delete_feedback`). Previously two sequential awaits could leave the UI and `recommendation_cache` out of sync on partial failure.
- **Feed correctness**: `play_threshold` filter now matches unresolved `lastfm_artist_name` rows in addition to `spotify_artist_id`. This was the Snarky Puppy leak — heavily-played artists from Last.fm with null Spotify ID slipped past the filter.
- **Token refresh dedup**: concurrent requests to `getSpotifyClientToken()` now share a single in-flight fetch instead of each firing their own.
- **Fetch timeouts** (8s) on all outbound fetches — `itunes`, `colour-extraction`, `resolve-track` (x2), `spotify-client-token`. Prevents upstream hangs from pinning a function for the full 300s execution limit.
- **`productionBrowserSourceMaps: false`** — no more unminified source shipped to the public.
- **Composite index** on `recommendation_cache(user_id, seen_at)` — speeds up the stats page seen-count and engine cooldown check.
- **RLS policies** rewritten to key on `auth.uid() = user_id` instead of `users.spotify_id` (which became nullable in 0011). Defense-in-depth — routes use the service client, which bypasses RLS.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 426/426 tests pass
- [x] `npx next build` — production build succeeds
- [ ] Apply migrations `0019`, `0020`, `0021` to Supabase
- [ ] Smoke test: thumbs up / down / skip / undo on a card; confirm cache row updates in one transaction
- [ ] Smoke test: verify no previously-heavily-played Last.fm artists appear in feed
- [ ] Confirm concurrent Spotify resolution calls share one token fetch (check server logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)