### PR TITLE
Sync fix + stats/history transparency + hard-cutoff UX

### DIFF
--- a/app/(app)/stats/page.tsx
+++ b/app/(app)/stats/page.tsx
@@ -81,15 +81,21 @@ export default async function StatsPage() {
     }
   }
 
-  // Resolve saved artists → { name, popularity } via recommendation_cache join
+  // Resolve saved + liked artists → { name, popularity } via one recommendation_cache join
   const savedIds = Array.from(new Set((savedArtistRows.data ?? []).map((r) => r.spotify_artist_id)))
+  const likedIds = Array.from(new Set(likedArtistIds))
+  const savedSet = new Set(savedIds)
+  const allIds = Array.from(new Set([...savedIds, ...likedIds]))
+
   const savedArtists: { name: string; popularity: number }[] = []
-  if (savedIds.length > 0) {
+  const likedArtists: { name: string; popularity: number }[] = []
+
+  if (allIds.length > 0) {
     const { data: cachedArtistData } = await supabase
       .from("recommendation_cache")
       .select("spotify_artist_id, artist_data")
       .eq("user_id", userId)
-      .in("spotify_artist_id", savedIds)
+      .in("spotify_artist_id", allIds)
 
     const seen = new Set<string>()
     for (const row of cachedArtistData ?? []) {
@@ -98,7 +104,12 @@ export default async function StatsPage() {
       const data = row.artist_data as { name?: string; popularity?: number } | null
       if (!data?.name) continue
       const pop = typeof data.popularity === "number" ? data.popularity : 0
-      savedArtists.push({ name: data.name, popularity: pop })
+      const item = { name: data.name, popularity: pop }
+      if (savedSet.has(row.spotify_artist_id)) {
+        savedArtists.push(item)
+      } else {
+        likedArtists.push(item)
+      }
     }
   }
 
@@ -110,6 +121,7 @@ export default async function StatsPage() {
       totalDislikes={dislikesResult.count ?? 0}
       topGenres={topGenres}
       savedArtists={savedArtists}
+      likedArtists={likedArtists}
     />
   )
 }

--- a/app/api/history/accumulate/route.ts
+++ b/app/api/history/accumulate/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request): Promise<Response> {
 
   if (userError) {
     console.error("[history/accumulate] User lookup error:", userError.message)
-    return apiError("Failed to load user profile")
+    return apiError(`Failed to load user profile: ${userError.message}`, 500)
   }
   if (!user) return apiError("User not found", 404)
 

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -24,6 +24,9 @@ export async function GET(): Promise<Response> {
   ])
 
   if (rowsResult.error) return dbError(rowsResult.error, "recommendations/fetch")
+  if (userResult.error) {
+    console.error("[recommendations/fetch] user lookup:", userResult.error.message)
+  }
 
   // Re-filter cached rows by the user's *current* underground_mode so toggling
   // the setting takes effect without requiring an explicit regenerate.

--- a/app/api/recommendations/route.ts
+++ b/app/api/recommendations/route.ts
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth"
 import { createServiceClient } from "@/lib/supabase/server"
 import { apiUnauthorized, dbError } from "@/lib/errors"
