### PR TITLE
Fix artist search silent failures + cache-backed 429 fallback

### DIFF
--- a/app/api/onboarding/search/route.ts
+++ b/app/api/onboarding/search/route.ts
@@ -3,11 +3,42 @@ import { auth } from "@/lib/auth"
 import { apiError, apiUnauthorized } from "@/lib/errors"
 import { getSpotifyClientToken } from "@/lib/spotify-client-token"
 import { musicProvider } from "@/lib/music-provider/provider"
+import { createServiceClient } from "@/lib/supabase/server"
+import type { Artist } from "@/lib/music-provider/types"
 
-// Artist search during onboarding uses server-side client credentials (no user OAuth needed)
+// Escape %/_/\ so user input can't turn into a wildcard in ILIKE.
+function escapeIlike(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_")
+}
+
+async function searchCachedArtists(query: string, limit = 10): Promise<Artist[]> {
+  try {
+    const supabase = createServiceClient()
+    const pattern = `${escapeIlike(query.toLowerCase())}%`
+    const { data, error } = await supabase
+      .from("artist_search_cache")
+      .select("artist_data")
+      .ilike("name_lower", pattern)
+      .limit(limit)
+    if (error) {
+      console.log(`[onboard-search] cache-fallback read-fail err="${error.message}"`)
+      return []
+    }
+    return (data ?? []).map((r) => r.artist_data as Artist)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.log(`[onboard-search] cache-fallback throw err="${msg}"`)
+    return []
+  }
+}
+
+// Artist search during onboarding uses server-side client credentials (no user OAuth needed).
 export async function GET(req: NextRequest) {
   const session = await auth()
-  if (!session?.user?.id) return apiUnauthorized()
+  if (!session?.user?.id) {
+    console.log("[onboard-search] unauth")
+    return apiUnauthorized()
+  }
 
   const query = req.nextUrl.searchParams.get("q")
   if (!query || query.trim().length === 0) {
@@ -17,15 +48,27 @@ export async function GET(req: NextRequest) {
     return apiError("Query too long", 400)
   }
 
+  const trimmed = query.trim()
   const accessToken = await getSpotifyClientToken()
-  if (!accessToken) return apiError("Spotify unavailable", 503)
+  if (!accessToken) {
+    console.error("[onboard-search] no client token — check SPOTIFY_CLIENT_ID/SECRET")
+    return apiError("Spotify unavailable", 503)
+  }
 
-  const result = await musicProvider.searchArtists(accessToken, query.trim())
+  const result = await musicProvider.searchArtists(accessToken, trimmed)
 
   if (!Array.isArray(result)) {
-    console.log(`[onboard-search] 429 query="${query.trim()}" retry-after=${result.retryAfterSec}s`)
+    const cached = await searchCachedArtists(trimmed)
+    console.log(
+      `[onboard-search] 429 query="${trimmed}" retry-after=${result.retryAfterSec}s ` +
+      `fallback-cache-n=${cached.length}`
+    )
+    if (cached.length > 0) {
+      return Response.json({ artists: cached, degraded: true })
+    }
     return apiError("Rate limited, try again in a moment", 429)
   }
 
+  console.log(`[onboard-search] q="${trimmed}" n=${result.length}`)
   return Response.json({ artists: result })
 }

--- a/components/onboarding/artist-search.tsx
+++ b/components/onboarding/artist-search.tsx
@@ -3,6 +3,23 @@
 import { useEffect, useRef, useState } from "react"
 import { Search, X } from "lucide-react"
 
+type SearchError =
+  | "unauth"
+  | "rate-limited"
+  | "unavailable"
+  | "network"
+  | "unknown"
+
+function errorMessage(kind: SearchError): string {
+  switch (kind) {
+    case "unauth": return "Please sign in again to search artists"
+    case "rate-limited": return "Too many searches — try again in a few seconds"
+    case "unavailable": return "Search is temporarily unavailable"
+    case "network": return "Network error — check your connection"
+    case "unknown": return "Couldn't search — try again"
+  }
+}
+
 export interface SpotifyArtist {
   id: string
   name: string
@@ -23,26 +40,51 @@ export function ArtistSearch({ selected, onAdd, onRemove, cap, minForHint = 3 }:
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<SpotifyArtist[]>([])
   const [searching, setSearching] = useState(false)
+  const [error, setError] = useState<SearchError | null>(null)
+  const [degraded, setDegraded] = useState(false)
   const debounceRef = useRef<NodeJS.Timeout | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current)
-    if (!query.trim()) { setResults([]); return }
+    abortRef.current?.abort()
+    if (!query.trim()) { setResults([]); setError(null); setDegraded(false); return }
 
     debounceRef.current = setTimeout(async () => {
+      const aborter = new AbortController()
+      abortRef.current = aborter
       setSearching(true)
+      setError(null)
       try {
-        const res = await fetch(`/api/onboarding/search?q=${encodeURIComponent(query.trim())}`)
+        const res = await fetch(
+          `/api/onboarding/search?q=${encodeURIComponent(query.trim())}`,
+          { signal: aborter.signal },
+        )
         if (res.ok) {
           const data = await res.json()
           setResults(data.artists ?? [])
+          setDegraded(!!data.degraded)
+          return
         }
+        setDegraded(false)
+        console.error("[artist-search]", res.status)
+        if (res.status === 401) setError("unauth")
+        else if (res.status === 429) setError("rate-limited")
+        else if (res.status === 503) setError("unavailable")
+        else setError("unknown")
+      } catch (err) {
+        if ((err as { name?: string } | null)?.name === "AbortError") return
+        console.error("[artist-search] network", err)
+        setError("network")
       } finally {
         setSearching(false)
       }
     }, 350)
 
-    return () => { if (debounceRef.current) clearTimeout(debounceRef.current) }
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      abortRef.current?.abort()
+    }
   }, [query])
 
   const selectedIds = new Set(selected.map((a) => a.id))
