### PR TITLE
Explore prewarm + tabbar pill + graph/card polish

### DIFF
--- a/app/(app)/explore/page.tsx
+++ b/app/(app)/explore/page.tsx
@@ -6,6 +6,7 @@ import { getSpotifyClientToken } from "@/lib/spotify-client-token"
 import {
   buildExploreRails,
   RAIL_META_KEY,
+  type HydratedRailArtist,
   type RailKey,
   type RailWhy,
 } from "@/lib/recommendation/explore-engine"
@@ -25,15 +26,6 @@ import {
   ensureWeeklyChallenge,
 } from "@/lib/challenges/engine"
 import ExploreLoading from "./loading"
-
-interface ArtistData {
-  id: string
-  name: string
-  genres?: string[]
-  imageUrl?: string | null
-  popularity?: number
-  artist_color?: string | null
-}
 
 const RAIL_TITLES: Record<RailKey, { title: string; subtitle: string; empty: string }> = {
   adjacent: {
@@ -125,31 +117,16 @@ async function ExploreRailsSection({
 }: RailsSectionProps) {
   const supabase = createServiceClient()
 
-  // Rails + challenge are independent — fire them in parallel. The challenge
-  // load is best-effort; its failure is swallowed so it cannot block the page.
+  // Rails (now including hydrated artists) + challenge fire in parallel. The
+  // hydration used to run as a serial DB roundtrip after the rails resolved;
+  // it now runs inside buildExploreRails alongside the cache upsert, so it
+  // also runs in parallel with loadChallenge here.
   const [buildResult, challenge] = await Promise.all([
-    buildExploreRails({ userId, accessToken, adventurous }),
+    buildExploreRails({ userId, accessToken, adventurous }, { hydrate: true }),
     loadChallenge(supabase, userId),
   ])
-  const { rails } = buildResult
-
-  // Hydrate artist IDs into full Artist records for the UI. Needs rail data.
-  const allIds = Array.from(new Set(rails.flatMap((r) => r.artistIds)))
-  const artistById = new Map<string, ArtistData>()
-  if (allIds.length > 0) {
-    const { data: rows } = await supabase
-      .from("artist_search_cache")
-      .select("spotify_artist_id, artist_data, artist_color")
-      .in("spotify_artist_id", allIds)
-    for (const row of rows ?? []) {
-      const a = (row.artist_data ?? {}) as ArtistData
-      artistById.set(row.spotify_artist_id as string, {
-        ...a,
-        id: row.spotify_artist_id as string,
-        artist_color: (row.artist_color as string | null) ?? null,
-      })
-    }
-  }
+  const { rails, hydrated } = buildResult
+  const artistById: Map<string, HydratedRailArtist> = hydrated ?? new Map()
 
   function hydrate(ids: string[], why: Record<string, RailWhy>): RailArtist[] {
     const out: RailArtist[] = []

--- a/app/(app)/feed/page.tsx
+++ b/app/(app)/feed/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation"
 import { auth } from "@/lib/auth"
 import { createServiceClient } from "@/lib/supabase/server"
 import { FeedClient } from "@/components/feed/feed-client"
+import { ExplorePrewarm } from "@/components/feed/explore-prewarm"
 import { RecommendationsLoader } from "@/components/feed/recommendations-loader"
 import { DEFAULT_MUSIC_PLATFORM, isMusicPlatform, type MusicPlatform } from "@/lib/music-links"
 
@@ -98,7 +99,12 @@ export default async function FeedPage() {
 
   // No valid recommendations — client component triggers generation and refreshes
   if (validRecs.length === 0) {
-    return <RecommendationsLoader />
+    return (
+      <>
+        <RecommendationsLoader />
+        <ExplorePrewarm />
+      </>
+    )
   }
 
   // Fetch tracks for the recommendations
@@ -127,5 +133,10 @@ export default async function FeedPage() {
   ])
   const signalCount = (artistCount ?? 0) + (feedbackCount ?? 0) + (saveCount ?? 0)
 
-  return <FeedClient recommendations={interleave(recsWithColor)} musicPlatform={musicPlatform} signalCount={signalCount} />
+  return (
+    <>
+      <FeedClient recommendations={interleave(recsWithColor)} musicPlatform={musicPlatform} signalCount={signalCount} />
+      <ExplorePrewarm />
+    </>
+  )
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation"
 import { safeAuth } from "@/lib/auth"
+import { createServiceClient } from "@/lib/supabase/server"
 import { AppNav } from "@/components/nav/app-nav"
 import { AudioProvider } from "@/lib/audio-context"
 import { MiniPlayer } from "@/components/player/mini-player"
@@ -16,11 +17,19 @@ export default async function AppLayout({
   // Seed the identicon from user ID (deterministic, not PII)
   const userSeed = session.user.id
 
+  const supabase = createServiceClient()
+  const { data: userRow } = await supabase
+    .from("users")
+    .select("adventurous")
+    .eq("id", session.user.id)
+    .maybeSingle()
+  const initialAdventurous = !!userRow?.adventurous
+
   return (
     <NavigationProgressProvider>
       <AudioProvider>
         <div className="app">
-          <AppNav userSeed={userSeed} />
+          <AppNav userSeed={userSeed} initialAdventurous={initialAdventurous} />
           <main className="app-main">
             <div className="app-col">{children}</div>
           </main>

--- a/app/api/explore/preload/route.ts
+++ b/app/api/explore/preload/route.ts
@@ -1,0 +1,45 @@
+import { auth } from "@/lib/auth"
+import { createServiceClient } from "@/lib/supabase/server"
+import { apiError, apiUnauthorized } from "@/lib/errors"
+import { getAccessToken } from "@/lib/get-access-token"
+import { getSpotifyClientToken } from "@/lib/spotify-client-token"
+import { buildExploreRails } from "@/lib/recommendation/explore-engine"
+import type { NextRequest } from "next/server"
+
+/**
+ * Background warm for the Explore page. Triggered from the Feed page while the
+ * user is viewing it, so that when they tap Explore the rails + artist cache
+ * are already populated. Read-only from the client's POV — the response body
+ * is just `{ ok: true }`; the value is the side-effect of populating
+ * `explore_cache` and `artist_search_cache`.
+ */
+export async function GET(req: NextRequest): Promise<Response> {
+  const session = await auth()
+  if (!session?.user?.id) return apiUnauthorized()
+
+  const userId = session.user.id
+  const supabase = createServiceClient()
+
+  const [{ data: user, error: userError }, userAccessToken] = await Promise.all([
+    supabase.from("users").select("id, adventurous").eq("id", userId).maybeSingle(),
+    getAccessToken(req),
+  ])
+  if (userError || !user) return apiError("User not found", 404)
+
+  const accessToken = userAccessToken ?? (await getSpotifyClientToken()) ?? ""
+
+  try {
+    await buildExploreRails(
+      {
+        userId: user.id,
+        accessToken,
+        adventurous: user.adventurous ?? false,
+      },
+      { hydrate: true },
+    )
+    return Response.json({ ok: true })
+  } catch (err) {
+    console.error("[explore/preload] fail", err instanceof Error ? err.message : err)
+    return apiError("Preload failed", 500)
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -177,15 +177,19 @@ body::after {
 /* ── Mobile bottom tab bar ─────────────────────────────────────── */
 .tabbar {
   position: fixed;
-  inset: auto 0 0 0;
-  height: 72px;
-  padding-bottom: env(safe-area-inset-bottom);
+  left: 12px;
+  right: 12px;
+  bottom: calc(12px + env(safe-area-inset-bottom));
+  height: 64px;
   background: rgba(8,8,8,0.85);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
-  border-top: 1px solid var(--border);
+  backdrop-filter: blur(18px) saturate(1.15);
+  -webkit-backdrop-filter: blur(18px) saturate(1.15);
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.35), 0 2px 8px rgba(0,0,0,0.25);
   display: flex;
   z-index: 50;
+  overflow: hidden;
 }
 .tabbar a {
   flex: 1;
@@ -201,8 +205,31 @@ body::after {
   letter-spacing: 0.04em;
   transition: color .2s var(--easing);
 }
-.tabbar a.active { color: var(--accent); }
+.tabbar a.active { color: var(--text-primary); }
 .tabbar a svg { width: 22px; height: 22px; }
+
+/* Adventurous-mode treatment: brighter glass + static rainbow ring drawn
+   via a pseudo-element so the 28px border-radius is preserved (border-image
+   does not follow border-radius). */
+.tabbar.adventurous {
+  backdrop-filter: blur(18px) saturate(1.5) brightness(1.08);
+  -webkit-backdrop-filter: blur(18px) saturate(1.5) brightness(1.08);
+  overflow: visible;
+}
+.tabbar.adventurous::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 2px;
+  background: linear-gradient(90deg, #f5b047, #ec6fb5, #7dd9c6, #a8c7fa);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+          mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  pointer-events: none;
+}
+
 /* Very narrow viewports (< 360px, i.e. iPhone SE & smaller): shrink labels so
    nothing clips. 6 tabs at ~53px each can't comfortably fit "Settings" at 11px. */
 @media (max-width: 359px) {
@@ -212,11 +239,11 @@ body::after {
 @media (min-width: 900px) { .tabbar { display: none; } }
 
 /* Mini-player pill — lift above the bottom tabbar on mobile so controls
-   and tab labels don't overlap. On desktop the tabbar is hidden so the
-   pill can sit at the usual float offset. */
+   and tab labels don't overlap. The tabbar is now a floating pill with
+   12px top + bottom margins, so total vertical footprint is 64 + 24 = 88. */
 @media (max-width: 899px) {
   .mini-player-pill {
-    bottom: calc(72px + env(safe-area-inset-bottom)) !important;
+    bottom: calc(88px + env(safe-area-inset-bottom)) !important;
   }
 }
 

--- a/components/feed/artist-card.tsx
+++ b/components/feed/artist-card.tsx
@@ -246,23 +246,8 @@ export function ArtistCard({
           }}
         />
 
-        {/* Genre + name */}
+        {/* Name + genre */}
         <div style={{ position: "absolute", left: 24, right: 24, bottom: 20 }}>
-          {(artist_data.genres?.length ?? 0) > 0 && artist_data.genres?.[0] && (
-            <div
-              className="mono"
-              style={{
-                fontSize: 10.5,
-                fontWeight: 600,
-                letterSpacing: "0.2em",
-                textTransform: "uppercase",
-                color: artistColor,
-                marginBottom: 10,
-              }}
-            >
-              {artist_data.genres[0]} · popularity {artist_data.popularity}
-            </div>
-          )}
           <div
             className="display"
             style={{
@@ -274,6 +259,21 @@ export function ArtistCard({
           >
             {artist_data.name}
           </div>
+          {(artist_data.genres?.length ?? 0) > 0 && artist_data.genres?.[0] && (
+            <div
+              className="mono"
+              style={{
+                fontSize: 10.5,
+                fontWeight: 600,
+                letterSpacing: "0.2em",
+                textTransform: "uppercase",
+                color: artistColor,
+                marginTop: 10,
+              }}
+            >
+              {artist_data.genres[0]} · popularity {artist_data.popularity}
+            </div>
+          )}
         </div>
       </div>
 

--- a/components/feed/explore-prewarm.tsx
+++ b/components/feed/explore-prewarm.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+const SKIP_KEY = "explore-warmed-at"
+const SKIP_WINDOW_MS = 60_000
+
+/**
+ * Mounted inside the Feed tree. After the page has been visible for a beat,
+ * fires a background GET to /api/explore/preload so the Explore page's rails
+ * + artist hydration cache are warm before the user navigates. No-op if the
+ * same client warmed it within the last minute (session-scoped guard).
+ */
+export function ExplorePrewarm() {
+  const firedRef = useRef(false)
+
+  useEffect(() => {
+    if (firedRef.current) return
+    firedRef.current = true
+
+    try {
+      const last = sessionStorage.getItem(SKIP_KEY)
+      if (last && Date.now() - Number(last) < SKIP_WINDOW_MS) return
+    } catch {
+      // sessionStorage can throw in private mode; fall through and warm.
+    }
+
+    const warm = () => {
+      fetch("/api/explore/preload", { credentials: "include" })
+        .then((r) => {
+          if (r.ok) {
+            try {
+              sessionStorage.setItem(SKIP_KEY, String(Date.now()))
+            } catch {
+              // ignore
+            }
+          }
+        })
+        .catch(() => {})
+    }
+
+    const idle = (window as unknown as {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number
+    }).requestIdleCallback
+    if (typeof idle === "function") {
+      idle(warm, { timeout: 1500 })
+    } else {
+      const t = setTimeout(warm, 600)
+      return () => clearTimeout(t)
+    }
+  }, [])
+
+  return null
+}

--- a/components/nav/app-nav.tsx
+++ b/components/nav/app-nav.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { Music2, Bookmark, Settings, Clock, BarChart3, Compass } from "lucide-react"
@@ -7,22 +8,44 @@ import { IdenticonAvatar } from "@/components/ui/identicon-avatar"
 import { NavLinkStatus } from "@/components/nav/navigation-progress"
 
 const navLinks = [
-  { href: "/feed",     label: "Feed",     icon: Music2    },
-  { href: "/explore",  label: "Explore",  icon: Compass   },
-  { href: "/history",  label: "History",  icon: Clock     },
-  { href: "/saved",    label: "Saved",    icon: Bookmark  },
-  { href: "/stats",    label: "Stats",    icon: BarChart3 },
-  { href: "/settings", label: "Settings", icon: Settings  },
+  { href: "/feed",     label: "Feed",     icon: Music2,    color: "var(--accent)" },
+  { href: "/explore",  label: "Explore",  icon: Compass,   color: "#f5b047" },
+  { href: "/history",  label: "History",  icon: Clock,     color: "#7dd9c6" },
+  { href: "/saved",    label: "Saved",    icon: Bookmark,  color: "#ec6fb5" },
+  { href: "/stats",    label: "Stats",    icon: BarChart3, color: "#a8c7fa" },
+  { href: "/settings", label: "Settings", icon: Settings,  color: "#ff9e7a" },
 ]
 
 interface AppNavProps {
   userSeed?: string
+  initialAdventurous?: boolean
 }
 
-export function AppNav({ userSeed = "user" }: AppNavProps) {
+export function AppNav({ userSeed = "user", initialAdventurous = false }: AppNavProps) {
   const pathname = usePathname()
+  const [adventurous, setAdventurous] = useState(initialAdventurous)
+
+  useEffect(() => {
+    const read = () => {
+      try {
+        setAdventurous(localStorage.getItem("flipside.adventurous") === "1")
+      } catch {
+        // noop — private mode or blocked storage
+      }
+    }
+    read()
+    window.addEventListener("flipside:adventurous-change", read)
+    window.addEventListener("storage", read)
+    return () => {
+      window.removeEventListener("flipside:adventurous-change", read)
+      window.removeEventListener("storage", read)
+    }
+  }, [])
+
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(href + "/")
+
+  const tabbarClass = `tabbar${adventurous ? " adventurous" : ""}`
 
   return (
     <>
@@ -40,6 +63,7 @@ export function AppNav({ userSeed = "user" }: AppNavProps) {
             <Link
               key={href}
               href={href}
+              prefetch={href === "/explore" ? true : undefined}
               className={isActive(href) ? "active" : ""}
             >
               {label}
@@ -53,18 +77,22 @@ export function AppNav({ userSeed = "user" }: AppNavProps) {
       </header>
 
       {/* ── Mobile bottom tab bar (< 900px) ── */}
-      <nav className="tabbar">
-        {navLinks.map(({ href, label, icon: Icon }) => (
-          <Link
-            key={href}
-            href={href}
-            className={isActive(href) ? "active" : ""}
-          >
-            <Icon size={22} />
-            <span>{label}</span>
-            <NavLinkStatus />
-          </Link>
-        ))}
+      <nav className={tabbarClass}>
+        {navLinks.map(({ href, label, icon: Icon, color }) => {
+          const active = isActive(href)
+          return (
+            <Link
+              key={href}
+              href={href}
+              prefetch={href === "/explore" ? true : undefined}
+              className={active ? "active" : ""}
+            >
+              <Icon size={22} style={{ color }} />
+              <span>{label}</span>
+              <NavLinkStatus />
+            </Link>
+          )
+        })}
       </nav>
     </>
   )

--- a/components/settings/curve-preview.tsx
+++ b/components/settings/curve-preview.tsx
@@ -24,7 +24,8 @@ const svgX = (pop: number) => 20 + (pop / 100) * 360
 const svgY = (score: number) => 170 - score * 160
 
 export function CurvePreview({ popularityCurve, undergroundMode, adventurous, exampleArtists }: CurvePreviewProps) {
-  const lineColor = adventurous ? "#f5b047" : "var(--accent)"
+  const lineColor = "var(--accent)"
+  const dottedColor = adventurous ? "#f5b047" : "#a78bfa"
   const fillUrl = adventurous ? "url(#curvePreviewFillAdventurous)" : "url(#curvePreviewFill)"
 
   const { defaultPath, defaultFill, undergroundPath } = useMemo(() => {
@@ -66,11 +67,9 @@ export function CurvePreview({ popularityCurve, undergroundMode, adventurous, ex
               <stop offset="0%" stopColor="var(--accent)" stopOpacity="0.4" />
               <stop offset="100%" stopColor="var(--accent)" stopOpacity="0" />
             </linearGradient>
-            <linearGradient id="curvePreviewFillAdventurous" x1="0" y1="0" x2="1" y2="1">
-              <stop offset="0%" stopColor="#f5b047" stopOpacity="0.55" />
-              <stop offset="45%" stopColor="#ec6fb5" stopOpacity="0.42" />
-              <stop offset="80%" stopColor="#7dd9c6" stopOpacity="0.30" />
-              <stop offset="100%" stopColor="#a8c7fa" stopOpacity="0.18" />
+            <linearGradient id="curvePreviewFillAdventurous" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor="#f5b047" stopOpacity="0.4" />
+              <stop offset="100%" stopColor="#f5b047" stopOpacity="0" />
             </linearGradient>
             <pattern
               id="undergroundCutoff"
@@ -160,13 +159,13 @@ export function CurvePreview({ popularityCurve, undergroundMode, adventurous, ex
           <path
             d={undergroundPath}
             fill="none"
-            stroke="#a78bfa"
+            stroke={dottedColor}
             strokeWidth="2"
             strokeDasharray="4 4"
             strokeLinejoin="round"
             style={{
               opacity: undergroundMode ? 1 : 0,
-              transition: "opacity 0.4s ease, d 0.15s ease",
+              transition: "opacity 0.4s ease, d 0.15s ease, stroke 0.3s ease",
             }}
           />
 

--- a/lib/recommendation/explore-engine.ts
+++ b/lib/recommendation/explore-engine.ts
@@ -698,9 +698,42 @@ function hashString(s: string): number {
 
 // ── Orchestrator ────────────────────────────────────────────────────────────
 
+export interface HydratedRailArtist {
+  id: string
+  name: string
+  genres?: string[]
+  imageUrl?: string | null
+  popularity?: number
+  artist_color?: string | null
+}
+
 export interface BuildRailsResult {
   rails: RailResult[]
   cacheHit: boolean
+  /** Populated when `opts.hydrate === true`. Maps spotify_artist_id → cached artist record. */
+  hydrated?: Map<string, HydratedRailArtist>
+}
+
+async function hydrateRailArtists(
+  supabase: SupabaseClient,
+  rails: RailResult[],
+): Promise<Map<string, HydratedRailArtist>> {
+  const allIds = Array.from(new Set(rails.flatMap((r) => r.artistIds)))
+  const byId = new Map<string, HydratedRailArtist>()
+  if (allIds.length === 0) return byId
+  const { data: rows } = await supabase
+    .from('artist_search_cache')
+    .select('spotify_artist_id, artist_data, artist_color')
+    .in('spotify_artist_id', allIds)
+  for (const row of rows ?? []) {
+    const a = (row.artist_data ?? {}) as Omit<HydratedRailArtist, 'id' | 'artist_color'>
+    byId.set(row.spotify_artist_id as string, {
+      ...a,
+      id: row.spotify_artist_id as string,
+      artist_color: (row.artist_color as string | null) ?? null,
+    })
+  }
+  return byId
 }
 
 /**
@@ -709,10 +742,13 @@ export interface BuildRailsResult {
  * results, and returns them.
  *
  * `force = true` bypasses the cache (used by the Regenerate button).
+ * `hydrate = true` additionally resolves each rail's artist IDs against
+ * `artist_search_cache` and returns a `hydrated` Map, in parallel with the
+ * cache upsert so it doesn't add serial latency on cache misses.
  */
 export async function buildExploreRails(
   input: BuildRailsInput,
-  opts: { force?: boolean } = {},
+  opts: { force?: boolean; hydrate?: boolean } = {},
 ): Promise<BuildRailsResult> {
   const supabase = createServiceClient()
   const now = new Date()
@@ -725,14 +761,13 @@ export async function buildExploreRails(
       .gt('expires_at', now.toISOString())
 
     if (cached && cached.length === RAIL_KEYS.length) {
-      return {
-        cacheHit: true,
-        rails: cached.map((row) => ({
-          railKey: row.rail_key as RailKey,
-          artistIds: (row.artist_ids ?? []) as string[],
-          why: (row.why ?? {}) as Record<string, RailWhy>,
-        })),
-      }
+      const rails: RailResult[] = cached.map((row) => ({
+        railKey: row.rail_key as RailKey,
+        artistIds: (row.artist_ids ?? []) as string[],
+        why: (row.why ?? {}) as Record<string, RailWhy>,
+      }))
+      const hydrated = opts.hydrate ? await hydrateRailArtists(supabase, rails) : undefined
+      return { cacheHit: true, rails, hydrated }
     }
   }
 
@@ -791,15 +826,17 @@ export async function buildExploreRails(
     expires_at: expiresAt,
   }))
 
-  const { error } = await supabase
-    .from('explore_cache')
-    .upsert(rows, { onConflict: 'user_id,rail_key' })
+  // Upsert + hydration are independent — fire in parallel to save a roundtrip.
+  const [{ error }, hydrated] = await Promise.all([
+    supabase.from('explore_cache').upsert(rows, { onConflict: 'user_id,rail_key' }),
+    opts.hydrate ? hydrateRailArtists(supabase, rails) : Promise.resolve(undefined),
+  ])
 
   if (error) {
     console.error('[explore-engine] cache upsert failed', error.message)
   }
 
-  return { rails, cacheHit: false }
+  return { rails, cacheHit: false, hydrated }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Explore perf:** hoist artist hydration into `buildExploreRails` (removes a serial follow-up query on cold load), add explicit `prefetch={true}` on the Explorer nav link, and warm `explore_cache` in the background from Feed via a new `/api/explore/preload` endpoint + `<ExplorePrewarm />` client component (guarded by a 60s `sessionStorage` window so fast nav doesn't spam it).
- **Settings curve preview:** solid line + anchor circles now stay `var(--accent)` in all modes; the dotted underground line and the fill gradient switch to amber when Adventurous is on (previously the solid line was being recolored, and the fill was a four-stop rainbow).
- **Feed artist card:** swap header order so the artist name sits above the `GENRE · POPULARITY N` caption.
- **Mobile tabbar:** redesigned as a floating glass pill (28px radius, 64px tall, 12px side/bottom margins, soft shadow) with per-tab icon colors (Feed violet, Explore amber, History mint, Saved rose, Stats blue, Settings coral). Adventurous mode adds a static 4-stop rainbow border (via `::before` + `mask-composite: exclude` so the 28px radius is preserved) and brightens/saturates the glass. `.mini-player-pill` bottom offset updated to clear the new pill footprint.

## Test plan

- [ ] `/settings` on mobile: toggle Adventurous — solid curve + anchors stay purple, dotted underground line + fill become amber, EXCLUDED hatch stays purple.
- [ ] `/feed` on mobile: each artist card shows name first, then the uppercase genre · popularity caption below.
- [ ] Mobile tabbar renders as a floating pill with per-tab colors; toggling Adventurous from Settings adds a static rainbow ring + brighter glass, no animation.
- [ ] From `/feed`: verify `GET /api/explore/preload` fires after idle, and `sessionStorage["explore-warmed-at"]` is set. Second visit within 60s skips the warm.
- [ ] Desktop (≥ 900px): topnav unchanged, tabbar hidden, no per-tab color leakage.
- [ ] `pnpm typecheck && pnpm lint` (or repo equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)