### PR TITLE
Feed diversity + Deep discovery: single-seed fix, tail-biased retrieval, 2nd-hop toggle

### DIFF
--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -13,7 +13,7 @@ export default async function SettingsPage() {
   const supabase = createServiceClient()
   const { data: user } = await supabase
     .from("users")
-    .select("id, play_threshold, popularity_curve, lastfm_username, statsfm_username, underground_mode, selected_genres")
+    .select("id, play_threshold, popularity_curve, lastfm_username, statsfm_username, underground_mode, deep_discovery, selected_genres")
     .eq("id", userId)
     .maybeSingle()
 
@@ -101,6 +101,7 @@ export default async function SettingsPage() {
       initialStatsfmUsername={user?.statsfm_username ?? null}
       initialLastfmArtistCount={lastfmArtistCount}
       initialUndergroundMode={user?.underground_mode ?? false}
+      initialDeepDiscovery={user?.deep_discovery ?? false}
       initialSelectedGenres={(user?.selected_genres as string[] | null) ?? []}
       initialSeedArtists={seedArtists}
       exampleArtists={exampleArtists}

--- a/app/api/recommendations/generate/route.ts
+++ b/app/api/recommendations/generate/route.ts
@@ -174,7 +174,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   // Read user row including play_threshold
   const { data: user, error: userError } = await supabase
     .from("users")
-    .select("id, play_threshold, popularity_curve, underground_mode, last_generated_at")
+    .select("id, play_threshold, popularity_curve, underground_mode, deep_discovery, last_generated_at")
     .eq("id", userId)
     .maybeSingle()
 
@@ -246,6 +246,7 @@ export async function POST(req: NextRequest): Promise<Response> {
       popularityCurve,
       genre,
       undergroundMode: user.underground_mode ?? false,
+      deepDiscovery: user.deep_discovery ?? false,
     })
 
     // Decorations (colour extraction + track pre-warming) and secondary

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -15,6 +15,7 @@ export async function PATCH(request: Request) {
     statsfmUsername?: string
     selectedGenres?: string[]
     undergroundMode?: boolean
+    deepDiscovery?: boolean
   }
   try {
     body = await request.json()
@@ -67,6 +68,11 @@ export async function PATCH(request: Request) {
   if (body.undergroundMode !== undefined) {
     update.underground_mode = !!body.undergroundMode
   }
+
+  if (body.deepDiscovery !== undefined) {
+    update.deep_discovery = !!body.deepDiscovery
+  }
+
 
   if (Object.keys(update).length === 0) {
     return apiError("No valid fields to update", 400)

--- a/components/settings/curve-preview.tsx
+++ b/components/settings/curve-preview.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo } from "react"
+import { UNDERGROUND_MAX_POPULARITY } from "@/lib/recommendation/types"
 
 export interface CurvePreviewProps {
   /** Base `k` of the scoring curve k^popularity. Range 0.90–1.00. */
@@ -28,9 +29,14 @@ export function CurvePreview({ popularityCurve, undergroundMode, exampleArtists 
       return `${svgX(p)},${svgY(y)}`
     })
 
+    // Underground curve applies the ((100-pop)/100)^2 extra-obscurity penalty,
+    // then hard-cliffs to 0 at UNDERGROUND_MAX_POPULARITY to mirror the engine
+    // filter that drops any candidate above that threshold.
     const undergroundPoints = Array.from({ length: 51 }, (_, i) => {
       const p = i * 2
-      const y = Math.pow(popularityCurve, p) * Math.pow((100 - p) / 100, 2)
+      const y = p > UNDERGROUND_MAX_POPULARITY
+        ? 0
+        : Math.pow(popularityCurve, p) * Math.pow((100 - p) / 100, 2)
       return `${svgX(p)},${svgY(y)}`
     })
 
@@ -58,6 +64,19 @@ export function CurvePreview({ popularityCurve, undergroundMode, exampleArtists 
           </defs>
 
           <line x1="20" y1="170" x2="380" y2="170" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
+
+          {/* Underground-mode excluded zone: everything above pop=50 is hard-dropped */}
+          <rect
+            x={svgX(UNDERGROUND_MAX_POPULARITY)}
+            y={svgY(1)}
+            width={svgX(100) - svgX(UNDERGROUND_MAX_POPULARITY)}
+            height={svgY(0) - svgY(1)}
+            fill="#a78bfa"
+            style={{
+              opacity: undergroundMode ? 0.15 : 0,
+              transition: "opacity 0.4s ease",
+            }}
+          />
 
           {[0, 20, 40, 60, 80, 100].map((tick) => (
             <g key={tick}>
@@ -113,28 +132,34 @@ export function CurvePreview({ popularityCurve, undergroundMode, exampleArtists 
       </div>
 
       <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 6 }}>
-        {exampleArtists.map(({ popularity, artist }) => (
-          <div key={popularity} style={{ display: "flex", flexDirection: "column", gap: 2, alignItems: "center", minWidth: 0 }}>
-            <span className="mono" style={{ fontSize: 10, color: "var(--text-muted)" }}>
-              pop. {popularity}
-            </span>
-            <span
-              style={{
-                fontSize: 12,
-                color: "var(--text-primary)",
-                textAlign: "center",
-                lineHeight: 1.2,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                maxWidth: "100%",
-              }}
-              title={artist?.name ?? undefined}
-            >
-              {artist?.name ?? "—"}
-            </span>
-          </div>
-        ))}
+        {exampleArtists.map(({ popularity, artist }) => {
+          const excluded = undergroundMode && popularity > UNDERGROUND_MAX_POPULARITY
+          return (
+            <div key={popularity} style={{ display: "flex", flexDirection: "column", gap: 2, alignItems: "center", minWidth: 0 }}>
+              <span className="mono" style={{ fontSize: 10, color: "var(--text-muted)", opacity: excluded ? 0.4 : 1, transition: "opacity 0.4s ease" }}>
+                pop. {popularity}
+              </span>
+              <span
+                style={{
+                  fontSize: 12,
+                  color: "var(--text-primary)",
+                  textAlign: "center",
+                  lineHeight: 1.2,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  maxWidth: "100%",
+                  opacity: excluded ? 0.4 : 1,
+                  textDecoration: excluded ? "line-through" : "none",
+                  transition: "opacity 0.4s ease",
+                }}
+                title={artist?.name ?? undefined}
+              >
+                {artist?.name ?? "—"}
+              </span>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -17,6 +17,7 @@ interface SettingsFormProps {
   initialStatsfmUsername: string | null
   initialLastfmArtistCount: number
   initialUndergroundMode: boolean
+  initialDeepDiscovery: boolean
   initialSelectedGenres: string[]
   initialSeedArtists: SpotifyArtist[]
   exampleArtists: { popularity: number; artist: { name: string; popularity: number } | null }[]
@@ -42,6 +43,7 @@ export function SettingsForm({
   initialStatsfmUsername,
   initialLastfmArtistCount,
   initialUndergroundMode,
+  initialDeepDiscovery,
   initialSelectedGenres,
   initialSeedArtists,
   exampleArtists,
@@ -52,6 +54,7 @@ export function SettingsForm({
   const [lastfmUsername, setLastfmUsername] = useState(initialLastfmUsername ?? "")
   const [statsfmUsername, setStatsfmUsername] = useState(initialStatsfmUsername ?? "")
   const [undergroundMode, setUndergroundMode] = useState(initialUndergroundMode)
+  const [deepDiscovery, setDeepDiscovery] = useState(initialDeepDiscovery)
   const [syncingSource, setSyncingSource] = useState<null | "lastfm" | "statsfm">(null)
   const [isGenerating, setIsGenerating] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
@@ -124,6 +127,17 @@ export function SettingsForm({
       await patchSettings({ undergroundMode: next })
     } catch {
       setUndergroundMode(!next)
+      toast.error("Failed to save setting")
+    }
+  }
+
+  async function handleDeepDiscoveryToggle() {
+    const next = !deepDiscovery
+    setDeepDiscovery(next)
+    try {
+      await patchSettings({ deepDiscovery: next })
+    } catch {
+      setDeepDiscovery(!next)
       toast.error("Failed to save setting")
     }
   }
@@ -530,6 +544,56 @@ export function SettingsForm({
                       position: "absolute",
                       top: 3,
                       left: undergroundMode ? 23 : 3,
+                      transition: "left 0.2s",
+                    }}
+                  />
+                </button>
+              </div>
+
+              <div className="divider" />
+
+              {/* Deep discovery toggle */}
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 16,
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>
+                    Deep discovery
+                  </div>
+                  <div className="muted" style={{ fontSize: 12, lineHeight: 1.5 }}>
+                    Walks two artists deep into similar-artist chains. More obscure picks; occasional genre drift.
+                  </div>
+                </div>
+                <button
+                  onClick={handleDeepDiscoveryToggle}
+                  role="switch"
+                  aria-checked={deepDiscovery}
+                  style={{
+                    width: 48,
+                    height: 28,
+                    borderRadius: 14,
+                    border: 0,
+                    cursor: "pointer",
+                    flexShrink: 0,
+                    background: deepDiscovery ? "var(--accent)" : "rgba(255,255,255,0.10)",
+                    position: "relative",
+                    transition: "background 0.2s",
+                  }}
+                >
+                  <div
+                    style={{
+                      width: 22,
+                      height: 22,
+                      borderRadius: "50%",
+                      background: "#fff",
+                      position: "absolute",
+                      top: 3,
+                      left: deepDiscovery ? 23 : 3,
                       transition: "left 0.2s",
                     }}
                   />

--- a/docs/superpowers/specs/2026-04-19-feed-deep-discovery-prd.md
+++ b/docs/superpowers/specs/2026-04-19-feed-deep-discovery-prd.md
@@ -1,0 +1,193 @@
+# PRD — Last.fm deep discovery, play-threshold leak, per-artist stats
+
+**Date**: 2026-04-19
+**Branch**: Nick (follow-up to PR #84)
+**Author**: TenNineteenOne
+
+## Problem
+
+After shipping PR #84 (round-robin seeds, per-source-seed penalty, underground hard-cap, parallel resolver) the feed is substantially more diverse, but two classes of issue remain:
+
+1. **Last.fm regression-to-the-mean.** `artist.getSimilar` sorts by similarity score, which correlates with popularity. Mainstream seed → mainstream similars. When ALL seeds are mainstream (e.g. a user who thumbs up Drake, Kendrick, Travis Scott repeatedly), round-robin alone can't help — every seed's similar list is popular. The "thumbs-up-popular → more popular" spiral is still possible.
+
+2. **Play-threshold filter leaks familiar artists for Last.fm-only users.** User reports Scary Pockets, bbno$, Lettuce, Sammy Rae landing in the feed despite 11 years of Last.fm scrobble history. Root cause identified: `accumulateLastFmHistory()` at [lib/listened-artists.ts:462-554](lib/listened-artists.ts:462) only pulls the user's **top 200 artists + last 200 tracks** and increments `play_count` by +1 per sync (doesn't import real scrobble counts). Ingestion is also **manual-only** — no auto-sync. A Last.fm user with a 20k-artist long tail loses everything below top-200, and what IS imported may fall below `play_threshold` because plays are under-counted.
+
+3. **No per-artist deep stats for surfaced artists.** User wants a "dig into it" surface where they can see Spotify popularity, Last.fm listener count, personal play count, tag data, and thumb state for every artist the feed has ever shown them. This does *not* belong on the feed card (user explicit ask: "I'm not saying they should see more detailed information in their feed"). Lives on the Stats or History tab.
+
+## Solution overview
+
+Ship in two phases to keep review sizes sane:
+
+- **Phase 1 — backend** (one PR): Problems #1 + #2. Both are Last.fm-side data/engine changes and review naturally together.
+- **Phase 2 — UI** (separate PR): Problem #3. Front-end work, independent of Phase 1.
+
+### Phase 1A — Last.fm retrieval diversity (Problem #1)
+
+Attack the regression-to-the-mean **upstream** of scoring.
+
+1. **Larger getSimilar + tail-bias.** Bump `artist.getSimilar` limit from the current 15 (skip-top-3-take-15) to the full 50 per seed. In `buildRoundRobinNames`, interleave the *tail* of each seed's list preferentially — tail results are less-similar (Last.fm sorts by similarity), which empirically correlates with less-mainstream.
+   - Interface change: `getSimilarArtistNames(): Promise<string[]>` → `Promise<{ name: string; match: number }[]>`. Last.fm's `getSimilar` response does NOT include `listeners` (that lives in `artist.getInfo` — deferred to Phase 2 where we fetch lazily on sheet-open).
+   - `buildRoundRobinNames` gains a `tailFirst: boolean` option. When `true`, iterate each seed's names at index `N-1-i` on cycle `i` so tails are consumed first.
+   - The current "skip top-3, take next 15" heuristic is replaced by full 50 + tail bias — a more principled form of the same idea.
+
+2. **"Deep Discovery" user-facing toggle.** New `users.deep_discovery boolean` column, default `false`. When ON:
+   - For each seed, take its 3 **lowest-`match`** first-hop similars (furthest from seed's typical neighborhood = likely niche).
+   - For each, call `getSimilar` again (2nd hop).
+   - Merge 2nd-hop items back under the original seed label — preserves per-source-seed penalty semantics from PR #84.
+   - Trade-off: ≤18 extra Last.fm calls per generation (6 seeds × 3 hops). Fired in parallel; Last.fm rate budget easily absorbs it.
+   - UI: toggle in Discovery settings card, under "Extra obscure". Copy: "Deep discovery — Walks two artists deep into similar-artist chains. More obscure picks; occasional genre drift."
+
+Listener-count pre-filter from the original PRD draft is **dropped** from Phase 1. Last.fm's `getSimilar` doesn't return `listeners`, and fetching via `artist.getInfo` would mean 300 extra API calls per generation (50 items × 6 seeds) — blows the latency budget. Listener counts are still valuable and will appear in Phase 2's detail surface, fetched on-demand per artist.
+
+### Phase 1B — Last.fm ingestion deepening (Problem #2)
+
+Fix the data at the source so the existing play-threshold filter has something real to filter against.
+
+4. **Full top-artists import.** Change `accumulateLastFmHistory()` at [lib/listened-artists.ts:462](lib/listened-artists.ts:462) to paginate `user.getTopArtists` until exhausted or a reasonable cap (e.g. 2000 — covers most users fully; pathological 11-year collectors may need more but 2k is still a 10× improvement).
+
+5. **Real play-count import.** Last.fm's `user.getTopArtists` response includes `playcount` per artist. Currently we increment by +1 per sync. Replace with *using the Last.fm-provided playcount* directly (overwrite on sync, don't increment). This makes `play_count > threshold` meaningful.
+
+6. **Auto-sync on sign-in for Last.fm-connected users.** When a user signs in and has a `lastfm_username` set, fire a background `accumulateLastFmHistory()` if `last_lastfm_sync_at` is older than 24 hours. Column add: `users.last_lastfm_sync_at timestamp with time zone nullable`. Non-blocking — the UI can proceed while sync runs in `after()`.
+
+7. **Name normalization audit.** With play counts real, spot-check that `normalizeArtistName(row.lastfm_artist_name)` at [engine.ts:206-207](lib/recommendation/engine.ts:206) matches `normalizeArtistName(val.artist.name)` at [:217](lib/recommendation/engine.ts:217) for the user's specific leaked cases (Scary Pockets, bbno$ → bbno$ has a punctuation issue). Fix normalization edge cases if found (add `$` stripping, handle leading "The ", etc.).
+
+### Phase 2 — Per-artist deep stats surface (Problem #3)
+
+Three pieces, decided with user. All share the same underlying data; the surfaces differ in what they emphasize.
+
+**A. Detail sheet (primary mechanic).** Bottom-sheet component that slides up when any artist is tapped outside the Feed (Saved cards, History rows, Stats dot plot is excluded — see C). Shows:
+   - Artist image + name
+   - **Spotify popularity** (0–100)
+   - **Last.fm listener count** (global)
+   - **Your Last.fm play count** (personal, from `listened_artists.play_count`)
+   - **Top tags** (top 3 Last.fm tags — one more API call per artist, cache aggressively)
+   - **Thumb state** (up / down / neutral)
+   - **First surfaced** (date the feed first showed this artist)
+
+   Component: `components/artists/detail-sheet.tsx`. Accepts an `artistId` prop; fetches from the new API endpoint on open. Close via swipe-down or backdrop tap.
+
+**B. History tab extended into a list view.** History currently shows feed history as cards (chronological). Extend it into a scrollable, sortable, filterable list:
+   - Columns: Artist | Popularity | Your plays | Listeners | Tags | Date | Thumb
+   - Filter chips: `Saved` / `Thumbed up` / `All seen`
+   - Sort: by popularity, plays, listeners, or date
+   - Tap any row → opens sheet A
+   - On mobile, the "table" becomes a vertical card list with the same data in a stacked layout (tags as pills, plays/listeners as an inline pair); only Stats columns stay visible.
+
+**C. Popularity dot plot on Stats (visualization only).** Each artist ever surfaced to the user is a dot on a 0–100 popularity axis, jittered vertically to avoid stacking. **Dots are NOT clickable** (explicit user ask — keeps it visually clean, avoids tooltip clutter). Purely a "where do my feeds land?" pattern indicator. Renders alongside the existing saved-artists dot plot (consider grouping under a "Your feed's shape" section).
+
+**Data source for all three:**
+- `recommendation_cache.artist_data` — popularity (already present); add `listeners` field when we fetch it during Phase 1A.
+- `listened_artists.play_count` — joined by `spotify_artist_id` or normalized `lastfm_artist_name`.
+- `feedback` joined for thumb state.
+- Last.fm `artist.getInfo` for tags — called lazily on sheet open, cached.
+- New column on `recommendation_cache`: `first_surfaced_at timestamp` (set to `created_at` of earliest row for (user, artist); backfill on migration).
+
+## Data model changes
+
+### Phase 1
+
+```sql
+-- 001X_users_deep_discovery.sql
+alter table users
+  add column deep_discovery boolean not null default false;
+
+-- 001Y_users_lastfm_sync.sql
+alter table users
+  add column last_lastfm_sync_at timestamptz null;
+```
+
+### Phase 2
+
+```sql
+-- 001Z_recommendation_cache_first_surfaced.sql
+alter table recommendation_cache
+  add column first_surfaced_at timestamptz null default now();
+-- backfill existing rows with created_at as a best-effort substitute
+update recommendation_cache
+  set first_surfaced_at = coalesce(first_surfaced_at, created_at)
+  where first_surfaced_at is null;
+```
+
+## API changes
+
+- `app/api/settings/route.ts` PATCH — accept `deepDiscovery: boolean`.
+- `app/api/recommendations/generate/route.ts` — read `users.deep_discovery`, pass into `buildRecommendations` input.
+- `app/api/history/accumulate/route.ts` (source=lastfm) — pull paginated + import real play counts.
+- New: `app/api/artists/surfaced/route.ts` GET — returns enriched surfaced-artist list for Phase 2 page. Pagination required (user may have 500+ surfaced artists over time).
+
+## Engine changes
+
+- `lib/music-provider/provider.ts` — `getSimilarArtistNames()` returns richer structure.
+- `lib/recommendation/engine.ts`:
+  - `runPipeline` accepts `deepDiscovery` input.
+  - `buildRoundRobinNames` gains `tailFirst` option.
+  - New: listener-count pre-filter step between Last.fm fetch and Spotify resolve.
+  - New: 2nd-hop walk when `deepDiscovery` is true.
+- `lib/recommendation/types.ts` — add `deepDiscovery?: boolean` to `RecommendationInput`.
+
+## UI changes
+
+Phase 1:
+- `components/settings/settings-form.tsx` (or the Discovery card) — new toggle "Deep discovery" under "Extra obscure". Helper copy.
+
+Phase 2:
+- New component: `components/artists/detail-sheet.tsx` — bottom sheet (swipe-down or backdrop to dismiss). Shared by Saved and extended History.
+- Extended component: `components/history/history-list.tsx` (or existing equivalent) — becomes a sortable filterable list; cards on mobile, table on desktop. Rows tap-open the detail sheet.
+- New component: `components/stats/surfaced-popularity-plot.tsx` — non-interactive dot plot under the existing saved-artists visual. Pure SVG, no hover/tap.
+- Saved-card tap handler wired to detail sheet.
+
+## Verification
+
+### Phase 1
+- `npx tsc --noEmit`, `npx vitest run` clean.
+- Tail-bias unit test: 6 seeds of 50 similars each, with the tail portions artificially tagged low-listener — confirm `buildRoundRobinNames(..., tailFirst=true)` returns low-listener names in the top 60 slots.
+- Listener-count pre-filter test: given a mixed candidate list, confirm top 5% listener rows are dropped pre-resolve.
+- Deep discovery integration smoke: regenerate with 6 mainstream hip-hop seeds (Drake/Kendrick/Travis/Tyler/Childish/Frank Ocean), k=0.95, `deep_discovery=true`. Expect ≥40% of final 20 at popularity < 50.
+- Last.fm ingestion smoke: call `/api/history/accumulate?source=lastfm` for the user, query `listened_artists` — expect (a) Scary Pockets present with realistic play_count matching Last.fm's scrobble count, (b) row count > 200.
+- Regenerate feed after re-ingestion — confirm Scary Pockets / bbno$ / Lettuce / Sammy Rae no longer leak.
+- Latency budget: cold first-generation with `deep_discovery=true` under 10s (currently ~6s with cap=60).
+
+### Phase 2
+- Detail sheet opens within 200ms of tap on a Saved or History item; first paint uses cached popularity/plays; tags stream in when Last.fm responds.
+- History filter chips (Saved / Thumbed-up / All seen) correctly scope the list.
+- History sorts by popularity / plays / listeners / date — each column works in both directions.
+- History mobile layout renders as stacked cards; desktop renders as a real table.
+- Stats page shows the surfaced-artists dot plot next to the saved-artists plot. Cursor doesn't change over dots, tapping doesn't do anything (confirmed intentional).
+- Pagination on History lazy-loads beyond page 1 for users with many generations.
+
+## Acceptance criteria
+
+**Phase 1:**
+- Regenerating with 6 mainstream-only seeds at default settings yields a feed with ≥30% popularity < 50 (vs likely < 10% today).
+- With Deep Discovery ON, same seeds yield ≥50% popularity < 50.
+- User's Scary Pockets/bbno$/Lettuce/Sammy Rae scenario: after a Last.fm re-ingestion, regenerate excludes all four.
+- No latency regression > 2s on cache-warm generations.
+
+**Phase 2:**
+- Tapping any artist in Saved or History opens the detail sheet with all six data points (popularity, listener count, your plays, tags, thumb state, first surfaced date) within one API round-trip.
+- History tab is filterable by Saved / Thumbed-up / All seen, and sortable by at least popularity + plays + date.
+- Stats page renders a non-interactive surfaced-artists dot plot alongside the existing saved-artists plot. Dots are not clickable.
+- Feed card copy is unchanged — detail sheet is reachable from Saved / History / Stats only, not from the Feed itself (explicit user ask).
+
+## Risks & mitigations
+
+- **Tail-of-Last.fm picks feel "unrelated"**: spot-check across seed archetypes before shipping. If noticeable, weight the tail bias lighter (e.g. 70% tail / 30% head).
+- **Listener-count → Spotify popularity correlation is noisy**: calibrate by sampling 100 artists with both data points and confirming correlation > 0.7 before shipping the pre-filter. If correlation is weaker, make the pre-filter a soft bias instead of a hard drop.
+- **Deep Discovery 2nd-hop drift**: if 2nd-hop artists are wildly off-genre, restrict hop 2 to candidates whose Last.fm tags overlap the seed's tags.
+- **Last.fm API rate limits on 2000-artist top-list import**: Last.fm allows 5 req/sec authenticated. 2000 artists at limit=200/page = 10 requests — trivial.
+- **Surfaced-artists page explosion**: users with many generations may have 1000+ cached artists. Paginate, lazy-load, don't render unnecessary tags on initial load.
+
+## Not in scope / explicitly dropped
+
+- Replacing Last.fm with another similarity provider. (Spotify `/recommendations` was deprecated late 2024; no alternative ships this PR.)
+- Rebalancing scoring weights beyond the 80/20 split.
+- Adding a popularity ceiling to non-underground mode.
+- Showing Last.fm tags on the feed card itself (user explicit ask: keep feed clean).
+
+## Sequencing
+
+1. Write PRD (this doc) — **done**.
+2. User review + approval on scope.
+3. Create GitHub issues for Phase 1A, 1B, Phase 2 (three issues under a single Milestone).
+4. Implement Phase 1 (bundle 1A + 1B) → PR → merge.
+5. Implement Phase 2 → PR → merge.

--- a/lib/music-provider/candidate-slice.test.ts
+++ b/lib/music-provider/candidate-slice.test.ts
@@ -1,65 +1,84 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { SpotifyProvider } from "./spotify-provider"
 
-// Stub fetch globally for Last.fm calls
 const provider = new SpotifyProvider()
 
-function lastFmResponse(names: string[]) {
+function lastFmResponse(items: Array<{ name: string; match?: string }>) {
   return {
     similarartists: {
-      artist: names.map((name) => ({ name })),
+      artist: items,
     },
   }
 }
 
-describe("getSimilarArtistNames candidate slice", () => {
+describe("getSimilarArtistNames shape and ranking", () => {
   beforeEach(() => {
     vi.stubEnv("LASTFM_API_KEY", "test-key")
     vi.restoreAllMocks()
   })
 
-  it("returns 15 items from a 50-item list, skipping top 3", async () => {
-    const names = Array.from({ length: 50 }, (_, i) => `Artist ${i}`)
+  it("returns the full ordered list (no skip-top-N heuristic — tail-bias is done in the engine)", async () => {
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      name: `Artist ${i}`,
+      match: (1 - i * 0.02).toFixed(2),
+    }))
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify(lastFmResponse(names)), { status: 200 })
+      new Response(JSON.stringify(lastFmResponse(items)), { status: 200 })
     )
 
     const result = await provider.getSimilarArtistNames("Seed")
-    expect(result).toHaveLength(15)
-    expect(result[0]).toBe("Artist 3")
-    expect(result[14]).toBe("Artist 17")
+    expect(result).toHaveLength(50)
+    expect(result[0].name).toBe("Artist 0")
+    expect(result[49].name).toBe("Artist 49")
   })
 
-  it("returns all items when fewer than 4 (niche artist fallback)", async () => {
-    const names = ["A", "B", "C"]
+  it("parses match as a float regardless of string/number encoding", async () => {
+    const items = [
+      { name: "A", match: "0.95" },
+      { name: "B", match: "0.5" },
+      { name: "C" },
+    ]
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify(lastFmResponse(names)), { status: 200 })
+      new Response(JSON.stringify(lastFmResponse(items)), { status: 200 })
     )
 
     const result = await provider.getSimilarArtistNames("Seed")
-    expect(result).toEqual(["A", "B", "C"])
+    expect(result[0]).toEqual({ name: "A", match: 0.95 })
+    expect(result[1]).toEqual({ name: "B", match: 0.5 })
+    expect(result[2]).toEqual({ name: "C", match: 0 })
   })
 
-  it("returns 1 candidate when exactly 4 items", async () => {
-    const names = ["A", "B", "C", "D"]
+  it("returns a short list unchanged for niche seeds", async () => {
+    const items = [
+      { name: "A", match: "0.8" },
+      { name: "B", match: "0.5" },
+      { name: "C", match: "0.2" },
+    ]
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify(lastFmResponse(names)), { status: 200 })
+      new Response(JSON.stringify(lastFmResponse(items)), { status: 200 })
     )
 
     const result = await provider.getSimilarArtistNames("Seed")
-    expect(result).toHaveLength(1)
-    expect(result[0]).toBe("D")
+    expect(result).toHaveLength(3)
+    expect(result.map((r) => r.name)).toEqual(["A", "B", "C"])
   })
 
-  it("returns available items when list has 10 items", async () => {
-    const names = Array.from({ length: 10 }, (_, i) => `Artist ${i}`)
+  it("returns empty array when API errors", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify(lastFmResponse(names)), { status: 200 })
+      new Response(JSON.stringify({ error: 6, message: "artist not found" }), { status: 200 })
+    )
+
+    const result = await provider.getSimilarArtistNames("Nope")
+    expect(result).toEqual([])
+  })
+
+  it("returns empty array on non-200 response", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {})
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("", { status: 500 })
     )
 
     const result = await provider.getSimilarArtistNames("Seed")
-    expect(result).toHaveLength(7) // items at indices 3-9
-    expect(result[0]).toBe("Artist 3")
-    expect(result[6]).toBe("Artist 9")
+    expect(result).toEqual([])
   })
 })

--- a/lib/music-provider/index.ts
+++ b/lib/music-provider/index.ts
@@ -13,6 +13,13 @@ export function isRateLimited(x: unknown): x is RateLimited {
   return typeof x === "object" && x !== null && (x as RateLimited).rateLimited === true
 }
 
+/** A similar-artist reference as returned by Last.fm's artist.getSimilar endpoint. */
+export interface SimilarArtistRef {
+  name: string
+  /** Similarity score in [0, 1]. Parsed from Last.fm's `match` string. 0 when missing/unparseable. */
+  match: number
+}
+
 export interface MusicProvider {
   /** Get user's top artists for a given time range */
   getTopArtists(accessToken: string, term: 'short_term' | 'medium_term' | 'long_term'): Promise<Artist[]>
@@ -29,8 +36,12 @@ export interface MusicProvider {
   /** Fetch full artist objects by IDs (batch, up to 50 per call). Always includes genres. */
   getArtists(accessToken: string, ids: string[]): Promise<Artist[]>
 
-  /** Get similar artist names from Last.fm (no Spotify call, no access token needed) */
-  getSimilarArtistNames(artistName: string): Promise<string[]>
+  /**
+   * Get similar artist refs from Last.fm (no Spotify call, no access token needed).
+   * Preserves the ordered similarity ranking and the `match` score so callers
+   * can pick tail (low match) items for niche discovery.
+   */
+  getSimilarArtistNames(artistName: string): Promise<SimilarArtistRef[]>
 
   /**
    * Search for artists by name. Returns a `RateLimited` sentinel with the

--- a/lib/music-provider/spotify-provider.ts
+++ b/lib/music-provider/spotify-provider.ts
@@ -1,4 +1,4 @@
-import type { MusicProvider, RateLimited } from "./index"
+import type { MusicProvider, RateLimited, SimilarArtistRef } from "./index"
 import type { Artist, PlayHistory, Track } from "./types"
 
 const SPOTIFY_BASE = "https://api.spotify.com/v1"
@@ -50,7 +50,7 @@ interface SpotifyRecentlyPlayedResponse {
 
 interface LastFmSimilarArtistsResponse {
   similarartists?: {
-    artist: Array<{ name: string }>
+    artist: Array<{ name: string; match?: string | number }>
   }
   error?: number
   message?: string
@@ -175,7 +175,7 @@ export class SpotifyProvider implements MusicProvider {
   // -------------------------------------------------------------------------
   // getSimilarArtistNames — Last.fm only, no Spotify call, no access token
   // -------------------------------------------------------------------------
-  async getSimilarArtistNames(artistName: string): Promise<string[]> {
+  async getSimilarArtistNames(artistName: string): Promise<SimilarArtistRef[]> {
     const apiKey = process.env.LASTFM_API_KEY
     if (!apiKey) {
       if (!SpotifyProvider._lastFmKeyMissing) {
@@ -199,11 +199,13 @@ export class SpotifyProvider implements MusicProvider {
       const data = (await res.json()) as LastFmSimilarArtistsResponse
       if (data.error || !data.similarartists?.artist?.length) return []
 
-      const all = data.similarartists.artist.map((a) => a.name)
-      // Skip top-3 obvious matches, take next 15 for a wider candidate pool.
-      // For niche artists with few results, return whatever we have.
-      if (all.length <= 3) return all
-      return all.slice(3, 18)
+      return data.similarartists.artist
+        .map((a) => {
+          const rawMatch = typeof a.match === "string" ? parseFloat(a.match) : a.match
+          const match = typeof rawMatch === "number" && Number.isFinite(rawMatch) ? rawMatch : 0
+          return { name: a.name, match }
+        })
+        .filter((a) => a.name)
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
         console.error(`[lfm] getSimilarArtistNames timed out after 8s artist="${artistName}"`)
@@ -216,8 +218,9 @@ export class SpotifyProvider implements MusicProvider {
 
   /** @deprecated Use getSimilarArtistNames + engine-level Spotify resolution instead */
   private async _getSimilarViaLastFm(accessToken: string, artistName: string): Promise<Artist[]> {
-    const names = await this.getSimilarArtistNames(artistName)
-    if (!names.length) return []
+    const refs = await this.getSimilarArtistNames(artistName)
+    if (!refs.length) return []
+    const names = refs.map((r) => r.name)
     const resolved: Artist[] = []
     for (let i = 0; i < names.length; i += 5) {
       const batch = names.slice(i, i + 5)

--- a/lib/recommendation/engine.test.ts
+++ b/lib/recommendation/engine.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest"
+import { buildRoundRobinNames, greedyPickTop } from "./engine"
+import type { ScoredArtist } from "./types"
+import type { ArtistWithTracks } from "@/lib/music-provider/types"
+
+function artist(id: string, name: string, popularity = 50, genre = "rock"): ArtistWithTracks {
+  return { id, name, genres: [genre], imageUrl: null, popularity, topTracks: [] }
+}
+
+function scored(
+  id: string,
+  score: number,
+  sourceArtists: string[] = [],
+  genre = "rock",
+  popularity = 50
+): ScoredArtist {
+  return {
+    artist: artist(id, id, popularity, genre),
+    score,
+    why: { sourceArtists, genres: [genre], friendBoost: [] },
+    source: "test",
+  }
+}
+
+describe("buildRoundRobinNames", () => {
+  it("returns empty when all seeds have empty similar lists", () => {
+    const r = buildRoundRobinNames(
+      [{ seed: "A", names: [] }, { seed: "B", names: [] }],
+      new Set()
+    )
+    expect(r).toEqual([])
+  })
+
+  it("interleaves seeds in round-robin order", () => {
+    const r = buildRoundRobinNames(
+      [
+        { seed: "A", names: ["a1", "a2", "a3"] },
+        { seed: "B", names: ["b1", "b2", "b3"] },
+      ],
+      new Set()
+    )
+    expect(r).toEqual(["a1", "b1", "a2", "b2", "a3", "b3"])
+  })
+
+  it("dedups across seeds (first occurrence wins)", () => {
+    const r = buildRoundRobinNames(
+      [
+        { seed: "A", names: ["x", "a2"] },
+        { seed: "B", names: ["x", "b2"] },
+      ],
+      new Set()
+    )
+    expect(r).toEqual(["x", "a2", "b2"])
+  })
+
+  it("dedup is case-insensitive", () => {
+    const r = buildRoundRobinNames(
+      [
+        { seed: "A", names: ["Khruangbin"] },
+        { seed: "B", names: ["khruangbin"] },
+      ],
+      new Set()
+    )
+    expect(r).toEqual(["Khruangbin"])
+  })
+
+  it("filters names present in knownNames (user's own seeds)", () => {
+    const r = buildRoundRobinNames(
+      [{ seed: "A", names: ["Arctic Monkeys", "The Strokes"] }],
+      new Set(["arctic monkeys"])
+    )
+    expect(r).toEqual(["The Strokes"])
+  })
+
+  it("no single seed can contribute more than ceil(cap/seeds) to top-N slots", () => {
+    // 6 seeds, each returning 10 distinct similars. Cap to 60 slots.
+    const lfm = Array.from({ length: 6 }, (_, s) => ({
+      seed: `S${s}`,
+      names: Array.from({ length: 10 }, (_, i) => `s${s}_n${i}`),
+    }))
+    const r = buildRoundRobinNames(lfm, new Set()).slice(0, 60)
+    // Each seed should contribute exactly 10 of the 60 slots.
+    for (let s = 0; s < 6; s++) {
+      const fromSeed = r.filter((n) => n.startsWith(`s${s}_`)).length
+      expect(fromSeed).toBe(10)
+    }
+  })
+
+  it("handles uneven seed list lengths without padding dead slots", () => {
+    const r = buildRoundRobinNames(
+      [
+        { seed: "A", names: ["a1"] },
+        { seed: "B", names: ["b1", "b2", "b3"] },
+      ],
+      new Set()
+    )
+    expect(r).toEqual(["a1", "b1", "b2", "b3"])
+  })
+
+  it("one mainstream-biased seed cannot flood the pool when other seeds have variety", () => {
+    // Simulates: one seed returns 15 mainstream artists; others have only a
+    // few similars. Under seed-order dedup, the mainstream seed's 15 artists
+    // would fill most of the first 20 slots. Round-robin caps its contribution.
+    const lfm = [
+      { seed: "Other1", names: ["o1a", "o1b", "o1c", "o1d", "o1e"] },
+      { seed: "Other2", names: ["o2a", "o2b", "o2c"] },
+      {
+        seed: "Mainstream",
+        names: Array.from({ length: 15 }, (_, i) => `m${i}`),
+      },
+    ]
+    const r = buildRoundRobinNames(lfm, new Set()).slice(0, 20)
+    const mainstream = r.filter((n) => n.startsWith("m")).length
+    // In round-robin, Mainstream gets 1 slot per cycle. After ~5 cycles the
+    // other seeds are exhausted, so Mainstream fills remaining slots — but
+    // NOT before every other name has been included.
+    expect(mainstream).toBeLessThanOrEqual(15)
+    // All Other1 + Other2 names should appear before we run out of round-robin slots.
+    expect(r).toContain("o1a")
+    expect(r).toContain("o2a")
+    expect(r).toContain("o1e")
+  })
+})
+
+describe("greedyPickTop", () => {
+  it("picks all items when pool size is <= maxSize", () => {
+    const pool = [scored("a", 0.9), scored("b", 0.5), scored("c", 0.3)]
+    const top = greedyPickTop(pool, 20)
+    expect(top.length).toBe(3)
+  })
+
+  it("without diversity pressure, picks in descending score order", () => {
+    const pool = [
+      scored("a", 0.1, ["S1"], "rock"),
+      scored("b", 0.3, ["S2"], "jazz"),
+      scored("c", 0.5, ["S3"], "pop"),
+      scored("d", 0.7, ["S4"], "folk"),
+    ]
+    const top = greedyPickTop(pool, 4)
+    expect(top.map((t) => t.artist.id)).toEqual(["d", "c", "b", "a"])
+  })
+
+  it("does not mutate the input pool", () => {
+    const pool = [scored("a", 0.9), scored("b", 0.5)]
+    const snapshot = [...pool]
+    greedyPickTop(pool, 1)
+    expect(pool).toEqual(snapshot)
+  })
+
+  it("penalizes candidates that share source seeds with already-picked ones", () => {
+    // 15 candidates share source "A" at score 0.30; 5 candidates share source
+    // "B" at score 0.28. Without a per-seed penalty, "A" sweeps all 20 slots
+    // (the 5 "B" candidates are blocked by lower score). With the penalty,
+    // after 3 "A" picks the 4th "A" gets -0.12, so "B" starts winning.
+    const poolA = Array.from({ length: 15 }, (_, i) => scored(`a${i}`, 0.30, ["A"], `g_a${i}`))
+    const poolB = Array.from({ length: 5 }, (_, i) => scored(`b${i}`, 0.28, ["B"], `g_b${i}`))
+    const top = greedyPickTop([...poolA, ...poolB], 20)
+    const fromB = top.filter((t) => t.why.sourceArtists.includes("B")).length
+    expect(fromB).toBeGreaterThanOrEqual(3)
+  })
+
+  it("still fills all slots when every candidate shares one source seed", () => {
+    // Degenerate case: only one seed's similars exist. Penalty must not
+    // prevent the feed from filling.
+    const pool = Array.from({ length: 30 }, (_, i) => scored(`a${i}`, 0.30 - i * 0.001, ["OnlySeed"], `g${i}`))
+    const top = greedyPickTop(pool, 20)
+    expect(top.length).toBe(20)
+  })
+
+  it("genre penalty still applies when source seeds overlap", () => {
+    // All from one seed, all same genre except one. Genre penalty should
+    // push the odd-genre item up relative to its raw score rank.
+    const pool = [
+      scored("a1", 0.50, ["S"], "rock"),
+      scored("a2", 0.48, ["S"], "rock"),
+      scored("a3", 0.46, ["S"], "rock"),
+      scored("a4", 0.44, ["S"], "rock"),
+      scored("odd", 0.40, ["S"], "jazz"),
+    ]
+    const top = greedyPickTop(pool, 5)
+    // Without diversity, odd would be last (rank 5). With genre + seed
+    // penalties stacking on the rock/S combo, odd should move up.
+    const oddIdx = top.findIndex((t) => t.artist.id === "odd")
+    expect(oddIdx).toBeLessThan(4)
+  })
+
+  it("respects maxSize even when more candidates are available", () => {
+    const pool = Array.from({ length: 50 }, (_, i) => scored(`a${i}`, 1 - i * 0.01))
+    const top = greedyPickTop(pool, 20)
+    expect(top.length).toBe(20)
+  })
+})

--- a/lib/recommendation/engine.test.ts
+++ b/lib/recommendation/engine.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest"
-import { buildRoundRobinNames, greedyPickTop } from "./engine"
+import { describe, it, expect, vi } from "vitest"
+import { buildRoundRobinNames, greedyPickTop, runDeepHop } from "./engine"
 import type { ScoredArtist } from "./types"
 import type { ArtistWithTracks } from "@/lib/music-provider/types"
+import type { SimilarArtistRef } from "@/lib/music-provider"
 
 function artist(id: string, name: string, popularity = 50, genre = "rock"): ArtistWithTracks {
   return { id, name, genres: [genre], imageUrl: null, popularity, topTracks: [] }
@@ -97,6 +98,46 @@ describe("buildRoundRobinNames", () => {
     expect(r).toEqual(["a1", "b1", "b2", "b3"])
   })
 
+  it("tailFirst reverses per-seed iteration order", () => {
+    const r = buildRoundRobinNames(
+      [
+        { seed: "A", names: ["a1", "a2", "a3"] },
+        { seed: "B", names: ["b1", "b2", "b3"] },
+      ],
+      new Set(),
+      { tailFirst: true }
+    )
+    expect(r).toEqual(["a3", "b3", "a2", "b2", "a1", "b1"])
+  })
+
+  it("tailFirst handles uneven seed lengths without skipping short-seed tails", () => {
+    const r = buildRoundRobinNames(
+      [
+        { seed: "A", names: ["a1", "a2", "a3", "a4", "a5"] },
+        { seed: "B", names: ["b1"] },
+      ],
+      new Set(),
+      { tailFirst: true }
+    )
+    // Cycle 0: a5, b1. Cycle 1-4: a4, a3, a2, a1.
+    expect(r).toEqual(["a5", "b1", "a4", "a3", "a2", "a1"])
+  })
+
+  it("tailFirst prioritizes low-similarity (tail) picks across seeds", () => {
+    // Simulates 6 seeds with 50 similars each, ordered head (mainstream) → tail (niche).
+    // Under tail-first round-robin, the first 60 slots should all come from the tail.
+    const lfm = Array.from({ length: 6 }, (_, s) => ({
+      seed: `S${s}`,
+      names: Array.from({ length: 50 }, (_, i) => `s${s}_idx${i}`),
+    }))
+    const r = buildRoundRobinNames(lfm, new Set(), { tailFirst: true }).slice(0, 60)
+    // Every item in the top 60 should have idx >= 40 (bottom 20%).
+    for (const name of r) {
+      const idx = parseInt(name.split("_idx")[1], 10)
+      expect(idx).toBeGreaterThanOrEqual(40)
+    }
+  })
+
   it("one mainstream-biased seed cannot flood the pool when other seeds have variety", () => {
     // Simulates: one seed returns 15 mainstream artists; others have only a
     // few similars. Under seed-order dedup, the mainstream seed's 15 artists
@@ -188,5 +229,73 @@ describe("greedyPickTop", () => {
     const pool = Array.from({ length: 50 }, (_, i) => scored(`a${i}`, 1 - i * 0.01))
     const top = greedyPickTop(pool, 20)
     expect(top.length).toBe(20)
+  })
+})
+
+function ref(name: string, match: number): SimilarArtistRef {
+  return { name, match }
+}
+
+describe("runDeepHop", () => {
+  it("fetches 2nd-hop for each seed's N lowest-match first-hop items", async () => {
+    const firstHop = [
+      {
+        seed: "Drake",
+        items: [ref("Kendrick", 0.9), ref("Tyler", 0.8), ref("Obscure1", 0.2), ref("Obscure2", 0.1), ref("Obscure3", 0.05)],
+      },
+    ]
+    const calls: string[] = []
+    const fetchSimilar = vi.fn(async (name: string): Promise<SimilarArtistRef[]> => {
+      calls.push(name)
+      return [ref(`${name}-related`, 0.5)]
+    })
+
+    const result = await runDeepHop(firstHop, fetchSimilar, 3)
+    // Only the 3 lowest-match items are hopped from.
+    expect(calls.sort()).toEqual(["Obscure1", "Obscure2", "Obscure3"])
+    // The parent seed's item list was extended with the hop results.
+    const drake = result.find((r) => r.seed === "Drake")!
+    expect(drake.items.map((i) => i.name)).toEqual(
+      expect.arrayContaining(["Kendrick", "Obscure1", "Obscure1-related", "Obscure2-related", "Obscure3-related"])
+    )
+  })
+
+  it("handles seeds with fewer items than hopsPerSeed", async () => {
+    const firstHop = [{ seed: "Niche", items: [ref("A", 0.5)] }]
+    const fetchSimilar = vi.fn(async (name: string): Promise<SimilarArtistRef[]> => [ref(`${name}-hop`, 0.3)])
+    const result = await runDeepHop(firstHop, fetchSimilar, 3)
+    expect(fetchSimilar).toHaveBeenCalledTimes(1)
+    expect(result[0].items.map((i) => i.name)).toEqual(["A", "A-hop"])
+  })
+
+  it("dedupes hop items against existing first-hop items (case-insensitive)", async () => {
+    const firstHop = [{ seed: "Seed", items: [ref("Already", 0.9), ref("Niche", 0.1)] }]
+    const fetchSimilar = vi.fn(async (): Promise<SimilarArtistRef[]> => [
+      ref("already", 0.4),  // case-insensitive dup of Already
+      ref("Fresh", 0.3),
+    ])
+    const result = await runDeepHop(firstHop, fetchSimilar, 3)
+    const names = result[0].items.map((i) => i.name)
+    expect(names).toEqual(["Already", "Niche", "Fresh"])
+  })
+
+  it("preserves per-seed isolation — hops from seed A don't pollute seed B", async () => {
+    const firstHop = [
+      { seed: "A", items: [ref("A-niche", 0.1)] },
+      { seed: "B", items: [ref("B-niche", 0.1)] },
+    ]
+    const fetchSimilar = vi.fn(async (name: string): Promise<SimilarArtistRef[]> => [ref(`${name}-hop`, 0.3)])
+    const result = await runDeepHop(firstHop, fetchSimilar, 3)
+    const a = result.find((r) => r.seed === "A")!
+    const b = result.find((r) => r.seed === "B")!
+    expect(a.items.map((i) => i.name)).toEqual(["A-niche", "A-niche-hop"])
+    expect(b.items.map((i) => i.name)).toEqual(["B-niche", "B-niche-hop"])
+  })
+
+  it("handles empty first-hop items without crashing", async () => {
+    const fetchSimilar = vi.fn(async (): Promise<SimilarArtistRef[]> => [])
+    const result = await runDeepHop([{ seed: "Seed", items: [] }], fetchSimilar, 3)
+    expect(fetchSimilar).not.toHaveBeenCalled()
+    expect(result[0].items).toEqual([])
   })
 })

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -1,7 +1,7 @@
 import { musicProvider } from '@/lib/music-provider/provider'
 import type { Artist } from '@/lib/music-provider/types'
 import { createServiceClient } from '@/lib/supabase/server'
-import type { BuildResult, RecommendationInput, ScoredArtist } from './types'
+import { UNDERGROUND_MAX_POPULARITY, type BuildResult, type RecommendationInput, type ScoredArtist } from './types'
 import { ArtistNameCache } from './artist-name-cache'
 import { resolveArtistsByName } from './resolve-candidates'
 import { normalizeArtistName } from '@/lib/listened-artists'
@@ -109,8 +109,77 @@ async function gatherSeedNames(userId: string, supabase: SupabaseClient): Promis
 
 // Primary/secondary split: resolve this many names on the critical path
 // (blocks the response), resolve the rest in the background via runSecondary.
-const PRIMARY_RESOLVE_CAP = 20
+const PRIMARY_RESOLVE_CAP = 60
 const SECONDARY_RESOLVE_CAP = 30
+
+/**
+ * Round-robin interleave across seed similar-lists so each seed contributes
+ * equally to the primary candidate pool. Without this, map insertion order
+ * equals seed order and a single mainstream-biased seed can flood the first
+ * PRIMARY_RESOLVE_CAP slots with its whole similars list.
+ */
+export function buildRoundRobinNames(
+  lfmResults: { seed: string; names: string[] }[],
+  knownNames: Set<string>
+): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  const maxLen = Math.max(0, ...lfmResults.map((r) => r.names.length))
+  for (let i = 0; i < maxLen; i++) {
+    for (const { names } of lfmResults) {
+      const n = names[i]
+      if (!n) continue
+      const key = n.toLowerCase()
+      if (seen.has(key) || knownNames.has(key)) continue
+      seen.add(key)
+      out.push(n)
+    }
+  }
+  return out
+}
+
+/**
+ * Greedy pick with soft per-genre AND per-source-seed diversity penalties.
+ * The per-seed penalty prevents one seed whose similar list is all mainstream
+ * from dominating the final feed even when its artists sit under several
+ * distinct genre labels.
+ */
+export function greedyPickTop(
+  pool: ScoredArtist[],
+  maxSize = 20,
+  genreWeight = 0.02,
+  sourceWeight = 0.04
+): ScoredArtist[] {
+  const working = [...pool]
+  const top: ScoredArtist[] = []
+  const genreCounts = new Map<string, number>()
+  const sourceSeedCounts = new Map<string, number>()
+  while (top.length < maxSize && working.length > 0) {
+    let bestIdx = 0
+    let bestAdjusted = -Infinity
+    for (let i = 0; i < working.length; i++) {
+      const primary = working[i].artist.genres[0] ?? 'unknown'
+      const gCount = genreCounts.get(primary) ?? 0
+      const srcPenalty = working[i].why.sourceArtists.reduce(
+        (acc, s) => acc + (sourceSeedCounts.get(s) ?? 0) * sourceWeight,
+        0
+      )
+      const adjusted = working[i].score - gCount * genreWeight - srcPenalty
+      if (adjusted > bestAdjusted) {
+        bestAdjusted = adjusted
+        bestIdx = i
+      }
+    }
+    const picked = working.splice(bestIdx, 1)[0]
+    const primary = picked.artist.genres[0] ?? 'unknown'
+    genreCounts.set(primary, (genreCounts.get(primary) ?? 0) + 1)
+    for (const s of picked.why.sourceArtists) {
+      sourceSeedCounts.set(s, (sourceSeedCounts.get(s) ?? 0) + 1)
+    }
+    top.push(picked)
+  }
+  return top
+}
 
 async function runPipeline(
   seedNames: string[],
@@ -144,8 +213,7 @@ async function runPipeline(
     }
   }
 
-  // Split: first chunk resolves synchronously (20), second chunk runs in after()
-  const allNames = [...nameToSeeds.keys()]
+  const allNames = buildRoundRobinNames(lfmResults, knownNames)
   const uniqueNames = allNames.slice(0, PRIMARY_RESOLVE_CAP)
   const secondaryNames = allNames.slice(PRIMARY_RESOLVE_CAP, PRIMARY_RESOLVE_CAP + SECONDARY_RESOLVE_CAP)
   const lfmTotal = lfmResults.reduce((sum, r) => sum + r.names.length, 0)
@@ -215,6 +283,7 @@ async function runPipeline(
       if (thumbsDownIds.has(id)) return false
       if (overThresholdIds.has(id)) { filtListened++; return false }
       if (overThresholdNames.has(normalizeArtistName(val.artist.name))) { filtListened++; return false }
+      if (undergroundMode && val.artist.popularity > UNDERGROUND_MAX_POPULARITY) return false
       // Genre filter: only include artists matching the requested genre
       if (genre && !val.artist.genres.some((g) => g.toLowerCase().includes(genre.toLowerCase()))) return false
       return true
@@ -263,25 +332,7 @@ async function runPipeline(
     JSON.stringify([...poolGenreDist.entries()].sort((a, b) => b[1] - a[1]).slice(0, 10))
   )
 
-  const top: ScoredArtist[] = []
-  const genreCounts = new Map<string, number>()
-  while (top.length < 20 && pool.length > 0) {
-    let bestIdx = 0
-    let bestAdjusted = -Infinity
-    for (let i = 0; i < pool.length; i++) {
-      const primary = pool[i].artist.genres[0] ?? "unknown"
-      const count = genreCounts.get(primary) ?? 0
-      const adjusted = pool[i].score - count * 0.02
-      if (adjusted > bestAdjusted) {
-        bestAdjusted = adjusted
-        bestIdx = i
-      }
-    }
-    const picked = pool.splice(bestIdx, 1)[0]
-    const primary = picked.artist.genres[0] ?? "unknown"
-    genreCounts.set(primary, (genreCounts.get(primary) ?? 0) + 1)
-    top.push(picked)
-  }
+  const top = greedyPickTop(pool, 20)
 
   if (top.length === 0) {
     console.error(
@@ -366,6 +417,7 @@ async function runPipeline(
           if (thumbsDownIds.has(artist.id)) continue
           if (overThresholdIds.has(artist.id)) continue
           if (overThresholdNames.has(normalizeArtistName(artist.name))) continue
+          if (undergroundMode && artist.popularity > UNDERGROUND_MAX_POPULARITY) continue
           if (genre && !artist.genres.some((g) => g.toLowerCase().includes(genre.toLowerCase()))) continue
           const seedArtists = nameToSeeds.get(name) ?? []
           secondaryCandidates.push({ artist, seedArtists })

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -1,5 +1,6 @@
 import { musicProvider } from '@/lib/music-provider/provider'
 import type { Artist } from '@/lib/music-provider/types'
+import type { SimilarArtistRef } from '@/lib/music-provider'
 import { createServiceClient } from '@/lib/supabase/server'
 import { UNDERGROUND_MAX_POPULARITY, type BuildResult, type RecommendationInput, type ScoredArtist } from './types'
 import { ArtistNameCache } from './artist-name-cache'
@@ -117,17 +118,25 @@ const SECONDARY_RESOLVE_CAP = 30
  * equally to the primary candidate pool. Without this, map insertion order
  * equals seed order and a single mainstream-biased seed can flood the first
  * PRIMARY_RESOLVE_CAP slots with its whole similars list.
+ *
+ * With `tailFirst`, each seed's list is consumed from the END (lowest-match
+ * items first). Last.fm orders similars by similarity, which correlates with
+ * popularity/mainstream-ness, so tail items are less-obvious picks.
  */
 export function buildRoundRobinNames(
   lfmResults: { seed: string; names: string[] }[],
-  knownNames: Set<string>
+  knownNames: Set<string>,
+  opts: { tailFirst?: boolean } = {}
 ): string[] {
+  const tailFirst = opts.tailFirst ?? false
   const out: string[] = []
   const seen = new Set<string>()
   const maxLen = Math.max(0, ...lfmResults.map((r) => r.names.length))
   for (let i = 0; i < maxLen; i++) {
     for (const { names } of lfmResults) {
-      const n = names[i]
+      const idx = tailFirst ? names.length - 1 - i : i
+      if (idx < 0 || idx >= names.length) continue
+      const n = names[idx]
       if (!n) continue
       const key = n.toLowerCase()
       if (seen.has(key) || knownNames.has(key)) continue
@@ -136,6 +145,49 @@ export function buildRoundRobinNames(
     }
   }
   return out
+}
+
+/**
+ * Deep-discovery 2nd-hop walk. For each seed, takes its N lowest-match first-hop
+ * similars (furthest from seed's typical neighborhood, likeliest to be niche) and
+ * calls getSimilar on each. Merges 2nd-hop refs back under the parent seed so
+ * round-robin and per-source-seed penalty semantics are preserved.
+ *
+ * Exported for tests. `fetchSimilar` is injected so tests can run without
+ * network access.
+ */
+export async function runDeepHop(
+  firstHop: { seed: string; items: SimilarArtistRef[] }[],
+  fetchSimilar: (name: string) => Promise<SimilarArtistRef[]>,
+  hopsPerSeed = 3
+): Promise<{ seed: string; items: SimilarArtistRef[] }[]> {
+  const bySeed = new Map<string, SimilarArtistRef[]>()
+  for (const { seed, items } of firstHop) bySeed.set(seed, [...items])
+
+  const tasks = firstHop.flatMap(({ seed, items }) =>
+    [...items]
+      .sort((a, b) => a.match - b.match)
+      .slice(0, hopsPerSeed)
+      .map(async (niche) => ({
+        parentSeed: seed,
+        hopItems: await fetchSimilar(niche.name),
+      }))
+  )
+  const hops = await Promise.all(tasks)
+
+  for (const { parentSeed, hopItems } of hops) {
+    const existing = bySeed.get(parentSeed)
+    if (!existing) continue
+    const seen = new Set(existing.map((i) => i.name.toLowerCase()))
+    for (const hi of hopItems) {
+      const key = hi.name.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      existing.push(hi)
+    }
+  }
+
+  return [...bySeed.entries()].map(([seed, items]) => ({ seed, items }))
 }
 
 /**
@@ -190,18 +242,30 @@ async function runPipeline(
   supabase: SupabaseClient,
   source: string,
   genre?: string,
-  undergroundMode?: boolean
+  undergroundMode?: boolean,
+  deepDiscovery?: boolean
 ): Promise<BuildResult> {
   const capSeedNames = seedNames.slice(0, 10)
-  console.log(`[engine] seeds-post-shuffle source=${source} seeds=${JSON.stringify(capSeedNames)}`)
+  console.log(`[engine] seeds-post-shuffle source=${source} seeds=${JSON.stringify(capSeedNames)} deepDiscovery=${!!deepDiscovery}`)
 
   // Step A: Fetch Last.fm similar artists for all seeds in parallel
-  const lfmResults = await Promise.all(
+  const firstHop = await Promise.all(
     capSeedNames.map(async (name) => ({
       seed: name,
-      names: await musicProvider.getSimilarArtistNames(name),
+      items: await musicProvider.getSimilarArtistNames(name),
     }))
   )
+
+  // Step A2: Deep-discovery 2nd hop — fire ≤3 extra getSimilar calls per seed
+  // from the lowest-match first-hop items. Merged back under the parent seed.
+  const lfmRefResults = deepDiscovery
+    ? await runDeepHop(firstHop, (n) => musicProvider.getSimilarArtistNames(n))
+    : firstHop
+
+  const lfmResults = lfmRefResults.map(({ seed, items }) => ({
+    seed,
+    names: items.map((i) => i.name),
+  }))
 
   const knownNames = new Set(capSeedNames.map((n) => n.toLowerCase()))
   const nameToSeeds = new Map<string, string[]>()
@@ -213,7 +277,9 @@ async function runPipeline(
     }
   }
 
-  const allNames = buildRoundRobinNames(lfmResults, knownNames)
+  // Tail-first round-robin: consume each seed's low-match items before its
+  // high-match ones, so the primary pool skews toward less-obvious similars.
+  const allNames = buildRoundRobinNames(lfmResults, knownNames, { tailFirst: true })
   const uniqueNames = allNames.slice(0, PRIMARY_RESOLVE_CAP)
   const secondaryNames = allNames.slice(PRIMARY_RESOLVE_CAP, PRIMARY_RESOLVE_CAP + SECONDARY_RESOLVE_CAP)
   const lfmTotal = lfmResults.reduce((sum, r) => sum + r.names.length, 0)
@@ -483,7 +549,7 @@ async function runPipeline(
 // ── Main entry point ────────────────────────────────────────────────────────
 
 export async function buildRecommendations(input: RecommendationInput): Promise<BuildResult> {
-  const { userId, accessToken, playThreshold, popularityCurve, genre, undergroundMode } = input
+  const { userId, accessToken, playThreshold, popularityCurve, genre, undergroundMode, deepDiscovery } = input
   const supabase = createServiceClient()
 
   // Gather seeds from all configured sources
@@ -491,7 +557,7 @@ export async function buildRecommendations(input: RecommendationInput): Promise<
 
   if (seedNames.length > 0) {
     console.log(`[engine] start userId=${userId} seeds=${seedNames.length}${genre ? ` genre=${genre}` : ""}`)
-    return runPipeline(seedNames, accessToken, userId, playThreshold, popularityCurve, supabase, 'multi_source', genre, undergroundMode)
+    return runPipeline(seedNames, accessToken, userId, playThreshold, popularityCurve, supabase, 'multi_source', genre, undergroundMode, deepDiscovery)
   }
 
   // Cold-start: no seeds configured — pick random artists from curated list
@@ -503,5 +569,5 @@ export async function buildRecommendations(input: RecommendationInput): Promise<
     ;[pool[i], pool[j]] = [pool[j], pool[i]]
   }
   const coldSeeds = pool.slice(0, 5).map((s) => s.name)
-  return runPipeline(coldSeeds, accessToken, userId, playThreshold, popularityCurve, supabase, 'cold_start', genre, undergroundMode)
+  return runPipeline(coldSeeds, accessToken, userId, playThreshold, popularityCurve, supabase, 'cold_start', genre, undergroundMode, deepDiscovery)
 }

--- a/lib/recommendation/resolve-candidates.test.ts
+++ b/lib/recommendation/resolve-candidates.test.ts
@@ -175,4 +175,36 @@ describe("resolveArtistsByName", () => {
     expect(r.cacheHits).toBe(1)
     expect(r.rateLimited).toBe(true)
   })
+
+  it("runs miss resolution concurrently up to the configured pool size", async () => {
+    let active = 0
+    let maxActive = 0
+    const search = vi.fn(async (name: string): Promise<Artist[] | RateLimited> => {
+      active++
+      if (active > maxActive) maxActive = active
+      await new Promise((r) => setTimeout(r, 5))
+      active--
+      return [artist(`id-${name}`, name)]
+    })
+    const names = ["a", "b", "c", "d", "e", "f", "g", "h"]
+    const r = await resolveArtistsByName(names, { ...makeDeps({ search }), concurrency: 4 })
+    expect(r.searchOk).toBe(8)
+    expect(maxActive).toBeGreaterThan(1)
+    expect(maxActive).toBeLessThanOrEqual(4)
+  })
+
+  it("serializes to concurrency=1 when configured", async () => {
+    let active = 0
+    let maxActive = 0
+    const search = vi.fn(async (name: string): Promise<Artist[] | RateLimited> => {
+      active++
+      if (active > maxActive) maxActive = active
+      await new Promise((r) => setTimeout(r, 1))
+      active--
+      return [artist(`id-${name}`, name)]
+    })
+    const r = await resolveArtistsByName(["a", "b", "c"], { ...makeDeps({ search }), concurrency: 1 })
+    expect(r.searchOk).toBe(3)
+    expect(maxActive).toBe(1)
+  })
 })

--- a/lib/recommendation/resolve-candidates.ts
+++ b/lib/recommendation/resolve-candidates.ts
@@ -18,6 +18,8 @@ export interface ResolveDeps {
   totalBackoffBudgetMs?: number
   /** Max attempts per name (initial + retries). Default 3. */
   maxAttemptsPerName?: number
+  /** Number of parallel miss-resolver workers. Default 4. */
+  concurrency?: number
   sleep?: (ms: number) => Promise<void>
 }
 
@@ -89,67 +91,68 @@ export async function resolveArtistsByName(
   }
   result.cacheMisses = misses.length
 
+  // Shared budget across workers; reserved synchronously before each sleep
+  // so concurrent workers see the updated value and don't double-spend.
   let spentBackoffMs = 0
-  let firstSuccessfulSearch = true
 
-  for (const name of misses) {
-    // Polite delay between successful live searches (skip before the first)
-    if (!firstSuccessfulSearch) {
-      await sleep(delayMs)
-    }
+  const queue = [...misses]
+  const concurrency = Math.max(1, Math.min(deps.concurrency ?? 4, queue.length))
 
-    let attempt = 0
-    let resolvedArtist: Artist | null = null
-    let exhaustedForThisName = false
+  async function runWorker() {
+    let firstSuccessfulSearch = true
 
-    while (attempt < maxAttempts) {
-      attempt++
-      const res = await deps.searchArtists(name)
+    while (queue.length > 0) {
+      const name = queue.shift()
+      if (name === undefined) return
 
-      if (isRateLimited(res)) {
-        result.rateLimited = true
-        if (attempt >= maxAttempts) {
-          exhaustedForThisName = true
-          break
-        }
-        result.searchRetries++
-        const budgetLeft = totalBackoffBudgetMs - spentBackoffMs
-        if (budgetLeft <= 0) {
-          result.backoffBudgetExhausted = true
-          // No more waiting — try next name immediately
-          exhaustedForThisName = true
-          break
-        }
-        const requested = Math.max(1, res.retryAfterSec) * 1000
-        const waitMs = Math.min(requested, maxRetryBackoffMs, budgetLeft)
-        await sleep(waitMs)
-        spentBackoffMs += waitMs
-        continue
+      // Polite delay between this worker's successful live searches.
+      if (!firstSuccessfulSearch) {
+        await sleep(delayMs)
       }
 
-      // Not rate limited — it's an array
-      if (res.length === 0) {
-        // No match for this name
+      let attempt = 0
+      let resolvedArtist: Artist | null = null
+
+      while (attempt < maxAttempts) {
+        attempt++
+        const res = await deps.searchArtists(name)
+
+        if (isRateLimited(res)) {
+          result.rateLimited = true
+          if (attempt >= maxAttempts) break
+          result.searchRetries++
+          const budgetLeft = totalBackoffBudgetMs - spentBackoffMs
+          if (budgetLeft <= 0) {
+            result.backoffBudgetExhausted = true
+            break
+          }
+          const requested = Math.max(1, res.retryAfterSec) * 1000
+          const waitMs = Math.min(requested, maxRetryBackoffMs, budgetLeft)
+          // Reserve before sleeping so concurrent workers see the updated budget
+          spentBackoffMs += waitMs
+          await sleep(waitMs)
+          continue
+        }
+
+        if (res.length === 0) break
+
+        const lower = name.toLowerCase()
+        resolvedArtist = res.find((a) => a.name.toLowerCase() === lower) ?? res[0]
         break
       }
 
-      const lower = name.toLowerCase()
-      resolvedArtist = res.find((a) => a.name.toLowerCase() === lower) ?? res[0]
-      break
-    }
-
-    if (resolvedArtist) {
-      result.searchOk++
-      result.resolved.set(name, resolvedArtist)
-      await deps.cache.write(name, resolvedArtist)
-      firstSuccessfulSearch = false
-    } else {
-      result.searchFail++
-      if (exhaustedForThisName) {
-        // Counted as fail above; keep looping to try next name
+      if (resolvedArtist) {
+        result.searchOk++
+        result.resolved.set(name, resolvedArtist)
+        await deps.cache.write(name, resolvedArtist)
+        firstSuccessfulSearch = false
+      } else {
+        result.searchFail++
       }
     }
   }
+
+  await Promise.all(Array.from({ length: concurrency }, runWorker))
 
   return result
 }

--- a/lib/recommendation/scoring.test.ts
+++ b/lib/recommendation/scoring.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { tierMultiplier } from "./engine"
+import { UNDERGROUND_MAX_POPULARITY } from "./types"
 
 describe("tierMultiplier (exponential decay)", () => {
   it("returns 1.0 at popularity 0", () => {
@@ -39,5 +40,13 @@ describe("tierMultiplier (exponential decay)", () => {
     for (let p = 0; p <= 100; p++) {
       expect(tierMultiplier(p)).toBeGreaterThan(0)
     }
+  })
+})
+
+describe("UNDERGROUND_MAX_POPULARITY", () => {
+  it("is pinned to 50 so the engine filter and UI cliff stay aligned", () => {
+    // Changing this value requires updating the curve-preview cliff, excluded-zone
+    // shading, and user-facing docs that promise "never above X popularity".
+    expect(UNDERGROUND_MAX_POPULARITY).toBe(50)
   })
 })

--- a/lib/recommendation/types.ts
+++ b/lib/recommendation/types.ts
@@ -16,6 +16,13 @@ export interface ScoredArtist {
   source: string
 }
 
+/**
+ * When `undergroundMode` is on, any candidate whose Spotify `popularity` is
+ * strictly greater than this value is hard-dropped from the pool. Shared with
+ * the settings curve preview so the UI cliff tracks the engine filter.
+ */
+export const UNDERGROUND_MAX_POPULARITY = 50
+
 export interface BuildResult {
   count: number
   /**

--- a/lib/recommendation/types.ts
+++ b/lib/recommendation/types.ts
@@ -7,6 +7,7 @@ export interface RecommendationInput {
   popularityCurve: number // from users.popularity_curve — base `k` of k^popularity scoring
   genre?: string        // optional genre filter for targeted generation
   undergroundMode?: boolean // when true, applies additional discoveryScore penalty
+  deepDiscovery?: boolean   // when true, take a 2nd-hop walk from each seed's lowest-match similars
 }
 
 export interface ScoredArtist {

--- a/supabase/migrations/0022_users_deep_discovery.sql
+++ b/supabase/migrations/0022_users_deep_discovery.sql
@@ -1,0 +1,4 @@
+-- Deep discovery toggle: when ON, the engine walks 2nd-hop from each seed's
+-- lowest-match similars, yielding more obscure picks at the cost of some
+-- genre drift. Default OFF so existing users see no behavior change.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS deep_discovery BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
Two-part PR addressing the Childish-Gambino-dominates-the-feed regression. First commit fixes single-seed pool domination + underground hard-cap. Second commit (Phase 1A of the deep-discovery PRD) attacks the retrieval-side regression-to-the-mean so "thumbs-up-popular → more popular" is no longer the default path.

## Part 1 — Feed diversity (commit e2ced49)
Fixes the observable "a single mainstream seed floods the final 20" bug and tightens the underground toggle into an actual hard cap.

- **Pool size.** `PRIMARY_RESOLVE_CAP` 20 → 60. With the cap equal to feed size, scoring could only order — not cull. Headroom restored.
- **Round-robin seed contribution.** `buildRoundRobinNames` replaces seed-order dedupe so each seed contributes equally to the primary pool.
- **Per-source-seed penalty in greedy pick.** `greedyPickTop` layers a per-source-seed penalty on top of the existing per-genre penalty. Mainstream hip-hop spread across "rap" / "pop rap" / "atl hip hop" is no longer invisible to diversity logic.
- **Underground hard-cap.** `undergroundMode` drops `popularity > 50` in primary and secondary filters. `UNDERGROUND_MAX_POPULARITY` is the single source of truth across engine + curve-preview UI.
- **Curve preview UI.** Dashed underground curve cliffs to 0 at pop=50; excluded-zone rectangle and dimmed/struck anchor labels fade in when underground is on.
- **Parallel resolver.** `resolveArtistsByName` miss loop goes serial → concurrent (pool of 4) with shared backoff budget.

## Part 2 — Phase 1A deep discovery (commit d683cb2)
Attacks Last.fm's regression-to-the-mean so a mainstream seed can no longer quietly funnel more mainstream names through.

- **Richer Last.fm shape.** `getSimilarArtistNames` now returns `{name, match}[]` with limit bumped 15 → 50.
- **Tail-biased round-robin.** `buildRoundRobinNames` gains a `tailFirst` option (default ON in the pipeline). Interleaves from the *bottom* of each seed's similar list — niche-leaning — across the cap slots. Swaps Last.fm's top-N mainstream bias for its tail.
- **Deep-discovery 2nd-hop walk.** New `runDeepHop` helper. When the toggle is on, fetches similars of each seed's 3 lowest-match (niche) first-hop items and merges back under the parent seed label — preserves the per-source-seed penalty from Part 1. Escapes the popularity gravity well entirely at the cost of occasional genre drift.
- **User-facing toggle.** New `users.deep_discovery` column (migration 0022), PATCH handling in `/api/settings`, and a "Deep discovery" toggle under "Extra obscure" on `/settings`. Copy: *"Walks two artists deep into similar-artist chains. More obscure picks; occasional genre drift."*

## Tests
453 passing (+23 across both parts). Typecheck clean.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 453/453 passing
- [x] Curve-preview manual check: toggling Extra obscure ON shows dashed cliff at p=50, excluded-zone shading, struck labels
- [x] Deep discovery toggle persists across reload (PATCH 200, state reflected on rehydrate)
- [x] Regenerate with `deepDiscovery=true` — 2nd-hop walk runs, writes 20 recs, `lfm` name count ~10× baseline
- [ ] Regenerate with mainstream-seeded user at k=0.95, underground OFF — confirm no single seed accounts for > 4 of the final 20
- [ ] Regenerate with underground ON — confirm no pop > 50 in feed; diversity preserved
- [ ] Cold first-generation latency remains < 6s with cap=60

## Migration
`supabase/migrations/0022_users_deep_discovery.sql` must be applied before deploy.

## Follow-up (Phase 1B, Phase 2 — tracked as separate issues)
- **#86 Phase 1B**: switch 2nd-hop parent-seed genre filter on by default; tune hopsPerSeed; add `[engine]` log lines for deep-hop observability.
- **#87 Phase 2**: per-artist transparency panel (Spotify popularity + Last.fm listener count on feed/history cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)