### PR TITLE
Dismiss flow: permanent hide with History undo + diversity nudge

### DIFF
--- a/app/(app)/history/page.tsx
+++ b/app/(app)/history/page.tsx
@@ -15,7 +15,7 @@ export default async function HistoryPage() {
   // 1. All seen recommendations
   const { data: seen } = await supabase
     .from("recommendation_cache")
-    .select("spotify_artist_id, artist_data, score, why, seen_at")
+    .select("spotify_artist_id, artist_data, score, why, seen_at, skip_at")
     .eq("user_id", userId)
     .not("seen_at", "is", null)
     .order("seen_at", { ascending: false })
@@ -49,22 +49,30 @@ export default async function HistoryPage() {
 
   const savedSet = new Set(((savesRes.data ?? []) as { spotify_artist_id: string }[]).map((s) => s.spotify_artist_id))
 
-  const history = (seen ?? []).map((rec) => ({
-    spotify_artist_id: rec.spotify_artist_id,
-    artist_data: rec.artist_data as {
-      id: string
-      name: string
-      genres: string[]
-      imageUrl: string | null
-      popularity: number
-    },
-    score: rec.score as number,
-    why: rec.why as { sourceArtists: string[]; genres: string[]; friendBoost: string[] },
-    artist_color: (rec.artist_data as Record<string, unknown>).artist_color as string | null ?? null,
-    seen_at: rec.seen_at as string,
-    signal: feedbackMap.get(rec.spotify_artist_id) ?? "skip",
-    bookmarked: savedSet.has(rec.spotify_artist_id),
-  }))
+  const history = (seen ?? []).map((rec) => {
+    const feedbackSignal = feedbackMap.get(rec.spotify_artist_id)
+    const signal = feedbackSignal
+      ? feedbackSignal
+      : rec.skip_at
+        ? "dismissed"
+        : "skip"
+    return {
+      spotify_artist_id: rec.spotify_artist_id,
+      artist_data: rec.artist_data as {
+        id: string
+        name: string
+        genres: string[]
+        imageUrl: string | null
+        popularity: number
+      },
+      score: rec.score as number,
+      why: rec.why as { sourceArtists: string[]; genres: string[]; friendBoost: string[] },
+      artist_color: (rec.artist_data as Record<string, unknown>).artist_color as string | null ?? null,
+      seen_at: rec.seen_at as string,
+      signal,
+      bookmarked: savedSet.has(rec.spotify_artist_id),
+    }
+  })
 
   const hasMore = (seen ?? []).length === 50
 

--- a/app/api/cron/recommendations/route.ts
+++ b/app/api/cron/recommendations/route.ts
@@ -37,6 +37,8 @@ export async function GET(req: NextRequest) {
 
   // Step 2: hard-delete anything that's been expired for > 30 days, regardless
   // of seen_at. Prevents unbounded table growth over months of production use.
+  // Exception: rows with skip_at set are permanent dismissals — deleting them
+  // would let the artist resurface in Explore/Feed ~60 days after dismissal.
   const thirtyDaysAgo = new Date(now)
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
 
@@ -44,6 +46,7 @@ export async function GET(req: NextRequest) {
     .from("recommendation_cache")
     .delete()
     .lt("expires_at", thirtyDaysAgo.toISOString())
+    .is("skip_at", null)
     .select("id")
 
   if (deleteErr) {

--- a/app/api/dismiss/[artistId]/route.ts
+++ b/app/api/dismiss/[artistId]/route.ts
@@ -1,0 +1,38 @@
+import { auth } from "@/lib/auth"
+import { createServiceClient } from "@/lib/supabase/server"
+import { apiError, apiUnauthorized, dbError } from "@/lib/errors"
+import { enforceSameOrigin } from "@/lib/csrf"
+import { isValidSpotifyId } from "@/lib/spotify-ids"
+import { invalidateExploreCache } from "@/lib/recommendation/explore-engine"
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ artistId: string }> }
+): Promise<Response> {
+  const blocked = enforceSameOrigin(request)
+  if (blocked) return blocked
+  const session = await auth()
+  if (!session?.user?.id) return apiUnauthorized()
+
+  const userId = session.user.id
+  const { artistId } = await params
+
+  if (!isValidSpotifyId(artistId)) return apiError("Invalid artist ID", 400)
+
+  const supabase = createServiceClient()
+
+  const { error: rpcError } = await supabase.rpc("rpc_clear_dismiss", {
+    p_user_id: userId,
+    p_artist_id: artistId,
+  })
+
+  if (rpcError) return dbError(rpcError, "dismiss/clear-rpc")
+
+  // Explore caches include the server-side skip_at filter, so cached rails
+  // omit the artist. Wipe the cache so the next Explore load can re-include.
+  await invalidateExploreCache(userId).catch((err) => {
+    console.error("[dismiss] explore-invalidate failed", err)
+  })
+
+  return new Response(null, { status: 204 })
+}

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest): Promise<Response> {
   // request from the client.
   const { data: seenRaw, error: seenErr } = await supabase
     .from("recommendation_cache")
-    .select("spotify_artist_id, artist_data, score, why, seen_at")
+    .select("spotify_artist_id, artist_data, score, why, seen_at, skip_at")
     .eq("user_id", userId)
     .not("seen_at", "is", null)
     .order("seen_at", { ascending: false })
@@ -64,17 +64,28 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   const savedSet = new Set((saves ?? []).map((s) => s.spotify_artist_id))
 
-  // 3. Merge into a single response
-  const history = (seen ?? []).map((rec) => ({
-    spotify_artist_id: rec.spotify_artist_id,
-    artist_data: rec.artist_data,
-    score: rec.score,
-    why: rec.why,
-    artist_color: (rec.artist_data as Record<string, unknown>)?.artist_color as string | null ?? null,
-    seen_at: rec.seen_at,
-    signal: feedbackMap.get(rec.spotify_artist_id) ?? "skip",
-    bookmarked: savedSet.has(rec.spotify_artist_id),
-  }))
+  // 3. Merge into a single response.
+  // Signal precedence: explicit feedback (thumbs_up/down) > permanent dismiss
+  // (skip_at) > passive seen (skip). A user can't have both a feedback row and
+  // a skip_at, but preferring feedback is the safe order.
+  const history = (seen ?? []).map((rec) => {
+    const feedbackSignal = feedbackMap.get(rec.spotify_artist_id as string)
+    const signal = feedbackSignal
+      ? feedbackSignal
+      : rec.skip_at
+        ? "dismissed"
+        : "skip"
+    return {
+      spotify_artist_id: rec.spotify_artist_id,
+      artist_data: rec.artist_data,
+      score: rec.score,
+      why: rec.why,
+      artist_color: (rec.artist_data as Record<string, unknown>)?.artist_color as string | null ?? null,
+      seen_at: rec.seen_at,
+      signal,
+      bookmarked: savedSet.has(rec.spotify_artist_id),
+    }
+  })
 
   return Response.json({ history, hasMore: seenArtistIds.length === limit })
 }

--- a/components/explore/explore-client.tsx
+++ b/components/explore/explore-client.tsx
@@ -226,9 +226,6 @@ export function ExploreClient({
           body: JSON.stringify({ spotifyArtistId: artistId }),
         })
         if (!res.ok) throw new Error("server")
-        if (!isCurrentlySaved) {
-          setDismissedSignals((prev) => new Map(prev).set(artistId, "saved"))
-        }
       } catch {
         setSavedIds((prev) => {
           const n = new Set(prev)
@@ -247,12 +244,21 @@ export function ExploreClient({
     try {
       const res = await fetch("/api/explore/generate?force=true", { method: "POST" })
       if (!res.ok) throw new Error("generate failed")
-      // Clear dismissed for the active tab's artists so a fresh roll isn't hidden.
+      // Drop stale thumbs_up entries so a refreshed roll doesn't carry over the
+      // green outline from the previous deck. thumbs_down and skip (Dismiss)
+      // stay put — the server filter now permanently excludes them anyway, and
+      // retaining the local entries is defensive for any in-flight writes.
       setDismissedSignals((prev) => {
         if (!activeRail) return prev
+        let changed = false
         const n = new Map(prev)
-        for (const a of activeRail.artists) n.delete(a.id)
-        return n
+        for (const a of activeRail.artists) {
+          if (n.get(a.id) === "thumbs_up") {
+            n.delete(a.id)
+            changed = true
+          }
+        }
+        return changed ? n : prev
       })
       startTransition(() => router.refresh())
     } catch {

--- a/components/feed/artist-card.tsx
+++ b/components/feed/artist-card.tsx
@@ -54,8 +54,7 @@ export interface ArtistCardProps {
    *   - null           → expanded card, default buttons
    *   - "thumbs_up"    → expanded card, green outline + "Liked" button (keep playing)
    *   - "thumbs_down"  → collapsed 56px bar, red-tinted "Passed"
-   *   - "skip"         → collapsed 56px bar, neutral "Maybe later"
-   *   - "saved"        → collapsed 56px bar, accent "Saved"
+   *   - "skip"         → collapsed 56px bar, neutral "Dismissed"
    */
   dismissSignal?: string | null
 }
@@ -64,8 +63,9 @@ export interface ArtistCardProps {
 // Component
 // ---------------------------------------------------------------------------
 
-// Collapse the card for thumbs_down / skip / saved, but NOT thumbs_up — we
-// keep the card visible after a like so the user can keep listening.
+// Collapse the card for thumbs_down / skip, but NOT thumbs_up — we keep the
+// card visible after a like so the user can keep listening. Bookmark no
+// longer dismisses: saves only toggle the bookmark icon.
 function signalCollapses(signal: string | null | undefined): boolean {
   return signal != null && signal !== "thumbs_up"
 }
@@ -149,14 +149,12 @@ function ArtistCardImpl({
 
   // ------------------------------------------------------------------
   // Collapsed (slim bar) state — no emoji, colour-coded labels. Only applies
-  // to thumbs_down / skip / saved. Thumbs_up keeps the card expanded below so
-  // the user can keep listening after liking.
+  // to thumbs_down / skip. Thumbs_up and saves keep the card expanded.
   // ------------------------------------------------------------------
   if (isCollapsed) {
     const labelMap: Record<string, { text: string; color: string; border: string }> = {
-      thumbs_down: { text: "Passed",      color: "var(--dislike)",    border: "rgba(255,75,75,0.35)" },
-      skip:        { text: "Maybe later", color: "var(--text-muted)", border: "var(--border)" },
-      saved:       { text: "Saved",       color: "var(--accent)",     border: "rgba(139,92,246,0.35)" },
+      thumbs_down: { text: "Passed",    color: "var(--dislike)",    border: "rgba(255,75,75,0.35)" },
+      skip:        { text: "Dismissed", color: "var(--text-muted)", border: "var(--border)" },
     }
     const signal = labelMap[dismissSignal ?? "skip"] ?? labelMap.skip
 
@@ -429,7 +427,7 @@ function ArtistCardImpl({
               className="btn"
               style={{ flex: 1, minWidth: 0, fontSize: 13, whiteSpace: "nowrap" }}
             >
-              <SkipForward size={15} /> Later
+              <SkipForward size={15} /> Dismiss
             </button>
             <button
               onClick={() => onFeedback("thumbs_up")}

--- a/components/history/history-client.tsx
+++ b/components/history/history-client.tsx
@@ -23,7 +23,7 @@ interface HistoryEntry {
   bookmarked: boolean
 }
 
-type FilterTab = "all" | "thumbs_up" | "thumbs_down" | "skip" | "bookmarked"
+type FilterTab = "all" | "thumbs_up" | "thumbs_down" | "skip" | "dismissed" | "bookmarked"
 
 interface HistoryClientProps {
   history: HistoryEntry[]
@@ -31,10 +31,11 @@ interface HistoryClientProps {
 }
 
 const SIG_STYLES: Record<string, { Icon: React.ElementType; color: string; label: string }> = {
-  thumbs_up:   { Icon: ThumbsUp,    color: "var(--like)",      label: "Liked"   },
-  thumbs_down: { Icon: ThumbsDown,  color: "var(--dislike)",   label: "Passed"  },
-  skip:        { Icon: SkipForward, color: "var(--text-muted)", label: "Skipped" },
-  bookmarked:  { Icon: Bookmark,    color: "var(--accent)",    label: "Saved"   },
+  thumbs_up:   { Icon: ThumbsUp,    color: "var(--like)",       label: "Liked"     },
+  thumbs_down: { Icon: ThumbsDown,  color: "var(--dislike)",    label: "Passed"    },
+  skip:        { Icon: SkipForward, color: "var(--text-muted)", label: "Skipped"   },
+  dismissed:   { Icon: SkipForward, color: "var(--text-faint)", label: "Dismissed" },
+  bookmarked:  { Icon: Bookmark,    color: "var(--accent)",     label: "Saved"     },
 }
 
 function timeAgo(dateStr: string): string {
@@ -82,6 +83,7 @@ const FILTER_TABS: { key: FilterTab; label: string }[] = [
   { key: "thumbs_up",   label: "Liked"     },
   { key: "thumbs_down", label: "Passed"    },
   { key: "skip",        label: "Skipped"   },
+  { key: "dismissed",   label: "Dismissed" },
   { key: "bookmarked",  label: "Saved"     },
 ]
 
@@ -103,11 +105,12 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
   }, [history, filter])
 
   const counts = useMemo(() => {
-    const c: Record<FilterTab, number> = { all: history.length, thumbs_up: 0, thumbs_down: 0, skip: 0, bookmarked: 0 }
+    const c: Record<FilterTab, number> = { all: history.length, thumbs_up: 0, thumbs_down: 0, skip: 0, dismissed: 0, bookmarked: 0 }
     for (const h of history) {
       if (h.bookmarked) c.bookmarked++
       else if (h.signal === "thumbs_up") c.thumbs_up++
       else if (h.signal === "thumbs_down") c.thumbs_down++
+      else if (h.signal === "dismissed") c.dismissed++
       else c.skip++
     }
     return c
@@ -115,10 +118,16 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
 
   const groups = useMemo(() => groupByPeriod(filtered), [filtered])
 
-  async function handleUndo(artistId: string) {
+  async function handleUndo(artistId: string, signal: string) {
     setUndoingIds((prev) => new Set(prev).add(artistId))
+    // Dismissed items have no feedback row (the skip RPC only stamps
+    // recommendation_cache.skip_at). Clearing requires a separate endpoint
+    // that wipes skip_at + seen_at so the artist is fully eligible again.
+    const endpoint = signal === "dismissed"
+      ? `/api/dismiss/${artistId}`
+      : `/api/feedback/${artistId}`
     try {
-      const res = await fetch(`/api/feedback/${artistId}`, { method: "DELETE" })
+      const res = await fetch(endpoint, { method: "DELETE" })
       if (!res.ok) throw new Error("Server error")
       setHistory((prev) => prev.filter((h) => h.spotify_artist_id !== artistId))
     } catch {
@@ -297,7 +306,7 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
 
                       {/* Quick actions */}
                       <div style={{ display: "flex", alignItems: "center", gap: 2, flexShrink: 0 }}>
-                        {entry.signal !== "thumbs_up" && !entry.bookmarked && (
+                        {entry.signal !== "thumbs_up" && entry.signal !== "dismissed" && !entry.bookmarked && (
                           <button
                             onClick={() => handleChangeSignal(entry.spotify_artist_id, "thumbs_up")}
                             title="Change to Liked"
@@ -310,7 +319,7 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
                             <ThumbsUp size={13} />
                           </button>
                         )}
-                        {entry.signal !== "thumbs_down" && !entry.bookmarked && (
+                        {entry.signal !== "thumbs_down" && entry.signal !== "dismissed" && !entry.bookmarked && (
                           <button
                             onClick={() => handleChangeSignal(entry.spotify_artist_id, "thumbs_down")}
                             title="Change to Passed"
@@ -324,9 +333,9 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
                           </button>
                         )}
                         <button
-                          onClick={() => handleUndo(entry.spotify_artist_id)}
+                          onClick={() => handleUndo(entry.spotify_artist_id, entry.signal)}
                           disabled={isUndoing}
-                          title="Undo — return to feed"
+                          title={entry.signal === "dismissed" ? "Unblock — allow in feed again" : "Undo — return to feed"}
                           style={{
                             width: 32, height: 32, borderRadius: 8,
                             background: "transparent", border: 0, cursor: "pointer",

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -671,7 +671,7 @@ export function SettingsForm({
                 >
                   ♫
                 </div>
-                <div style={{ flex: 1 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontSize: 14, fontWeight: 600 }}>Last.fm</div>
                   <div
                     className="mono"
@@ -724,7 +724,7 @@ export function SettingsForm({
                 >
                   📊
                 </div>
-                <div style={{ flex: 1 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontSize: 14, fontWeight: 600 }}>stats.fm</div>
                   <div
                     className="mono"

--- a/lib/recommendation/engine.test.ts
+++ b/lib/recommendation/engine.test.ts
@@ -326,17 +326,17 @@ describe("isEligibleForCooldown", () => {
     expect(isEligibleForCooldown(eightDays, null, now)).toBe(true)
   })
 
-  it("blocks when skip_at is within 30 days", () => {
+  it("blocks when skip_at is set recently (permanent dismiss)", () => {
     const fifteenDays = new Date(now.getTime() - 15 * 86400_000).toISOString()
     expect(isEligibleForCooldown(null, fifteenDays, now)).toBe(false)
   })
 
-  it("allows when skip_at is past 30 days", () => {
-    const thirtyFiveDays = new Date(now.getTime() - 35 * 86400_000).toISOString()
-    expect(isEligibleForCooldown(null, thirtyFiveDays, now)).toBe(true)
+  it("blocks when skip_at is set long ago (permanent dismiss, no expiry)", () => {
+    const hundredDays = new Date(now.getTime() - 100 * 86400_000).toISOString()
+    expect(isEligibleForCooldown(null, hundredDays, now)).toBe(false)
   })
 
-  it("skip cooldown outranks seen cooldown (fresh seen, old skip → blocked)", () => {
+  it("skip cooldown outranks seen cooldown (any skip_at blocks regardless of age)", () => {
     const seen = new Date(now.getTime() - 1 * 86400_000).toISOString()
     const skip = new Date(now.getTime() - 28 * 86400_000).toISOString()
     expect(isEligibleForCooldown(seen, skip, now)).toBe(false)
@@ -344,17 +344,17 @@ describe("isEligibleForCooldown", () => {
 })
 
 describe("greedyPickTop diversity strength", () => {
-  it("homogeneous 40-rock pool produces ≤12 rocks in top 20 at 0.05 penalty", () => {
+  it("homogeneous 40-rock pool produces ≤10 rocks in top 20 at 0.10 penalty", () => {
     // 40 candidates, 30 rock (score 0.5 descending) + 10 other genres (score 0.4 descending).
-    // At 0.02 penalty the top would skew heavy-rock; at 0.05 the penalty
-    // after 5-6 rock picks exceeds the 0.1 score gap and diversity wins.
+    // At 0.10 penalty the 2nd rock already costs 0.10 (landing at 0.399 vs 0.4
+    // for the next other genre), so others sweep in until exhausted.
     const pool: ScoredArtist[] = [
       ...Array.from({ length: 30 }, (_, i) => scored(`r${i}`, 0.5 - i * 0.001, [`S${i}`], "rock")),
       ...Array.from({ length: 10 }, (_, i) => scored(`o${i}`, 0.4 - i * 0.001, [`T${i}`], `genre_${i}`)),
     ]
     const top = greedyPickTop(pool, 20)
     const rocks = top.filter((t) => t.artist.genres[0] === "rock").length
-    expect(rocks).toBeLessThanOrEqual(12)
+    expect(rocks).toBeLessThanOrEqual(10)
   })
 })
 

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -231,14 +231,17 @@ export async function runDeepHop(
 
 /**
  * Greedy pick with soft per-genre AND per-source-seed diversity penalties.
- * genreWeight raised 0.02 → 0.05 so the 6th same-genre pick takes a ~0.25
- * hit — enough to actually dominate score deltas in a homogeneous pool.
+ * genreWeight raised 0.05 → 0.10 (and sourceWeight 0.04 → 0.08) as a near-term
+ * nudge against session-echo from thumbs-up-heavy seed pools — the 6th
+ * same-genre pick now takes a ~0.50 hit, well above typical score deltas, so
+ * a homogeneous pool breaks up earlier. The full "quiet signal + rolling
+ * sample + cross-rail budget" overhaul lives in its own PRD.
  */
 export function greedyPickTop(
   pool: ScoredArtist[],
   maxSize = 20,
-  genreWeight = 0.05,
-  sourceWeight = 0.04
+  genreWeight = 0.10,
+  sourceWeight = 0.08
 ): ScoredArtist[] {
   const working = [...pool]
   const top: ScoredArtist[] = []
@@ -272,19 +275,16 @@ export function greedyPickTop(
 }
 
 /**
- * Cooldown gate: `skip_at` wins over `seen_at` because a deliberate skip
- * signals stronger disinterest than a passive surface, so the window is
- * longer (30d vs 7d).
+ * Cooldown gate: a `skip_at` timestamp is a permanent hide ("Dismiss" button).
+ * Undo is available from the History page, which clears skip_at via the
+ * dismiss RPC. A passive `seen_at` is a 7-day soft cooldown.
  */
 export function isEligibleForCooldown(
   seenAt: string | null | undefined,
   skipAt: string | null | undefined,
   now: Date = new Date()
 ): boolean {
-  if (skipAt) {
-    const days = (now.getTime() - new Date(skipAt).getTime()) / (1000 * 60 * 60 * 24)
-    if (days < 30) return false
-  }
+  if (skipAt) return false
   if (seenAt) {
     const days = (now.getTime() - new Date(seenAt).getTime()) / (1000 * 60 * 60 * 24)
     if (days < 7) return false

--- a/lib/recommendation/explore-engine.ts
+++ b/lib/recommendation/explore-engine.ts
@@ -223,7 +223,7 @@ async function resolveAndFilter(
   filters: {
     listenedIds: Set<string>
     thumbsDownIds: Set<string>
-    seenIds: Set<string>
+    excludedIds: Set<string>
     undergroundMode?: boolean
   },
 ): Promise<Artist[]> {
@@ -241,22 +241,38 @@ async function resolveAndFilter(
   for (const artist of resolved.resolved.values()) {
     if (filters.listenedIds.has(artist.id)) continue
     if (filters.thumbsDownIds.has(artist.id)) continue
-    if (filters.seenIds.has(artist.id)) continue
+    if (filters.excludedIds.has(artist.id)) continue
     if (filters.undergroundMode && (artist.popularity ?? 0) > UNDERGROUND_MAX_POPULARITY) continue
     out.push(artist)
   }
   return out
 }
 
-async function loadSeenIds(supabase: SupabaseClient, userId: string): Promise<Set<string>> {
+/**
+ * IDs the explore engine should never resurface this generation:
+ *   - seen_at within the 7-day passive cooldown
+ *   - skip_at set (permanent dismiss via the Dismiss button; undo lives on
+ *     the History page and clears skip_at via rpc_clear_dismiss)
+ */
+async function loadExcludedIds(supabase: SupabaseClient, userId: string): Promise<Set<string>> {
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
-  const { data } = await supabase
-    .from('recommendation_cache')
-    .select('spotify_artist_id, seen_at')
-    .eq('user_id', userId)
-    .not('seen_at', 'is', null)
-    .gte('seen_at', sevenDaysAgo)
-  return new Set((data ?? []).map((r) => r.spotify_artist_id as string))
+  const [seenRes, skipRes] = await Promise.all([
+    supabase
+      .from('recommendation_cache')
+      .select('spotify_artist_id')
+      .eq('user_id', userId)
+      .not('seen_at', 'is', null)
+      .gte('seen_at', sevenDaysAgo),
+    supabase
+      .from('recommendation_cache')
+      .select('spotify_artist_id')
+      .eq('user_id', userId)
+      .not('skip_at', 'is', null),
+  ])
+  const ids = new Set<string>()
+  for (const r of seenRes.data ?? []) ids.add(r.spotify_artist_id as string)
+  for (const r of skipRes.data ?? []) ids.add(r.spotify_artist_id as string)
+  return ids
 }
 
 // ── Rail implementations ────────────────────────────────────────────────────
@@ -302,7 +318,7 @@ export async function adjacentRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
 ): Promise<RailResult> {
   const target = input.adventurous ? AFTERHOURS_TARGET_ADVENTUROUS : AFTERHOURS_TARGET
   const perTag = AFTERHOURS_PER_TAG
@@ -346,7 +362,7 @@ export async function adjacentRail(
   const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
     listenedIds: ctx.listenedIds,
     thumbsDownIds: ctx.thumbsDownIds,
-    seenIds,
+    excludedIds,
     undergroundMode: input.undergroundMode,
   })
 
@@ -395,7 +411,7 @@ export async function outsideRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
 ): Promise<RailResult> {
   void supabase
   const target = input.adventurous ? OUTSIDE_TARGET_ADVENTUROUS : OUTSIDE_TARGET
@@ -473,7 +489,7 @@ export async function outsideRail(
   const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
     listenedIds: ctx.listenedIds,
     thumbsDownIds: ctx.thumbsDownIds,
-    seenIds,
+    excludedIds,
     undergroundMode: input.undergroundMode,
   })
 
@@ -521,7 +537,7 @@ export async function wildcardsRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
 ): Promise<RailResult> {
   const target = input.adventurous ? WILDCARDS_TARGET_ADVENTUROUS : WILDCARDS_TARGET
   const seedCount = input.adventurous ? WILDCARDS_SEED_COUNT_ADVENTUROUS : WILDCARDS_SEED_COUNT
@@ -604,7 +620,7 @@ export async function wildcardsRail(
   const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
     listenedIds: ctx.listenedIds,
     thumbsDownIds: ctx.thumbsDownIds,
-    seenIds,
+    excludedIds,
     undergroundMode: input.undergroundMode,
   })
   const artistByName = new Map<string, Artist>()
@@ -671,7 +687,7 @@ export async function leftfieldRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
   opts: { seedKey?: string; excludeIds?: Set<string> } = {},
 ): Promise<RailResult> {
   try {
@@ -733,7 +749,7 @@ export async function leftfieldRail(
     const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
       listenedIds: ctx.listenedIds,
       thumbsDownIds: ctx.thumbsDownIds,
-      seenIds,
+      excludedIds,
       undergroundMode: input.undergroundMode,
     })
     const artistByName = new Map<string, Artist>()
@@ -869,19 +885,19 @@ export async function buildExploreRails(
     }
   }
 
-  const [ctx, seenIds] = await Promise.all([
+  const [ctx, excludedIds] = await Promise.all([
     loadUserContext(supabase, input.userId),
-    loadSeenIds(supabase, input.userId),
+    loadExcludedIds(supabase, input.userId),
   ])
 
   // allSettled so one rail throwing doesn't nuke the whole explore generation.
   // Each rail already has its own internal try/catch for Last.fm calls; this is
   // belt-and-braces against unexpected DB / null-deref errors.
   const railFns: Array<{ key: RailKey; run: () => Promise<RailResult> }> = [
-    { key: "adjacent", run: () => adjacentRail(input, ctx, supabase, seenIds) },
-    { key: "outside", run: () => outsideRail(input, ctx, supabase, seenIds) },
-    { key: "wildcards", run: () => wildcardsRail(input, ctx, supabase, seenIds) },
-    { key: "leftfield", run: () => leftfieldRail(input, ctx, supabase, seenIds) },
+    { key: "adjacent", run: () => adjacentRail(input, ctx, supabase, excludedIds) },
+    { key: "outside", run: () => outsideRail(input, ctx, supabase, excludedIds) },
+    { key: "wildcards", run: () => wildcardsRail(input, ctx, supabase, excludedIds) },
+    { key: "leftfield", run: () => leftfieldRail(input, ctx, supabase, excludedIds) },
   ]
   const settled = await Promise.allSettled(railFns.map((r) => r.run()))
   const rails: RailResult[] = settled.map((s, i) => {
@@ -897,7 +913,7 @@ export async function buildExploreRails(
   if (ctx.thumbsUpIds.size === 0) {
     const primaryLeftfield = rails.find((r) => r.railKey === 'leftfield')
     const excludeIds = new Set(primaryLeftfield?.artistIds ?? [])
-    const fallback = await leftfieldRail(input, ctx, supabase, seenIds, {
+    const fallback = await leftfieldRail(input, ctx, supabase, excludedIds, {
       seedKey: 'wildcards-fallback',
       excludeIds,
     })
@@ -929,7 +945,7 @@ export async function buildExploreRails(
     for (const r of shortRails) {
       const need = MIN_PICKS_FLOOR - r.artistIds.length
       if (need <= 0) continue
-      const topup = await leftfieldRail(input, ctx, supabase, seenIds, {
+      const topup = await leftfieldRail(input, ctx, supabase, excludedIds, {
         seedKey: `${r.railKey}-topup`,
         excludeIds: existingIds,
       })

--- a/supabase/migrations/0034_rpc_clear_dismiss.sql
+++ b/supabase/migrations/0034_rpc_clear_dismiss.sql
@@ -1,0 +1,32 @@
+-- rpc_clear_dismiss: Unblock a permanently-dismissed artist so they can
+-- resurface in Explore and Feed again.
+--
+-- The "Dismiss" button on a card writes skip_at (and seen_at) via
+-- rpc_record_feedback with signal='skip'. Migration 0033 intentionally does
+-- NOT insert a feedback row for skip, so the existing rpc_delete_feedback is
+-- a no-op for dismissed items. This RPC clears both columns on the
+-- recommendation_cache row so the artist is fully eligible again (no skip_at
+-- filter, no 7-day seen_at cooldown).
+--
+-- Idempotent: UPDATE on a non-existent row is a no-op.
+
+CREATE OR REPLACE FUNCTION rpc_clear_dismiss(
+  p_user_id UUID,
+  p_artist_id TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE recommendation_cache
+  SET skip_at = NULL,
+      seen_at = NULL
+  WHERE user_id = p_user_id
+    AND spotify_artist_id = p_artist_id;
+END;
+$$;
+
+-- Permissions mirror 0033_feedback_rpc_intent_fixes.sql — server-only via
+-- service role; app code calls through the service client.
+REVOKE EXECUTE ON FUNCTION rpc_clear_dismiss(UUID, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION rpc_clear_dismiss(UUID, TEXT) FROM anon;
+REVOKE EXECUTE ON FUNCTION rpc_clear_dismiss(UUID, TEXT) FROM authenticated;


### PR DESCRIPTION
## Summary

Post-release bug sweep follow-ups + a near-term diversity nudge:

- **Settings** — Last.fm / stats.fm "Sync now" buttons no longer overlap the card's right border (`flex: 1` wrappers now use `minWidth: 0`)
- **Explore** — bookmark no longer collapses the card; saves only toggle the bookmark icon
- **"Later" → "Dismiss"** with *permanent* hide semantics across Feed and Explore
  - Feed engine: any `skip_at` blocks forever (no 30-day window)
  - Explore engine: new `loadExcludedIds` unions 7-day seen + permanent skip
  - Cron: `.is("skip_at", null)` guard on the 30-day purge so dismissed rows don't age out and resurface
- **History** — new "Dismissed" filter tab + Unblock action, backed by `rpc_clear_dismiss` (wipes `skip_at` + `seen_at`) and `DELETE /api/dismiss/[artistId]`
- **Shuffle** — no longer clears dismiss signals; only `thumbs_up` selections are cleared
- **Diversity nudge** — `genreWeight` 0.05 → 0.10 and `sourceWeight` 0.04 → 0.08 in `greedyPickTop` to break up session-echo from thumbs-up-heavy seed pools. Full "quiet signal + rolling sample + cross-rail budget" overhaul lives in a separate PRD.
- **Rename** — `seenIds` → `excludedIds` throughout `explore-engine.ts` to reflect unioned contents

## Migrations

- `0034_rpc_clear_dismiss.sql` — service-role-only RPC that clears `skip_at` + `seen_at` for an artist

## Test plan

- [x] `npx vitest run` — 386/386 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Preview verified: Settings sync buttons sit inside card padding; History shows 6-tab order (All · Liked · Passed · Skipped · Dismissed · Saved); `/api/dismiss/[artistId]` returns 204 after migration applied
- [ ] Manual: dismiss an artist in Explore → shuffle → confirm they don't come back
- [ ] Manual: History → Dismissed → Unblock → refresh Explore → artist can resurface
- [ ] Manual: log out / back in — dismissed artists still hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)