### PR TITLE
Feed: change header subtitle from "N cued" to "N artists"

### DIFF
--- a/components/feed/feed-client.tsx
+++ b/components/feed/feed-client.tsx
@@ -183,7 +183,7 @@ export function FeedClient({ recommendations }: FeedClientProps) {
       {/* Page header */}
       <div className="page-head">
         <h1>Today&apos;s feed</h1>
-        <span className="sub">{filteredRecs.length} cued</span>
+        <span className="sub">{filteredRecs.length} artists</span>
       </div>
 
       {/* Genre filter chips */}


### PR DESCRIPTION
"Cued" read like a misspelling of "queued" — switch to the same "N artists" pattern the Saved page uses for consistency.