+import { UNDERGROUND_MAX_POPULARITY } from "@/lib/recommendation/types"
 
 export async function GET(): Promise<Response> {
   const session = await auth()
@@ -10,17 +11,32 @@ export async function GET(): Promise<Response> {
   const supabase = createServiceClient()
   const now = new Date().toISOString()
 
-  const { data, error } = await supabase
-    .from("recommendation_cache")
-    .select("spotify_artist_id, artist_data, score, why, source, seen_at")
-    .eq("user_id", userId)
-    .is("seen_at", null)
-    .gt("expires_at", now)
-    .order("score", { ascending: false })
-    .limit(20)
+  const [rowsResult, userResult] = await Promise.all([
+    supabase
+      .from("recommendation_cache")
+      .select("spotify_artist_id, artist_data, score, why, source, seen_at")
+      .eq("user_id", userId)
+      .is("seen_at", null)
+      .gt("expires_at", now)
+      .order("score", { ascending: false })
+      .limit(40),
+    supabase.from("users").select("underground_mode").eq("id", userId).maybeSingle(),
+  ])
 
-  if (error) return dbError(error, "recommendations/fetch")
+  if (rowsResult.error) return dbError(rowsResult.error, "recommendations/fetch")
+
+  // Re-filter cached rows by the user's *current* underground_mode so toggling
+  // the setting takes effect without requiring an explicit regenerate.
+  const undergroundMode = !!userResult.data?.underground_mode
+  let recommendations = rowsResult.data ?? []
+  if (undergroundMode) {
+    recommendations = recommendations.filter((r) => {
+      const pop = (r.artist_data as { popularity?: number } | null)?.popularity
+      return typeof pop !== "number" || pop <= UNDERGROUND_MAX_POPULARITY
+    })
+  }
+  recommendations = recommendations.slice(0, 20)
 
   // Return empty — client will trigger POST /api/recommendations/generate via useEffect
-  return Response.json({ recommendations: data ?? [], generating: false })
+  return Response.json({ recommendations, generating: false })
 }

--- a/components/history/history-client.tsx
+++ b/components/history/history-client.tsx
@@ -282,6 +282,7 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
                         </div>
                         <div className="mono" style={{ fontSize: 11, color: "var(--text-muted)" }}>
                           {timeAgo(entry.seen_at)}
+                          {entry.artist_data.popularity > 0 && ` · pop ${entry.artist_data.popularity}`}
                         </div>
                       </div>
 

--- a/components/settings/curve-preview.tsx
+++ b/components/settings/curve-preview.tsx
@@ -61,22 +61,68 @@ export function CurvePreview({ popularityCurve, undergroundMode, exampleArtists 
               <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.4" />
               <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
             </linearGradient>
+            <pattern
+              id="undergroundCutoff"
+              patternUnits="userSpaceOnUse"
+              width="8"
+              height="8"
+              patternTransform="rotate(45)"
+            >
+              <rect width="8" height="8" fill="#a78bfa" fillOpacity="0.08" />
+              <line x1="0" y1="0" x2="0" y2="8" stroke="#a78bfa" strokeOpacity="0.55" strokeWidth="2" />
+            </pattern>
           </defs>
 
           <line x1="20" y1="170" x2="380" y2="170" stroke="rgba(255,255,255,0.12)" strokeWidth="1" />
 
-          {/* Underground-mode excluded zone: everything above pop=50 is hard-dropped */}
-          <rect
-            x={svgX(UNDERGROUND_MAX_POPULARITY)}
-            y={svgY(1)}
-            width={svgX(100) - svgX(UNDERGROUND_MAX_POPULARITY)}
-            height={svgY(0) - svgY(1)}
-            fill="#a78bfa"
+          {/* Underground-mode excluded zone: every artist above pop=50 is hard-dropped */}
+          <g
             style={{
-              opacity: undergroundMode ? 0.15 : 0,
+              opacity: undergroundMode ? 1 : 0,
               transition: "opacity 0.4s ease",
             }}
-          />
+          >
+            <rect
+              x={svgX(UNDERGROUND_MAX_POPULARITY)}
+              y={svgY(1)}
+              width={svgX(100) - svgX(UNDERGROUND_MAX_POPULARITY)}
+              height={svgY(0) - svgY(1)}
+              fill="url(#undergroundCutoff)"
+            />
+            <line
+              x1={svgX(UNDERGROUND_MAX_POPULARITY)}
+              y1={svgY(1)}
+              x2={svgX(UNDERGROUND_MAX_POPULARITY)}
+              y2={svgY(0)}
+              stroke="#a78bfa"
+              strokeOpacity="0.75"
+              strokeWidth="1.5"
+              strokeDasharray="3 3"
+            />
+            <text
+              x={(svgX(UNDERGROUND_MAX_POPULARITY) + svgX(100)) / 2}
+              y={svgY(0.55)}
+              textAnchor="middle"
+              fill="#a78bfa"
+              fontSize="9"
+              fontWeight="700"
+              letterSpacing="0.12em"
+              className="mono"
+            >
+              EXCLUDED
+            </text>
+            <text
+              x={(svgX(UNDERGROUND_MAX_POPULARITY) + svgX(100)) / 2}
+              y={svgY(0.35)}
+              textAnchor="middle"
+              fill="#a78bfa"
+              fillOpacity="0.75"
+              fontSize="8"
+              className="mono"
+            >
+              hard cutoff at pop {UNDERGROUND_MAX_POPULARITY}
+            </text>
+          </g>
 
           {[0, 20, 40, 60, 80, 100].map((tick) => (
             <g key={tick}>

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -516,7 +516,7 @@ export function SettingsForm({
                     Extra obscure
                   </div>
                   <div className="muted" style={{ fontSize: 12, lineHeight: 1.5 }}>
-                    Applies an extra penalty on top of the curve above. The dashed overlay shows the combined effect.
+                    Drops every artist above pop 50 entirely, and penalizes the rest on top of the curve above. The striped region is excluded; the dashed overlay shows the combined effect.
                   </div>
                 </div>
                 <button

--- a/components/stats/stats-client.tsx
+++ b/components/stats/stats-client.tsx
@@ -15,6 +15,13 @@ interface StatsClientProps {
   totalDislikes: number
   topGenres: { genre: string; count: number }[]
   savedArtists: SavedArtist[]
+  likedArtists: SavedArtist[]
+}
+
+type TasteKind = "saved" | "liked"
+const KIND_COLOR: Record<TasteKind, string> = {
+  saved: "var(--accent)",
+  liked: "#22c55e",
 }
 
 function StatCard({
@@ -124,12 +131,61 @@ function hashSeed(str: string): number {
   return (h >>> 0) / 4294967295
 }
 
-function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) {
+function LegendSwatch({ color, label }: { color: string; label: string }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 5, fontSize: 11, color: "var(--text-muted)" }}>
+      <span style={{ width: 8, height: 8, borderRadius: "50%", background: color, display: "inline-block" }} />
+      {label}
+    </span>
+  )
+}
+
+function KindBadge({ kind }: { kind: TasteKind }) {
+  const color = KIND_COLOR[kind]
+  const label = kind === "saved" ? "Saved" : "Liked"
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 8px",
+        borderRadius: 999,
+        fontSize: 10,
+        fontWeight: 600,
+        letterSpacing: "0.02em",
+        color,
+        border: `1px solid ${color}`,
+        opacity: 0.9,
+      }}
+    >
+      {label}
+    </span>
+  )
+}
+
+type TasteItem = { name: string; popularity: number; kind: TasteKind }
+
+function TasteProfileView({
+  savedArtists,
+  likedArtists,
+}: {
+  savedArtists: SavedArtist[]
+  likedArtists: SavedArtist[]
+}) {
   const [sortDesc, setSortDesc] = useState(false)
 
+  const items = useMemo<TasteItem[]>(() => {
+    const savedNames = new Set(savedArtists.map((a) => a.name))
+    const out: TasteItem[] = savedArtists.map((a) => ({ ...a, kind: "saved" as const }))
+    for (const a of likedArtists) {
+      if (savedNames.has(a.name)) continue
+      out.push({ ...a, kind: "liked" })
+    }
+    return out
+  }, [savedArtists, likedArtists])
+
   const sorted = useMemo(
-    () => [...savedArtists].sort((a, b) => (sortDesc ? b.popularity - a.popularity : a.popularity - b.popularity)),
-    [savedArtists, sortDesc]
+    () => [...items].sort((a, b) => (sortDesc ? b.popularity - a.popularity : a.popularity - b.popularity)),
+    [items, sortDesc]
   )
 
   const svgHeight = 110
@@ -149,16 +205,22 @@ function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) 
         gap: 16,
       }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <Bookmark size={16} style={{ color: "var(--accent)" }} />
-        <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-secondary)" }}>
-          Your saved artists
-        </span>
+      <div style={{ display: "flex", alignItems: "center", gap: 12, justifyContent: "space-between", flexWrap: "wrap" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <Bookmark size={16} style={{ color: "var(--accent)" }} />
+          <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-secondary)" }}>
+            Your taste profile
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <LegendSwatch color={KIND_COLOR.saved} label="Saved" />
+          <LegendSwatch color={KIND_COLOR.liked} label="Liked" />
+        </div>
       </div>
 
-      {savedArtists.length === 0 ? (
+      {items.length === 0 ? (
         <p style={{ fontSize: 14, color: "var(--text-muted)" }}>
-          Save some artists to see where they fall on the popularity scale.
+          Save or like some artists to see where they fall on the popularity scale.
         </p>
       ) : (
         <>
@@ -166,7 +228,7 @@ function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) 
             viewBox={`0 0 400 ${svgHeight}`}
             width="100%"
             style={{ display: "block" }}
-            aria-label="Saved artists popularity distribution"
+            aria-label="Taste profile popularity distribution"
           >
             <line
               x1={svgPad.left}
@@ -203,22 +265,22 @@ function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) 
               )
             })}
 
-            {savedArtists.map((a) => {
+            {items.map((a) => {
               const cx = svgPad.left + (a.popularity / 100) * plotW
               const jitter = hashSeed(a.name)
               const cy = svgPad.top + jitter * plotH
               return (
                 <circle
-                  key={a.name}
+                  key={`${a.kind}-${a.name}`}
                   cx={cx}
                   cy={cy}
                   r="4"
-                  fill="var(--accent)"
+                  fill={KIND_COLOR[a.kind]}
                   fillOpacity="0.7"
                   stroke="var(--bg-card)"
                   strokeWidth="1"
                 >
-                  <title>{`${a.name} · popularity ${a.popularity}`}</title>
+                  <title>{`${a.name} · popularity ${a.popularity} · ${a.kind}`}</title>
                 </circle>
               )
             })}
@@ -230,7 +292,7 @@ function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) 
               onClick={() => setSortDesc((v) => !v)}
               style={{
                 display: "grid",
-                gridTemplateColumns: "1fr 80px 90px",
+                gridTemplateColumns: "1fr 72px 90px",
                 gap: 8,
                 padding: "8px 0",
                 background: "transparent",
@@ -246,20 +308,20 @@ function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) 
               }}
             >
               <span>Artist</span>
+              <span style={{ textAlign: "right" }}>Kind</span>
               <span style={{ display: "inline-flex", alignItems: "center", gap: 4, justifyContent: "flex-end" }}>
                 Popularity
                 <ArrowUpDown size={11} />
               </span>
-              <span style={{ textAlign: "right" }}>Tier</span>
             </button>
 
             <div style={{ maxHeight: 320, overflowY: "auto" }}>
               {sorted.map((a) => (
                 <div
-                  key={a.name}
+                  key={`${a.kind}-${a.name}`}
                   style={{
                     display: "grid",
-                    gridTemplateColumns: "1fr 80px 90px",
+                    gridTemplateColumns: "1fr 72px 90px",
                     gap: 8,
                     padding: "10px 0",
                     borderBottom: "1px solid rgba(255,255,255,0.04)",
@@ -278,11 +340,15 @@ function SavedPopularityView({ savedArtists }: { savedArtists: SavedArtist[] }) 
                   >
                     {a.name}
                   </span>
-                  <span className="mono" style={{ fontSize: 12, color: "var(--text-secondary)", textAlign: "right" }}>
-                    {a.popularity}
+                  <span style={{ textAlign: "right" }}>
+                    <KindBadge kind={a.kind} />
                   </span>
-                  <span style={{ fontSize: 12, color: "var(--text-muted)", textAlign: "right" }}>
-                    {popularityTier(a.popularity)}
+                  <span
+                    className="mono"
+                    style={{ fontSize: 12, color: "var(--text-secondary)", textAlign: "right" }}
+                    title={popularityTier(a.popularity)}
+                  >
+                    {a.popularity}
                   </span>
                 </div>
               ))}
@@ -301,6 +367,7 @@ export function StatsClient({
   totalDislikes,
   topGenres,
   savedArtists,
+  likedArtists,
 }: StatsClientProps) {
   return (
     <div>
@@ -318,7 +385,7 @@ export function StatsClient({
 
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <GenreCard genres={topGenres} />
-        <SavedPopularityView savedArtists={savedArtists} />
+        <TasteProfileView savedArtists={savedArtists} likedArtists={likedArtists} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Three unrelated fixes shipped together on the `Nick` branch.

### Last.fm "Sync now" bug
The **Failed to load user profile** toast was hiding the real Postgres error. Migration `0017_statsfm_username.sql` wasn't applied on remote Supabase, so the `users` select in `/api/history/accumulate` threw `column users.last_accumulated_lastfm_at does not exist`. Fix:

- Surface the real error text in the response body (solo-owner app — visibility > redaction). Next drift like this takes one click to diagnose.
- Log `userResult.error` in `/api/recommendations` GET so a users-table hiccup no longer silently serves un-filtered recs.
- Migration 0017 applied to remote Supabase (idempotent rerun — `statsfm_username` was already there).

### Hard-cutoff shading
"Extra obscure" was rendering the pop-50→100 excluded zone as a 15%-opacity solid tint — it read like a gradient penalty, not a hard filter. Rework:

- Diagonal stripes via SVG pattern, dashed vertical cutoff line at pop 50.
- `EXCLUDED` label + `hard cutoff at pop 50` sub-label inside the region.
- Rewrite the toggle copy to state the hard drop explicitly.

### Stats + history transparency (original scope of this PR)
- **History rows** show Spotify popularity next to the timestamp (`just now · pop 62`), suppressed when `popularity === 0`.
- **Stats dot plot** → *Your taste profile*, with saved (accent) + liked (green) series on the same popularity axis, a sortable table, and a Kind badge column.
- **Underground re-filter**: `GET /api/recommendations` now reads current `underground_mode` and filters cached rows with `popularity > UNDERGROUND_MAX_POPULARITY` before returning — toggling takes effect without a regenerate.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 453/453 pass
- [x] `npm run build` — green
- [x] `POST /api/history/accumulate` with missing username returns 400 "No Last.fm account connected" (was 500 with the missing-column error)
- [x] `/settings` Discovery card renders striped EXCLUDED region when Extra obscure is on (screenshotted)
- [x] `/api/recommendations` GET still returns recs, underground filter no-op when no cached row exceeds the cap

## Out of scope / follow-ups

- Last.fm / stats.fm username existence validation (regex validates format only; invalid names fail at Sync time). Filed for backlog consideration.
- Backfilling stale `artist_data.popularity` on historical cache rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)