@@ -80,8 +122,22 @@ export function ArtistSearch({ selected, onAdd, onRemove, cap, minForHint = 3 }:
           style={{ paddingLeft: 32 }}
         />
       </div>
-      {searching && (
+      {searching && !error && (
         <div className="mono muted" style={{ fontSize: 11 }}>Searching…</div>
+      )}
+      {error && (
+        <div
+          className="mono"
+          style={{ fontSize: 11, color: "var(--danger, #f87171)" }}
+          role="alert"
+        >
+          {errorMessage(error)}
+        </div>
+      )}
+      {!error && degraded && results.length > 0 && (
+        <div className="mono muted" style={{ fontSize: 11 }}>
+          Showing cached results — live search is rate-limited
+        </div>
       )}
       {results.length > 0 && (
         <div

--- a/lib/spotify-client-token.ts
+++ b/lib/spotify-client-token.ts
@@ -9,11 +9,18 @@
 let cachedToken: string | null = null
 let tokenExpiresAt = 0
 let inFlight: Promise<string | null> | null = null
+let loggedMissingCreds = false
 
 async function fetchToken(): Promise<string | null> {
   const clientId = process.env.SPOTIFY_CLIENT_ID
   const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-  if (!clientId || !clientSecret) return null
+  if (!clientId || !clientSecret) {
+    if (!loggedMissingCreds) {
+      console.error("[spotify-client-token] SPOTIFY_CLIENT_ID or SPOTIFY_CLIENT_SECRET is missing")
+      loggedMissingCreds = true
+    }
+    return null
+  }
 
   const res = await fetch("https://accounts.spotify.com/api/token", {
     method: "POST",


### PR DESCRIPTION
## Summary

- Users reported *"artist search isn't working at all"*. Root cause: the UI silently swallowed every non-OK response from `/api/onboarding/search` — a 401, 429, 503, or network error all looked identical (a brief "Searching…" then nothing).
- Spotify client-credentials quota is actively rate-limited in production (observed `retry-after` up to ~19 min), so a large fraction of real searches hit 429.
- This PR surfaces the errors, adds server-side diagnostics, and falls back to the existing `artist_search_cache` table on 429 so most searches return results even when Spotify throttles us.

## Changes

- **`components/onboarding/artist-search.tsx`**
  - Typed error states (`unauth` / `rate-limited` / `unavailable` / `network` / `unknown`) with inline red messages under the input.
  - `AbortController` to cancel stale in-flight requests on new keystrokes.
  - Console breadcrumb (`[artist-search] <status>`) for debuggability.
  - Renders *"Showing cached results — live search is rate-limited"* hint when the server responds with `{ degraded: true }`.
- **`app/api/onboarding/search/route.ts`**
  - Structured logs: `[onboard-search] unauth` / `no client token` / `q="…" n=<count>` / `429 query="…" retry-after=<s>s fallback-cache-n=<n>`.
  - On Spotify 429, prefix-ILIKE the cached query against `artist_search_cache.name_lower` and return `{ artists, degraded: true }` if ≥ 1 row matches. Falls through to 429 only when the cache is empty for that prefix.
  - `escapeIlike()` helper to prevent `%`/`_`/`\` in user input from turning into wildcards.
- **`lib/spotify-client-token.ts`**
  - One-shot `console.error("[spotify-client-token] … missing")` when `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` is absent, so env-var regressions are visible in logs instead of silently returning 503.

## Verification

Verified locally against live Spotify 429s:

```
[onboard-search] 429 query="radiohead"    retry-after=168s fallback-cache-n=1
[onboard-search] 429 query="vertilizar"   retry-after=167s fallback-cache-n=1
[onboard-search] 429 query="miauthamine"  retry-after=166s fallback-cache-n=1
```

API responses: status `200` with `degraded: true` + cached artists.
UI: inline "Showing cached results — live search is rate-limited" hint renders above the result row; artist is clickable for selection.

## Test plan

- [ ] `/onboarding` → "Artists I like" → search a common artist (e.g. `radiohead`) — expect results within ~400 ms.
- [ ] `/settings` → Taste anchors → Artists — same behavior.
- [ ] Simulate missing creds (unset `SPOTIFY_CLIENT_ID` in `.env.local`, restart) — expect inline *"Search is temporarily unavailable"* + `[spotify-client-token] … missing` server log.
- [ ] Simulate 429 with empty cache (query with a string unlikely to be in cache, e.g. `zzqrandom`) — expect inline *"Too many searches — try again in a few seconds"*.
- [ ] Simulate 429 with cache hit — expect inline *"Showing cached results"* hint + cached row rendered.
- [ ] Sign out and `curl /api/onboarding/search?q=foo` — expect 401 + `[onboard-search] unauth` server log.
- [ ] Block `/api/onboarding/search` in DevTools — expect *"Network error — check your connection"*.
- [ ] Preview deploy: confirm `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` exist in Preview env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)