### PR TITLE
Rail coverage + thumbs-up UX + post-release bug sweep

### DIFF
--- a/components/explore/explore-artist-row.tsx
+++ b/components/explore/explore-artist-row.tsx
@@ -72,7 +72,6 @@ export const ExploreArtistRow = memo(function ExploreArtistRow({
     [artist.id, onFeedback],
   )
   const recommendation = useMemo(() => railArtistToRecommendation(artist), [artist])
-  const isDismissed = dismissSignal !== null
 
   return (
     <motion.div
@@ -88,7 +87,6 @@ export const ExploreArtistRow = memo(function ExploreArtistRow({
         onSave={handleSave}
         onFeedback={handleFeedback}
         isSaved={isSaved}
-        isDismissed={isDismissed}
         dismissSignal={dismissSignal}
       />
     </motion.div>

--- a/components/explore/explore-client.tsx
+++ b/components/explore/explore-client.tsx
@@ -82,6 +82,9 @@ export function ExploreClient({
   const [dismissedSignals, setDismissedSignals] = useState<Map<string, string>>(new Map())
   const [savedIds, setSavedIds] = useState<Set<string>>(new Set(initialSavedIds))
   const saveQueueRef = useRef(createKeyedSerializer())
+  // Serialize feedback per artist so rapid like/unlike taps don't race
+  // POST and DELETE against each other on the server.
+  const feedbackQueueRef = useRef(createKeyedSerializer())
   const [isRegenerating, setIsRegenerating] = useState(false)
   const [adventurous, setAdventurous] = useState(initialAdventurous)
   const [isTogglingAdv, setIsTogglingAdv] = useState(false)
@@ -153,47 +156,51 @@ export function ExploreClient({
   const dismissedSignalsRef = useRef(dismissedSignals)
   dismissedSignalsRef.current = dismissedSignals
 
-  const handleFeedback = useCallback(async (artistId: string, signal: string) => {
-    const currentSignal = dismissedSignalsRef.current.get(artistId)
+  const handleFeedback = useCallback((artistId: string, signal: string) => {
+    return feedbackQueueRef.current(artistId, async () => {
+      const currentSignal = dismissedSignalsRef.current.get(artistId)
 
-    // Thumbs-up toggle: tapping 'Liked' again un-likes via DELETE.
-    if (signal === "thumbs_up" && currentSignal === "thumbs_up") {
-      setDismissedSignals((prev) => {
-        const n = new Map(prev)
-        n.delete(artistId)
-        return n
-      })
-      try {
-        const res = await fetch(`/api/feedback/${encodeURIComponent(artistId)}`, { method: "DELETE" })
-        if (!res.ok && res.status !== 204) throw new Error("server")
-      } catch {
-        setDismissedSignals((prev) => new Map(prev).set(artistId, "thumbs_up"))
-        toast.error("Couldn't undo — try again")
+      // Thumbs-up toggle: tapping 'Liked' again un-likes via DELETE. Migration
+      // 0033 leaves seen_at set, so the card still won't return on next
+      // refresh — undo is session-only.
+      if (signal === "thumbs_up" && currentSignal === "thumbs_up") {
+        setDismissedSignals((prev) => {
+          const n = new Map(prev)
+          n.delete(artistId)
+          return n
+        })
+        try {
+          const res = await fetch(`/api/feedback/${encodeURIComponent(artistId)}`, { method: "DELETE" })
+          if (!res.ok && res.status !== 204) throw new Error("server")
+        } catch {
+          setDismissedSignals((prev) => new Map(prev).set(artistId, "thumbs_up"))
+          toast.error("Couldn't undo — try again")
+        }
+        return
       }
-      return
-    }
 
-    setDismissedSignals((prev) => new Map(prev).set(artistId, signal))
-    // "skip" is local-only in Explore — no server call, no recommendation_cache write.
-    if (signal !== "thumbs_up" && signal !== "thumbs_down") return
-    try {
-      const res = await fetch("/api/feedback", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        // railKey lets the server narrow-invalidate only the owning rail; other
-        // rails pick up the signal on their own TTL via the persisted feedback row.
-        body: JSON.stringify({ spotifyArtistId: artistId, signal, railKey: activeKey }),
-      })
-      if (!res.ok) throw new Error("server")
-    } catch {
-      setDismissedSignals((prev) => {
-        const n = new Map(prev)
-        if (currentSignal === undefined) n.delete(artistId)
-        else n.set(artistId, currentSignal)
-        return n
-      })
-      toast.error("Couldn't save feedback — try again")
-    }
+      setDismissedSignals((prev) => new Map(prev).set(artistId, signal))
+      // "skip" is local-only in Explore — no server call, no recommendation_cache write.
+      if (signal !== "thumbs_up" && signal !== "thumbs_down") return
+      try {
+        const res = await fetch("/api/feedback", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          // railKey lets the server narrow-invalidate only the owning rail; other
+          // rails pick up the signal on their own TTL via the persisted feedback row.
+          body: JSON.stringify({ spotifyArtistId: artistId, signal, railKey: activeKey }),
+        })
+        if (!res.ok) throw new Error("server")
+      } catch {
+        setDismissedSignals((prev) => {
+          const n = new Map(prev)
+          if (currentSignal === undefined) n.delete(artistId)
+          else n.set(artistId, currentSignal)
+          return n
+        })
+        toast.error("Couldn't save feedback — try again")
+      }
+    })
   }, [activeKey])
 
   // Ref lets handleSave stay identity-stable across saves — otherwise every

--- a/components/explore/explore-client.tsx
+++ b/components/explore/explore-client.tsx
@@ -150,7 +150,29 @@ export function ExploreClient({
     [orderedRails, activeKey],
   )
 
+  const dismissedSignalsRef = useRef(dismissedSignals)
+  dismissedSignalsRef.current = dismissedSignals
+
   const handleFeedback = useCallback(async (artistId: string, signal: string) => {
+    const currentSignal = dismissedSignalsRef.current.get(artistId)
+
+    // Thumbs-up toggle: tapping 'Liked' again un-likes via DELETE.
+    if (signal === "thumbs_up" && currentSignal === "thumbs_up") {
+      setDismissedSignals((prev) => {
+        const n = new Map(prev)
+        n.delete(artistId)
+        return n
+      })
+      try {
+        const res = await fetch(`/api/feedback/${encodeURIComponent(artistId)}`, { method: "DELETE" })
+        if (!res.ok && res.status !== 204) throw new Error("server")
+      } catch {
+        setDismissedSignals((prev) => new Map(prev).set(artistId, "thumbs_up"))
+        toast.error("Couldn't undo — try again")
+      }
+      return
+    }
+
     setDismissedSignals((prev) => new Map(prev).set(artistId, signal))
     // "skip" is local-only in Explore — no server call, no recommendation_cache write.
     if (signal !== "thumbs_up" && signal !== "thumbs_down") return
@@ -166,7 +188,8 @@ export function ExploreClient({
     } catch {
       setDismissedSignals((prev) => {
         const n = new Map(prev)
-        n.delete(artistId)
+        if (currentSignal === undefined) n.delete(artistId)
+        else n.set(artistId, currentSignal)
         return n
       })
       toast.error("Couldn't save feedback — try again")

--- a/components/feed/artist-card.tsx
+++ b/components/feed/artist-card.tsx
@@ -47,8 +47,16 @@ export interface ArtistCardProps {
   musicPlatform: MusicPlatform
   onSave: () => void
   onFeedback: (signal: string) => void
-  isDismissed?: boolean
   isSaved?: boolean
+  /**
+   * Last signal received for this artist. Drives both the collapsed dismiss
+   * state and the in-place "Liked" affordance:
+   *   - null           → expanded card, default buttons
+   *   - "thumbs_up"    → expanded card, green outline + "Liked" button (keep playing)
+   *   - "thumbs_down"  → collapsed 56px bar, red-tinted "Passed"
+   *   - "skip"         → collapsed 56px bar, neutral "Maybe later"
+   *   - "saved"        → collapsed 56px bar, accent "Saved"
+   */
   dismissSignal?: string | null
 }
 
@@ -56,15 +64,22 @@ export interface ArtistCardProps {
 // Component
 // ---------------------------------------------------------------------------
 
+// Collapse the card for thumbs_down / skip / saved, but NOT thumbs_up — we
+// keep the card visible after a like so the user can keep listening.
+function signalCollapses(signal: string | null | undefined): boolean {
+  return signal != null && signal !== "thumbs_up"
+}
+
 function ArtistCardImpl({
   recommendation,
   musicPlatform,
   onSave,
   onFeedback,
-  isDismissed = false,
   isSaved = false,
   dismissSignal = null,
 }: ArtistCardProps) {
+  const isLiked = dismissSignal === "thumbs_up"
+  const isCollapsed = signalCollapses(dismissSignal)
   const { artist_data, why, artist_color } = recommendation
   const artistColor = useMemo(() => {
     const c = sanitizeHex(artist_color)
@@ -133,14 +148,15 @@ function ArtistCardImpl({
         : null
 
   // ------------------------------------------------------------------
-  // Collapsed (slim bar) state — no emoji, colour-coded labels
+  // Collapsed (slim bar) state — no emoji, colour-coded labels. Only applies
+  // to thumbs_down / skip / saved. Thumbs_up keeps the card expanded below so
+  // the user can keep listening after liking.
   // ------------------------------------------------------------------
-  if (isDismissed) {
-    const labelMap: Record<string, { text: string; color: string }> = {
-      thumbs_up:   { text: "Liked",       color: "var(--like)"     },
-      thumbs_down: { text: "Passed",      color: "var(--dislike)"  },
-      skip:        { text: "Maybe later", color: "var(--text-muted)" },
-      saved:       { text: "Saved",       color: "var(--accent)"   },
+  if (isCollapsed) {
+    const labelMap: Record<string, { text: string; color: string; border: string }> = {
+      thumbs_down: { text: "Passed",      color: "var(--dislike)",    border: "rgba(255,75,75,0.35)" },
+      skip:        { text: "Maybe later", color: "var(--text-muted)", border: "var(--border)" },
+      saved:       { text: "Saved",       color: "var(--accent)",     border: "rgba(139,92,246,0.35)" },
     }
     const signal = labelMap[dismissSignal ?? "skip"] ?? labelMap.skip
 
@@ -154,7 +170,7 @@ function ArtistCardImpl({
         style={{
           padding: "14px 18px",
           background: "rgba(15,15,15,0.6)",
-          border: "1px solid var(--border)",
+          border: `1px solid ${signal.border}`,
           borderRadius: 16,
           display: "flex",
           alignItems: "center",
@@ -182,7 +198,9 @@ function ArtistCardImpl({
   }
 
   // ------------------------------------------------------------------
-  // Expanded hero card
+  // Expanded hero card (also rendered after thumbs_up — card stays visible so
+  // the user can keep playing tracks. The 'liked' affordance is a subtle green
+  // outline + glow + the + More like this button swapping to ✓ Liked.)
   // ------------------------------------------------------------------
   return (
     <motion.div
@@ -198,8 +216,13 @@ function ArtistCardImpl({
         background: "rgba(15,15,15,0.65)",
         backdropFilter: "blur(30px)",
         WebkitBackdropFilter: "blur(30px)",
-        border: "1px solid rgba(255,255,255,0.08)",
-        boxShadow: "0 30px 80px rgba(0,0,0,0.55)",
+        border: isLiked
+          ? "2px solid rgba(34,197,94,0.55)"
+          : "1px solid rgba(255,255,255,0.08)",
+        boxShadow: isLiked
+          ? "0 0 0 4px rgba(34,197,94,0.12), 0 30px 80px rgba(0,0,0,0.55)"
+          : "0 30px 80px rgba(0,0,0,0.55)",
+        transition: "border-color 0.25s ease, box-shadow 0.25s ease",
       }}
     >
       {/* Hero image */}
@@ -410,6 +433,7 @@ function ArtistCardImpl({
             </button>
             <button
               onClick={() => onFeedback("thumbs_up")}
+              aria-pressed={isLiked}
               className="btn"
               style={{
                 flex: 1.2,
@@ -417,14 +441,21 @@ function ArtistCardImpl({
                 fontSize: 13,
                 whiteSpace: "nowrap",
                 color: "var(--like)",
-                background: "rgba(34,197,94,0.07)",
-                borderColor: "rgba(34,197,94,0.22)",
+                background: isLiked ? "rgba(34,197,94,0.22)" : "rgba(34,197,94,0.07)",
+                borderColor: isLiked ? "rgba(34,197,94,0.55)" : "rgba(34,197,94,0.22)",
+                fontWeight: isLiked ? 700 : undefined,
               }}
             >
-              <span className="mono" style={{ fontSize: 13, fontWeight: 700 }}>
-                +
-              </span>{" "}
-              More like this
+              {isLiked ? (
+                <>
+                  <Check size={15} strokeWidth={2.5} /> Liked
+                </>
+              ) : (
+                <>
+                  <span className="mono" style={{ fontSize: 13, fontWeight: 700 }}>+</span>{" "}
+                  More like this
+                </>
+              )}
             </button>
           </div>
         </div>

--- a/components/feed/feed-client.tsx
+++ b/components/feed/feed-client.tsx
@@ -80,7 +80,33 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
 
   const sequence = useMemo(() => buildSequence(recommendations), [recommendations])
 
+  // Ref mirrors dismissedSignals so handleFeedback can read the current state
+  // without re-creating its identity on every dismiss (preserves FeedCardRow
+  // memoization).
+  const dismissedSignalsRef = useRef(dismissedSignals)
+  dismissedSignalsRef.current = dismissedSignals
+
   const handleFeedback = useCallback(async (artistId: string, signal: string) => {
+    // Thumbs-up toggle: if already liked, tapping again un-likes (soft-deletes
+    // the feedback row via rpc_delete_feedback). seen_at stays set so the card
+    // still won't return on next refresh — undo is session-only.
+    const currentSignal = dismissedSignalsRef.current.get(artistId)
+    if (signal === "thumbs_up" && currentSignal === "thumbs_up") {
+      setDismissedSignals((prev) => {
+        const next = new Map(prev)
+        next.delete(artistId)
+        return next
+      })
+      try {
+        const res = await fetch(`/api/feedback/${encodeURIComponent(artistId)}`, { method: "DELETE" })
+        if (!res.ok && res.status !== 204) throw new Error("Server error")
+      } catch {
+        setDismissedSignals((prev) => new Map(prev).set(artistId, "thumbs_up"))
+        toast.error("Couldn't undo — try again")
+      }
+      return
+    }
+
     setDismissedSignals((prev) => new Map(prev).set(artistId, signal))
     try {
       const res = await fetch("/api/feedback", {
@@ -92,7 +118,8 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
     } catch {
       setDismissedSignals((prev) => {
         const next = new Map(prev)
-        next.delete(artistId)
+        if (currentSignal === undefined) next.delete(artistId)
+        else next.set(artistId, currentSignal)
         return next
       })
       toast.error("Couldn't save feedback — try again")
@@ -192,7 +219,6 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
               rec={rec}
               musicPlatform={musicPlatform}
               isSaved={savedIds.has(id)}
-              isDismissed={dismissedSignals.has(id)}
               dismissSignal={dismissedSignals.get(id) ?? null}
               onSaveAction={handleSave}
               onFeedbackAction={handleFeedback}
@@ -222,7 +248,6 @@ interface FeedCardRowProps {
   rec: Recommendation
   musicPlatform: MusicPlatform
   isSaved: boolean
-  isDismissed: boolean
   dismissSignal: string | null
   onSaveAction: (artistId: string) => Promise<void> | void
   onFeedbackAction: (artistId: string, signal: string) => Promise<void> | void
@@ -232,7 +257,6 @@ const FeedCardRow = memo(function FeedCardRow({
   rec,
   musicPlatform,
   isSaved,
-  isDismissed,
   dismissSignal,
   onSaveAction,
   onFeedbackAction,
@@ -245,7 +269,6 @@ const FeedCardRow = memo(function FeedCardRow({
       recommendation={rec}
       musicPlatform={musicPlatform}
       isSaved={isSaved}
-      isDismissed={isDismissed}
       dismissSignal={dismissSignal}
       onSave={onSave}
       onFeedback={onFeedback}

--- a/components/feed/feed-client.tsx
+++ b/components/feed/feed-client.tsx
@@ -70,6 +70,10 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
   // before the first render commits. The ref blocks the second call instantly.
   const isGeneratingRef = useRef(false)
   const saveQueueRef = useRef(createKeyedSerializer())
+  // Mirror queue for feedback so rapid taps on the same artist (like → unlike
+  // → like) serialize on the server. Without this, DELETE and POST can race
+  // and the final server state can disagree with the user's last intent.
+  const feedbackQueueRef = useRef(createKeyedSerializer())
   const router = useRouter()
 
   const palette = `
@@ -86,44 +90,50 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
   const dismissedSignalsRef = useRef(dismissedSignals)
   dismissedSignalsRef.current = dismissedSignals
 
-  const handleFeedback = useCallback(async (artistId: string, signal: string) => {
-    // Thumbs-up toggle: if already liked, tapping again un-likes (soft-deletes
-    // the feedback row via rpc_delete_feedback). seen_at stays set so the card
-    // still won't return on next refresh — undo is session-only.
-    const currentSignal = dismissedSignalsRef.current.get(artistId)
-    if (signal === "thumbs_up" && currentSignal === "thumbs_up") {
-      setDismissedSignals((prev) => {
-        const next = new Map(prev)
-        next.delete(artistId)
-        return next
-      })
-      try {
-        const res = await fetch(`/api/feedback/${encodeURIComponent(artistId)}`, { method: "DELETE" })
-        if (!res.ok && res.status !== 204) throw new Error("Server error")
-      } catch {
-        setDismissedSignals((prev) => new Map(prev).set(artistId, "thumbs_up"))
-        toast.error("Couldn't undo — try again")
+  const handleFeedback = useCallback((artistId: string, signal: string) => {
+    // Serialize per-artist so rapid like/unlike taps hit the server in order;
+    // otherwise POST and DELETE can interleave and the final server state
+    // won't match the user's last intent. Same pattern as handleSave above.
+    return feedbackQueueRef.current(artistId, async () => {
+      // Thumbs-up toggle: if already liked, tapping again un-likes
+      // (soft-deletes the feedback row via rpc_delete_feedback). Migration
+      // 0033 leaves seen_at set, so the card still won't return on next
+      // refresh — undo is session-only.
+      const currentSignal = dismissedSignalsRef.current.get(artistId)
+      if (signal === "thumbs_up" && currentSignal === "thumbs_up") {
+        setDismissedSignals((prev) => {
+          const next = new Map(prev)
+          next.delete(artistId)
+          return next
+        })
+        try {
+          const res = await fetch(`/api/feedback/${encodeURIComponent(artistId)}`, { method: "DELETE" })
+          if (!res.ok && res.status !== 204) throw new Error("Server error")
+        } catch {
+          setDismissedSignals((prev) => new Map(prev).set(artistId, "thumbs_up"))
+          toast.error("Couldn't undo — try again")
+        }
+        return
       }
-      return
-    }
 
-    setDismissedSignals((prev) => new Map(prev).set(artistId, signal))
-    try {
-      const res = await fetch("/api/feedback", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ spotifyArtistId: artistId, signal }),
-      })
-      if (!res.ok) throw new Error("Server error")
-    } catch {
-      setDismissedSignals((prev) => {
-        const next = new Map(prev)
-        if (currentSignal === undefined) next.delete(artistId)
-        else next.set(artistId, currentSignal)
-        return next
-      })
-      toast.error("Couldn't save feedback — try again")
-    }
+      setDismissedSignals((prev) => new Map(prev).set(artistId, signal))
+      try {
+        const res = await fetch("/api/feedback", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ spotifyArtistId: artistId, signal }),
+        })
+        if (!res.ok) throw new Error("Server error")
+      } catch {
+        setDismissedSignals((prev) => {
+          const next = new Map(prev)
+          if (currentSignal === undefined) next.delete(artistId)
+          else next.set(artistId, currentSignal)
+          return next
+        })
+        toast.error("Couldn't save feedback — try again")
+      }
+    })
   }, [])
 
   async function handleGenerateMore() {

--- a/lib/recommendation/explore-engine.ts
+++ b/lib/recommendation/explore-engine.ts
@@ -273,8 +273,12 @@ async function loadSeenIds(supabase: SupabaseClient, userId: string): Promise<Se
 
 const AFTERHOURS_TARGET = 10
 const AFTERHOURS_TARGET_ADVENTUROUS = 12
-const AFTERHOURS_PER_TAG = 4
-const AFTERHOURS_PICK_COUNT = 6
+// Larger pool to keep the rail robust for users with thin signal state: mood
+// tags often return only 2-4 artists on Last.fm, and listened/seen filters
+// drop more. 10 tags × 6 per tag = 60 theoretical candidates — enough that the
+// rail reliably clears the MIN_PICKS=5 floor after attrition.
+const AFTERHOURS_PER_TAG = 6
+const AFTERHOURS_PICK_COUNT = 10
 
 // Mood tags for the After Hours rail — late-night / ambient / atmospheric.
 // Rotated per user per week so pickups feel fresh without thrashing. Broad
@@ -369,8 +373,12 @@ export async function adjacentRail(
 
 const OUTSIDE_TARGET = 10
 const OUTSIDE_TARGET_ADVENTUROUS = 12
-const OUTSIDE_ANCHORS_PICKED = 3
-const OUTSIDE_ANCHORS_PICKED_ADVENTUROUS = 4
+// Pick more anchors so niche anchors with thin Last.fm results don't starve the
+// rail. The per-anchor target (6) + mid-list slice still preserve the rail's
+// "uncharted" identity — each anchor is genuinely a corner the user hasn't
+// explored; we just sample more of them.
+const OUTSIDE_ANCHORS_PICKED = 5
+const OUTSIDE_ANCHORS_PICKED_ADVENTUROUS = 6
 const OUTSIDE_MID_START = 10 // slice start of Last.fm top artists — skip mainstream head
 const OUTSIDE_MID_END = 40   // exclusive slice end
 const OUTSIDE_PER_ANCHOR_TARGET = 6
@@ -515,15 +523,31 @@ export async function wildcardsRail(
   supabase: SupabaseClient,
   seenIds: Set<string>,
 ): Promise<RailResult> {
-  const thumbsUpIds = [...ctx.thumbsUpIds]
-  if (thumbsUpIds.length === 0) return { railKey: 'wildcards', artistIds: [], why: {} }
-
   const target = input.adventurous ? WILDCARDS_TARGET_ADVENTUROUS : WILDCARDS_TARGET
   const seedCount = input.adventurous ? WILDCARDS_SEED_COUNT_ADVENTUROUS : WILDCARDS_SEED_COUNT
   const perSeedCount = input.adventurous ? WILDCARDS_PER_SEED_ADVENTUROUS : WILDCARDS_PER_SEED
 
-  const shuffledIds = seededShuffle(thumbsUpIds, cacheWindowSeed(input.userId, 'wildcards'))
-  const seedIds = shuffledIds.slice(0, seedCount)
+  // Primary seed pool: artists the user thumbs-up'd. If there are none yet
+  // (cold-start), fall back to the user's most-played listened artists so the
+  // rail still reads as "rabbit holes from your taste" instead of being empty.
+  // Excludes thumbs-down artists so a disliked seed never powers the rail.
+  let seedIds: string[]
+  if (ctx.thumbsUpIds.size > 0) {
+    const shuffledIds = seededShuffle([...ctx.thumbsUpIds], cacheWindowSeed(input.userId, 'wildcards'))
+    seedIds = shuffledIds.slice(0, seedCount)
+  } else {
+    const topListened = [...ctx.listened]
+      .filter((a) => !ctx.thumbsDownIds.has(a.spotify_artist_id))
+      .sort((a, b) => b.play_count - a.play_count)
+      .slice(0, seedCount * 2)
+      .map((a) => a.spotify_artist_id)
+    if (topListened.length === 0) {
+      return { railKey: 'wildcards', artistIds: [], why: {} }
+    }
+    // Stable shuffle over the top pool so the rail rotates week-to-week even
+    // when the user's play counts stay put.
+    seedIds = seededShuffle(topListened, cacheWindowSeed(input.userId, 'wildcards')).slice(0, seedCount)
+  }
 
   // Resolve seed ids → seed names via artist_search_cache (plus seed_artists as
   // a fallback since those live in `seed_artists` and may pre-date any cache row).
@@ -886,6 +910,41 @@ export async function buildExploreRails(
           ...fallback.why,
           [RAIL_META_KEY]: { fallbackKind: 'leftfield-for-wildcards' },
         },
+      }
+    }
+  }
+
+  // Minimum-floor topup. If any rail ends up below MIN_PICKS (matches the
+  // client's visibility cutoff in explore-client.tsx), blend in leftfield-
+  // sampled picks until it clears the floor. Keeps each rail's identity
+  // (original title/subtitle, original native picks first) while guaranteeing
+  // all four rails render for users with thin signal. Excludes IDs already in
+  // any rail so the topup never creates cross-rail duplicates.
+  const MIN_PICKS_FLOOR = 5
+  const shortRails = rails.filter((r) => r.artistIds.length < MIN_PICKS_FLOOR && r.railKey !== 'leftfield')
+  if (shortRails.length > 0) {
+    const existingIds = new Set<string>()
+    for (const r of rails) for (const id of r.artistIds) existingIds.add(id)
+
+    for (const r of shortRails) {
+      const need = MIN_PICKS_FLOOR - r.artistIds.length
+      if (need <= 0) continue
+      const topup = await leftfieldRail(input, ctx, supabase, seenIds, {
+        seedKey: `${r.railKey}-topup`,
+        excludeIds: existingIds,
+      })
+      const added: string[] = []
+      for (const id of topup.artistIds) {
+        if (existingIds.has(id)) continue
+        added.push(id)
+        existingIds.add(id)
+        if (added.length >= need) break
+      }
+      if (added.length > 0) {
+        r.artistIds = [...r.artistIds, ...added]
+        for (const id of added) {
+          if (!r.why[id]) r.why[id] = (topup.why[id] ?? {})
+        }
       }
     }
   }

--- a/supabase/migrations/0033_feedback_rpc_intent_fixes.sql
+++ b/supabase/migrations/0033_feedback_rpc_intent_fixes.sql
@@ -1,0 +1,110 @@
+-- Two intent fixes surfaced in the post-release bug sweep:
+--
+-- 1. rpc_record_feedback used to only credit the weekly challenge when the
+--    feedback row was genuinely new (v_inserted = true). That meant a user
+--    who thumbs-down'd an artist and later changed their mind to thumbs-up
+--    hit the ON CONFLICT UPDATE path and got no challenge credit for what
+--    is a real fresh "like" action. Fix: track the row's previous signal
+--    before the upsert and credit any transition INTO thumbs_up from a
+--    non-thumbs_up state (new row, or flip from thumbs_down).
+--
+-- 2. rpc_delete_feedback used to reset recommendation_cache.seen_at = NULL
+--    on un-like, which made un-liked cards re-surface on the next feed load.
+--    The agreed product intent (per the thumbs-up grill) is session-only
+--    undo: the card was already processed for the day, un-like should not
+--    summon it back. Fix: leave seen_at untouched.
+--
+-- Both RPCs are re-created atomically so the deploy is either fully applied
+-- or fully unapplied.
+
+CREATE OR REPLACE FUNCTION rpc_record_feedback(
+  p_user_id UUID,
+  p_artist_id TEXT,
+  p_signal TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_previous_signal TEXT;
+  v_was_deleted BOOLEAN := FALSE;
+  v_week_start DATE;
+BEGIN
+  IF p_signal NOT IN ('thumbs_up', 'thumbs_down', 'skip') THEN
+    RAISE EXCEPTION 'invalid signal: %', p_signal;
+  END IF;
+
+  IF p_signal <> 'skip' THEN
+    -- Snapshot the previous live signal (if any) before the upsert so we can
+    -- decide whether this is a transition into thumbs_up worth crediting.
+    -- A soft-deleted row counts as "no previous live signal" — resurrecting
+    -- it with thumbs_up should credit the challenge.
+    SELECT signal, deleted_at IS NOT NULL
+      INTO v_previous_signal, v_was_deleted
+      FROM feedback
+      WHERE user_id = p_user_id
+        AND spotify_artist_id = p_artist_id
+      LIMIT 1;
+
+    INSERT INTO feedback (user_id, spotify_artist_id, signal, deleted_at)
+    VALUES (p_user_id, p_artist_id, p_signal, NULL)
+    ON CONFLICT (user_id, spotify_artist_id)
+    DO UPDATE SET
+      signal = EXCLUDED.signal,
+      deleted_at = NULL;
+  END IF;
+
+  UPDATE recommendation_cache
+  SET
+    seen_at = NOW(),
+    skip_at = CASE WHEN p_signal = 'skip' THEN NOW() ELSE skip_at END
+  WHERE user_id = p_user_id
+    AND spotify_artist_id = p_artist_id;
+
+  -- Credit the challenge when transitioning INTO a live thumbs_up from
+  -- anything else (no row yet, soft-deleted row, thumbs_down, or skip).
+  -- Still guards against double-counting a user who toggles thumbs_up
+  -- repeatedly (previous was thumbs_up and not deleted → no credit).
+  IF p_signal = 'thumbs_up' AND (
+    v_previous_signal IS NULL
+    OR v_was_deleted
+    OR v_previous_signal <> 'thumbs_up'
+  ) THEN
+    v_week_start := date_trunc('week', (NOW() AT TIME ZONE 'UTC'))::DATE;
+    PERFORM rpc_increment_challenge_progress(
+      p_user_id,
+      v_week_start,
+      p_signal,
+      1
+    );
+  END IF;
+END;
+$$;
+
+-- rpc_delete_feedback: soft-delete the feedback row but leave seen_at alone.
+-- The card was already seen / processed; un-liking doesn't un-process it.
+CREATE OR REPLACE FUNCTION rpc_delete_feedback(
+  p_user_id UUID,
+  p_artist_id TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE feedback
+  SET deleted_at = NOW()
+  WHERE user_id = p_user_id
+    AND spotify_artist_id = p_artist_id;
+
+  -- Intentionally does NOT touch recommendation_cache.seen_at.
+  -- Session-only undo: the user already dealt with this card; it stays
+  -- out of future feed pulls regardless of whether they later changed
+  -- their mind within the session.
+END;
+$$;
+
+-- Permissions mirror 0028_rpc_permissions_and_saves_index.sql.
+REVOKE EXECUTE ON FUNCTION rpc_record_feedback(UUID, TEXT, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION rpc_record_feedback(UUID, TEXT, TEXT) FROM anon;
+REVOKE EXECUTE ON FUNCTION rpc_record_feedback(UUID, TEXT, TEXT) FROM authenticated;
+REVOKE EXECUTE ON FUNCTION rpc_delete_feedback(UUID, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION rpc_delete_feedback(UUID, TEXT) FROM anon;
+REVOKE EXECUTE ON FUNCTION rpc_delete_feedback(UUID, TEXT) FROM authenticated;


### PR DESCRIPTION
## Summary

Three commits that landed on `Nick` after PR #112 was merged. Each is independently revertable; no schema changes outside the included migration.

### 1. `Explore: guarantee all 4 rails populate for every user` (1339d0e)
- **After hours**: 10 tags × 6 per tag = 60 candidates (was 6 × 4 = 24). Niche mood tags with thin Last.fm response no longer starve the rail.
- **Uncharted territory**: 5 anchors instead of 3. Single niche anchor with <10 artists can no longer leave the rail empty.
- **Rabbit holes**: falls back to top-played listened artists as pseudo-seeds when the user has 0 thumbs-ups (preserves the "rabbit holes from your taste" feel instead of going empty).
- **Universal safety net**: minimum-floor topup pass in `buildExploreRails` — any rail under `MIN_PICKS=5` gets blended leftfield-sampled picks with a unique seed key + cross-rail exclusion. Native picks always come first; the rail keeps its title/subtitle.

### 2. `Thumbs-up keeps card visible so you can keep listening` (f23b437)
Previously, tapping "+ More like this" on a Feed or Explore card collapsed it to a 56px bar, hiding the track strip. New behavior across both surfaces:

- **Thumbs-up**: card stays fully expanded. Subtle 2px green outline + soft glow. Button swaps to "✓ Liked" (green fill). All other buttons remain active.
- **Tap "✓ Liked" again**: soft-deletes feedback row via `DELETE /api/feedback/:artistId` (existing rpc_delete_feedback path). Green outline removes, button reverts.
- **Thumbs-down**: still collapses to 56px bar, now with red-tinted border matching the red "Passed" label (was neutral gray).
- **Later / Skip**: unchanged.
- **Saved** (bookmark-driven collapse in Explore): accent-tinted border.

Under the hood: `ArtistCardProps` drops the redundant `isDismissed` prop; collapse state derives from `dismissSignal` alone via a `signalCollapses()` helper.

### 3. `Post-release bug sweep: feedback RPC intent + toggle race` (800ee86)
Three agents audited the new thumbs-up behavior and surfaced four real issues (all fixed here) alongside a broader confirmation that app intent is intact:

- **B1 (HIGH)**: `thumbs_down → thumbs_up` used to get no weekly-challenge credit because `rpc_record_feedback` only incremented when `v_inserted = true`. Migration `0033` now credits any transition INTO live thumbs_up (new row, soft-deleted row being resurrected, or signal flip from `thumbs_down`/`skip`). Still guards against double-credit for repeated taps on an already-live thumbs_up.
- **B2 (HIGH)**: `rpc_delete_feedback` was resetting `seen_at = NULL` on un-like, so un-liked cards re-surfaced on next feed refresh. This contradicted the stated session-only undo semantics. Migration `0033` leaves `seen_at` alone on delete.
- **B3 (MEDIUM)**: rapid like/unlike taps raced POST vs DELETE on the server. Both Feed and Explore `handleFeedback` now wrap in a per-artist keyed serializer (same pattern as `handleSave`) so requests hit the server in click order.
- **B4 (LOW)**: updated the misleading code comment about `seen_at` to reference migration `0033`.

Dismissed false positives (listed in the plan for traceability): searchBuckets memory leak (fine for hobby scale), user-cache `.select("*")` exposing `spotify_id` (no sensitive cols), ChallengeSlot promise-rejection (loadChallenge catches internally), leftfield theoretically going short (oversampling makes it practically impossible), rail identity dilution (intentional blend-mode), popularity-curve not invalidating explore cache (ranking-only staleness is fine).

Verified intact: sign-in → onboarding → feed, feed behavior, settings toggles, security posture, React.cache dedup, memoization, Suspense challenge streaming, rail topup hydration.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 551/551 pass
- [x] `npm run build` succeeds
- [ ] Apply migration `0033_feedback_rpc_intent_fixes.sql` on prod Supabase
- [ ] Smoke test in prod after deploy:
  - [ ] Cold `/explore` shows all 4 rails populated
  - [ ] Tap "+ More like this" → card stays, green outline, button becomes "✓ Liked"
  - [ ] Tap "✓ Liked" again → un-likes; refresh — card should NOT re-appear
  - [ ] Tap thumbs-down → card collapses with red-tinted border
  - [ ] Thumbs-down then change to thumbs-up on the same artist — weekly challenge counter should increment by 1
  - [ ] Rapid-tap Liked many times quickly — final server state matches final visual state

🤖 Generated with [Claude Code](https://claude.com/claude-code)