### PR TITLE
Diversity overhaul: rolling like sample + 25% cluster cap + rail budget

### DIFF
--- a/app/(app)/history/page.tsx
+++ b/app/(app)/history/page.tsx
@@ -15,7 +15,7 @@ export default async function HistoryPage() {
   // 1. All seen recommendations
   const { data: seen } = await supabase
     .from("recommendation_cache")
-    .select("spotify_artist_id, artist_data, score, why, seen_at")
+    .select("spotify_artist_id, artist_data, score, why, seen_at, skip_at")
     .eq("user_id", userId)
     .not("seen_at", "is", null)
     .order("seen_at", { ascending: false })
@@ -49,22 +49,30 @@ export default async function HistoryPage() {
 
   const savedSet = new Set(((savesRes.data ?? []) as { spotify_artist_id: string }[]).map((s) => s.spotify_artist_id))
 
-  const history = (seen ?? []).map((rec) => ({
-    spotify_artist_id: rec.spotify_artist_id,
-    artist_data: rec.artist_data as {
-      id: string
-      name: string
-      genres: string[]
-      imageUrl: string | null
-      popularity: number
-    },
-    score: rec.score as number,
-    why: rec.why as { sourceArtists: string[]; genres: string[]; friendBoost: string[] },
-    artist_color: (rec.artist_data as Record<string, unknown>).artist_color as string | null ?? null,
-    seen_at: rec.seen_at as string,
-    signal: feedbackMap.get(rec.spotify_artist_id) ?? "skip",
-    bookmarked: savedSet.has(rec.spotify_artist_id),
-  }))
+  const history = (seen ?? []).map((rec) => {
+    const feedbackSignal = feedbackMap.get(rec.spotify_artist_id)
+    const signal = feedbackSignal
+      ? feedbackSignal
+      : rec.skip_at
+        ? "dismissed"
+        : "skip"
+    return {
+      spotify_artist_id: rec.spotify_artist_id,
+      artist_data: rec.artist_data as {
+        id: string
+        name: string
+        genres: string[]
+        imageUrl: string | null
+        popularity: number
+      },
+      score: rec.score as number,
+      why: rec.why as { sourceArtists: string[]; genres: string[]; friendBoost: string[] },
+      artist_color: (rec.artist_data as Record<string, unknown>).artist_color as string | null ?? null,
+      seen_at: rec.seen_at as string,
+      signal,
+      bookmarked: savedSet.has(rec.spotify_artist_id),
+    }
+  })
 
   const hasMore = (seen ?? []).length === 50
 

--- a/app/api/cron/recommendations/route.ts
+++ b/app/api/cron/recommendations/route.ts
@@ -37,6 +37,8 @@ export async function GET(req: NextRequest) {
 
   // Step 2: hard-delete anything that's been expired for > 30 days, regardless
   // of seen_at. Prevents unbounded table growth over months of production use.
+  // Exception: rows with skip_at set are permanent dismissals — deleting them
+  // would let the artist resurface in Explore/Feed ~60 days after dismissal.
   const thirtyDaysAgo = new Date(now)
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
 
@@ -44,6 +46,7 @@ export async function GET(req: NextRequest) {
     .from("recommendation_cache")
     .delete()
     .lt("expires_at", thirtyDaysAgo.toISOString())
+    .is("skip_at", null)
     .select("id")
 
   if (deleteErr) {

--- a/app/api/dismiss/[artistId]/route.ts
+++ b/app/api/dismiss/[artistId]/route.ts
@@ -1,0 +1,38 @@
+import { auth } from "@/lib/auth"
+import { createServiceClient } from "@/lib/supabase/server"
+import { apiError, apiUnauthorized, dbError } from "@/lib/errors"
+import { enforceSameOrigin } from "@/lib/csrf"
+import { isValidSpotifyId } from "@/lib/spotify-ids"
+import { invalidateExploreCache } from "@/lib/recommendation/explore-engine"
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ artistId: string }> }
+): Promise<Response> {
+  const blocked = enforceSameOrigin(request)
+  if (blocked) return blocked
+  const session = await auth()
+  if (!session?.user?.id) return apiUnauthorized()
+
+  const userId = session.user.id
+  const { artistId } = await params
+
+  if (!isValidSpotifyId(artistId)) return apiError("Invalid artist ID", 400)
+
+  const supabase = createServiceClient()
+
+  const { error: rpcError } = await supabase.rpc("rpc_clear_dismiss", {
+    p_user_id: userId,
+    p_artist_id: artistId,
+  })
+
+  if (rpcError) return dbError(rpcError, "dismiss/clear-rpc")
+
+  // Explore caches include the server-side skip_at filter, so cached rails
+  // omit the artist. Wipe the cache so the next Explore load can re-include.
+  await invalidateExploreCache(userId).catch((err) => {
+    console.error("[dismiss] explore-invalidate failed", err)
+  })
+
+  return new Response(null, { status: 204 })
+}

--- a/app/api/history/route.ts
+++ b/app/api/history/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest): Promise<Response> {
   // request from the client.
   const { data: seenRaw, error: seenErr } = await supabase
     .from("recommendation_cache")
-    .select("spotify_artist_id, artist_data, score, why, seen_at")
+    .select("spotify_artist_id, artist_data, score, why, seen_at, skip_at")
     .eq("user_id", userId)
     .not("seen_at", "is", null)
     .order("seen_at", { ascending: false })
@@ -64,17 +64,28 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   const savedSet = new Set((saves ?? []).map((s) => s.spotify_artist_id))
 
-  // 3. Merge into a single response
-  const history = (seen ?? []).map((rec) => ({
-    spotify_artist_id: rec.spotify_artist_id,
-    artist_data: rec.artist_data,
-    score: rec.score,
-    why: rec.why,
-    artist_color: (rec.artist_data as Record<string, unknown>)?.artist_color as string | null ?? null,
-    seen_at: rec.seen_at,
-    signal: feedbackMap.get(rec.spotify_artist_id) ?? "skip",
-    bookmarked: savedSet.has(rec.spotify_artist_id),
-  }))
+  // 3. Merge into a single response.
+  // Signal precedence: explicit feedback (thumbs_up/down) > permanent dismiss
+  // (skip_at) > passive seen (skip). A user can't have both a feedback row and
+  // a skip_at, but preferring feedback is the safe order.
+  const history = (seen ?? []).map((rec) => {
+    const feedbackSignal = feedbackMap.get(rec.spotify_artist_id as string)
+    const signal = feedbackSignal
+      ? feedbackSignal
+      : rec.skip_at
+        ? "dismissed"
+        : "skip"
+    return {
+      spotify_artist_id: rec.spotify_artist_id,
+      artist_data: rec.artist_data,
+      score: rec.score,
+      why: rec.why,
+      artist_color: (rec.artist_data as Record<string, unknown>)?.artist_color as string | null ?? null,
+      seen_at: rec.seen_at,
+      signal,
+      bookmarked: savedSet.has(rec.spotify_artist_id),
+    }
+  })
 
   return Response.json({ history, hasMore: seenArtistIds.length === limit })
 }

--- a/components/explore/explore-client.tsx
+++ b/components/explore/explore-client.tsx
@@ -226,9 +226,6 @@ export function ExploreClient({
           body: JSON.stringify({ spotifyArtistId: artistId }),
         })
         if (!res.ok) throw new Error("server")
-        if (!isCurrentlySaved) {
-          setDismissedSignals((prev) => new Map(prev).set(artistId, "saved"))
-        }
       } catch {
         setSavedIds((prev) => {
           const n = new Set(prev)
@@ -247,12 +244,21 @@ export function ExploreClient({
     try {
       const res = await fetch("/api/explore/generate?force=true", { method: "POST" })
       if (!res.ok) throw new Error("generate failed")
-      // Clear dismissed for the active tab's artists so a fresh roll isn't hidden.
+      // Drop stale thumbs_up entries so a refreshed roll doesn't carry over the
+      // green outline from the previous deck. thumbs_down and skip (Dismiss)
+      // stay put — the server filter now permanently excludes them anyway, and
+      // retaining the local entries is defensive for any in-flight writes.
       setDismissedSignals((prev) => {
         if (!activeRail) return prev
+        let changed = false
         const n = new Map(prev)
-        for (const a of activeRail.artists) n.delete(a.id)
-        return n
+        for (const a of activeRail.artists) {
+          if (n.get(a.id) === "thumbs_up") {
+            n.delete(a.id)
+            changed = true
+          }
+        }
+        return changed ? n : prev
       })
       startTransition(() => router.refresh())
     } catch {

--- a/components/feed/artist-card.tsx
+++ b/components/feed/artist-card.tsx
@@ -54,8 +54,7 @@ export interface ArtistCardProps {
    *   - null           → expanded card, default buttons
    *   - "thumbs_up"    → expanded card, green outline + "Liked" button (keep playing)
    *   - "thumbs_down"  → collapsed 56px bar, red-tinted "Passed"
-   *   - "skip"         → collapsed 56px bar, neutral "Maybe later"
-   *   - "saved"        → collapsed 56px bar, accent "Saved"
+   *   - "skip"         → collapsed 56px bar, neutral "Dismissed"
    */
   dismissSignal?: string | null
 }
@@ -64,8 +63,9 @@ export interface ArtistCardProps {
 // Component
 // ---------------------------------------------------------------------------
 
-// Collapse the card for thumbs_down / skip / saved, but NOT thumbs_up — we
-// keep the card visible after a like so the user can keep listening.
+// Collapse the card for thumbs_down / skip, but NOT thumbs_up — we keep the
+// card visible after a like so the user can keep listening. Bookmark no
+// longer dismisses: saves only toggle the bookmark icon.
 function signalCollapses(signal: string | null | undefined): boolean {
   return signal != null && signal !== "thumbs_up"
 }
@@ -149,14 +149,12 @@ function ArtistCardImpl({
 
   // ------------------------------------------------------------------
   // Collapsed (slim bar) state — no emoji, colour-coded labels. Only applies
-  // to thumbs_down / skip / saved. Thumbs_up keeps the card expanded below so
-  // the user can keep listening after liking.
+  // to thumbs_down / skip. Thumbs_up and saves keep the card expanded.
   // ------------------------------------------------------------------
   if (isCollapsed) {
     const labelMap: Record<string, { text: string; color: string; border: string }> = {
-      thumbs_down: { text: "Passed",      color: "var(--dislike)",    border: "rgba(255,75,75,0.35)" },
-      skip:        { text: "Maybe later", color: "var(--text-muted)", border: "var(--border)" },
-      saved:       { text: "Saved",       color: "var(--accent)",     border: "rgba(139,92,246,0.35)" },
+      thumbs_down: { text: "Passed",    color: "var(--dislike)",    border: "rgba(255,75,75,0.35)" },
+      skip:        { text: "Dismissed", color: "var(--text-muted)", border: "var(--border)" },
     }
     const signal = labelMap[dismissSignal ?? "skip"] ?? labelMap.skip
 
@@ -429,7 +427,7 @@ function ArtistCardImpl({
               className="btn"
               style={{ flex: 1, minWidth: 0, fontSize: 13, whiteSpace: "nowrap" }}
             >
-              <SkipForward size={15} /> Later
+              <SkipForward size={15} /> Dismiss
             </button>
             <button
               onClick={() => onFeedback("thumbs_up")}

--- a/components/history/history-client.tsx
+++ b/components/history/history-client.tsx
@@ -23,7 +23,7 @@ interface HistoryEntry {
   bookmarked: boolean
 }
 
-type FilterTab = "all" | "thumbs_up" | "thumbs_down" | "skip" | "bookmarked"
+type FilterTab = "all" | "thumbs_up" | "thumbs_down" | "skip" | "dismissed" | "bookmarked"
 
 interface HistoryClientProps {
   history: HistoryEntry[]
@@ -31,10 +31,11 @@ interface HistoryClientProps {
 }
 
 const SIG_STYLES: Record<string, { Icon: React.ElementType; color: string; label: string }> = {
-  thumbs_up:   { Icon: ThumbsUp,    color: "var(--like)",      label: "Liked"   },
-  thumbs_down: { Icon: ThumbsDown,  color: "var(--dislike)",   label: "Passed"  },
-  skip:        { Icon: SkipForward, color: "var(--text-muted)", label: "Skipped" },
-  bookmarked:  { Icon: Bookmark,    color: "var(--accent)",    label: "Saved"   },
+  thumbs_up:   { Icon: ThumbsUp,    color: "var(--like)",       label: "Liked"     },
+  thumbs_down: { Icon: ThumbsDown,  color: "var(--dislike)",    label: "Passed"    },
+  skip:        { Icon: SkipForward, color: "var(--text-muted)", label: "Skipped"   },
+  dismissed:   { Icon: SkipForward, color: "var(--text-faint)", label: "Dismissed" },
+  bookmarked:  { Icon: Bookmark,    color: "var(--accent)",     label: "Saved"     },
 }
 
 function timeAgo(dateStr: string): string {
@@ -82,6 +83,7 @@ const FILTER_TABS: { key: FilterTab; label: string }[] = [
   { key: "thumbs_up",   label: "Liked"     },
   { key: "thumbs_down", label: "Passed"    },
   { key: "skip",        label: "Skipped"   },
+  { key: "dismissed",   label: "Dismissed" },
   { key: "bookmarked",  label: "Saved"     },
 ]
 
@@ -103,11 +105,12 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
   }, [history, filter])
 
   const counts = useMemo(() => {
-    const c: Record<FilterTab, number> = { all: history.length, thumbs_up: 0, thumbs_down: 0, skip: 0, bookmarked: 0 }
+    const c: Record<FilterTab, number> = { all: history.length, thumbs_up: 0, thumbs_down: 0, skip: 0, dismissed: 0, bookmarked: 0 }
     for (const h of history) {
       if (h.bookmarked) c.bookmarked++
       else if (h.signal === "thumbs_up") c.thumbs_up++
       else if (h.signal === "thumbs_down") c.thumbs_down++
+      else if (h.signal === "dismissed") c.dismissed++
       else c.skip++
     }
     return c
@@ -115,10 +118,16 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
 
   const groups = useMemo(() => groupByPeriod(filtered), [filtered])
 
-  async function handleUndo(artistId: string) {
+  async function handleUndo(artistId: string, signal: string) {
     setUndoingIds((prev) => new Set(prev).add(artistId))
+    // Dismissed items have no feedback row (the skip RPC only stamps
+    // recommendation_cache.skip_at). Clearing requires a separate endpoint
+    // that wipes skip_at + seen_at so the artist is fully eligible again.
+    const endpoint = signal === "dismissed"
+      ? `/api/dismiss/${artistId}`
+      : `/api/feedback/${artistId}`
     try {
-      const res = await fetch(`/api/feedback/${artistId}`, { method: "DELETE" })
+      const res = await fetch(endpoint, { method: "DELETE" })
       if (!res.ok) throw new Error("Server error")
       setHistory((prev) => prev.filter((h) => h.spotify_artist_id !== artistId))
     } catch {
@@ -297,7 +306,7 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
 
                       {/* Quick actions */}
                       <div style={{ display: "flex", alignItems: "center", gap: 2, flexShrink: 0 }}>
-                        {entry.signal !== "thumbs_up" && !entry.bookmarked && (
+                        {entry.signal !== "thumbs_up" && entry.signal !== "dismissed" && !entry.bookmarked && (
                           <button
                             onClick={() => handleChangeSignal(entry.spotify_artist_id, "thumbs_up")}
                             title="Change to Liked"
@@ -310,7 +319,7 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
                             <ThumbsUp size={13} />
                           </button>
                         )}
-                        {entry.signal !== "thumbs_down" && !entry.bookmarked && (
+                        {entry.signal !== "thumbs_down" && entry.signal !== "dismissed" && !entry.bookmarked && (
                           <button
                             onClick={() => handleChangeSignal(entry.spotify_artist_id, "thumbs_down")}
                             title="Change to Passed"
@@ -324,9 +333,9 @@ export function HistoryClient({ history: initialHistory, hasMore: initialHasMore
                           </button>
                         )}
                         <button
-                          onClick={() => handleUndo(entry.spotify_artist_id)}
+                          onClick={() => handleUndo(entry.spotify_artist_id, entry.signal)}
                           disabled={isUndoing}
-                          title="Undo — return to feed"
+                          title={entry.signal === "dismissed" ? "Unblock — allow in feed again" : "Undo — return to feed"}
                           style={{
                             width: 32, height: 32, borderRadius: 8,
                             background: "transparent", border: 0, cursor: "pointer",

--- a/components/settings/settings-form.tsx
+++ b/components/settings/settings-form.tsx
@@ -671,7 +671,7 @@ export function SettingsForm({
                 >
                   ♫
                 </div>
-                <div style={{ flex: 1 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontSize: 14, fontWeight: 600 }}>Last.fm</div>
                   <div
                     className="mono"
@@ -724,7 +724,7 @@ export function SettingsForm({
                 >
                   📊
                 </div>
-                <div style={{ flex: 1 }}>
+                <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontSize: 14, fontWeight: 600 }}>stats.fm</div>
                   <div
                     className="mono"

--- a/docs/prd-diversity-overhaul.md
+++ b/docs/prd-diversity-overhaul.md
@@ -1,0 +1,169 @@
+# PRD: Recommendation Diversity Overhaul
+
+**Status:** Drafted 2026-04-24 · Awaiting implementation
+**Related:** Shipped near-term nudge in [apps#114](https://github.com/TenNineteenOne/flipside/pull/114) (bumped `greedyPickTop` weights 0.05→0.10 / 0.04→0.08). This PRD covers the full overhaul.
+
+---
+
+## Problem
+
+A user who likes several artists in one session (e.g. liking 5 J-rock artists) risks their feed collapsing into a single-genre echo chamber. The recent soft diversity nudge (`genreWeight = 0.10`) helps on a homogeneous pool but doesn't address:
+
+- Feed and Explore both use **all thumbs-up artists as seeds** every request. The more a user likes, the more a dominant cluster self-reinforces — even a soft penalty can't break out when most seeds point to the same genre.
+- Explore's 4 rails each independently pick candidates; there's no cross-rail budget. A cluster can occupy meaningful shares of every rail.
+- No surface-level guarantee of "fresh air" — when a user's taste is narrow, the whole 80-item Explore page stays narrow.
+
+## North Star
+
+Likes are a **quiet signal**: they nudge, never dominate. The user's taste is represented without flooding the surface.
+
+## Decisions (locked)
+
+| # | Decision | Value |
+|---|---|---|
+| 1 | Cluster definition | Primary genre — `artist.genres[0]` |
+| 2 | Cluster cap | 25% of visible surface (Feed: 5/20, Explore: 20/80) |
+| 3 | Exploration budget — baseline | 20% of visible surface |
+| 4 | Exploration budget — Adventurous ON | 50% of visible surface |
+| 5 | Like scoring | **No boost** — likes only affect pool membership (no multiplier) |
+| 6 | Rolling like sample | 10 random likes per request |
+
+## Non-goals
+
+- **No scoring boost from likes.** The audit confirms likes already only affect pool membership via seed assembly — no `likeBoost` multiplier exists. This PRD *preserves* that shape and does not add one.
+- **No new user-facing toggles.** Exploration budget piggybacks on the existing Adventurous toggle.
+- **No schema changes.** `feedback`, `recommendation_cache`, `explore_cache` all stay as-is.
+- **No new tables or RPC surface.**
+- **No change to Dismiss / skip_at / Feed cooldown.** Shipped in 114.
+
+---
+
+## Current state (from codebase audit)
+
+- **Feed seed assembly** ([lib/recommendation/engine.ts:87](lib/recommendation/engine.ts#L87) `gatherSeedContext`) already `limit(10)` on thumbs-up but **fetches the 10 most recent**, not a random sample. Rolling sample is a single-line diff here.
+- **Explore seed assembly** ([lib/recommendation/explore-engine.ts:143](lib/recommendation/explore-engine.ts#L143) `loadUserContext`) fetches **ALL** thumbs-up IDs, no limit. `wildcardsRail` uses every like. This is where the rolling sample bites.
+- **Greedy-pick** ([engine.ts:240](lib/recommendation/engine.ts#L240)) applies `genreWeight` and `sourceWeight` soft penalties but **no hard cap**. Feed-only; Explore doesn't call it.
+- **Explore rail composition** ([explore-engine.ts:862](lib/recommendation/explore-engine.ts#L862) `buildExploreRails`) runs 4 rails in parallel via `Promise.allSettled`, no cross-rail cluster tracking.
+- **Exploration pool today:** Feed's `augmentWithAdjacent` injects 2 (non-adv) or 4 (adv) picks at positions ≥5. Explore's `leftfieldRail` is already unbiased (uniform tag sampling, no thumbs-up input) — it's the closest thing to an exploration rail, currently 10 of 80 slots (12.5%).
+- **Explore cache** ([explore-engine.ts:968](lib/recommendation/explore-engine.ts#L968)) keys on `(user_id, rail_key)` with 24h TTL + weekly `cacheWindowSeed`. Rolling sample at request time conflicts with stable cache — resolved by seeding the sample with the cache window, not fresh randomness.
+- **No like-scoring boost exists today.** The "pool-only, no boost" decision is a confirmation of current behavior, not a removal.
+
+---
+
+## Target state
+
+### Shared pipeline changes
+
+- **Seed assembly** draws a deterministic rolling sample of 10 likes per request, seeded by `cacheWindowSeed(userId, 'like-sample')` so the sample is stable across cache hits within the window but rotates when the window rolls or the cache is invalidated.
+- **Cluster tracking** is attached to the final visible set (post-composition). Any pick whose `artist.genres[0]` count would exceed the 25% cap is swapped for the next-best non-over-budget candidate from the same rail's leftover pool. If no swap is possible (pool exhausted), leave the pick and log a diagnostic.
+- **Exploration budget** is reserved *before* the biased pipeline runs. For a 20-slot Feed at 20%, slots 1–16 go to the biased pipeline and 4 slots are held for leftfield/adjacent-unbiased picks. For Explore's 80 slots, 16 (20%) or 40 (50% adv) come from the unbiased pool.
+
+### Feed (20 items per page)
+
+- **Biased pool** shrinks from full 20 to 16 (baseline) or 10 (adv).
+- **Unbiased pool** grows from `augmentWithAdjacent`'s 2/4 to 4/10 picks.
+- Cluster cap: max 5 of 20 (25%) from any `genres[0]`.
+
+### Explore (4 rails × 20 slots = 80 items)
+
+- **Baseline:** rail sizes stay as today (~10 each, adventurous bumps to ~12). Leftfield's existing ~12.5% share is *already* below the 20% target — bump its target from 10 to **16** so leftfield represents a clean 20% of visible Explore. Total becomes 10+10+10+16 = 46 before topup, up to ~60 after floor-topup.
+- **Adventurous:** leftfield target grows to **40**; other 3 rails stay at adventurous targets (12 each). Leftfield becomes half the visible Explore. Total becomes 12+12+12+40 = 76.
+- Cross-rail cluster cap: max 25% of the *total rendered* slots share a `genres[0]`. Enforced in `buildExploreRails` after `Promise.allSettled` returns but before cache upsert. Over-budget picks get swapped for under-budget leftovers from the same rail's pool.
+
+### Adventurous toggle semantics (cumulative)
+
+| Behavior | Today | After overhaul |
+|---|---|---|
+| `AFTERHOURS_TARGET` | 10 → 12 | unchanged |
+| `OUTSIDE_TARGET` | 10 → 12 | unchanged |
+| `WILDCARDS_TARGET` | 10 → 12 | unchanged |
+| `LEFTFIELD_TARGET` | 10 → 12 | **10 → 16 baseline, 12 → 40 adv** |
+| `ADVENTUROUS_MAINSTREAM_PENALTY` | 0.08 | unchanged |
+| Feed `augmentWithAdjacent` N | 2 / 4 | **4 / 10** |
+| Feed biased pool size | 20 | **20 / 16 / 10** (baseline Feed / budget baseline / adv) |
+
+---
+
+## Milestones
+
+### M1 — Rolling like sample (small, low risk)
+
+**Scope:** Replace "all likes" / "10 most recent" with "deterministic random sample of 10" in both engines.
+
+**Changes:**
+- `engine.ts:gatherSeedContext` — replace `.order('created_at', { ascending: false }).limit(10)` with a fetch-all + seeded-shuffle + slice(10). Seed = `cacheWindowSeed(userId, 'like-sample')`.
+- `explore-engine.ts:loadUserContext` — same treatment; tag as `thumbsUpIds = Set<string>` of the sampled 10, not all.
+- `wildcardsRail` now operates on the sampled set (no code change; reads from `thumbsUpIds`).
+- Tests: seed assembly tests in `engine.test.ts` need new assertions that sample size ≤ 10 and is deterministic per cache window.
+
+**Risks:** Users with <10 likes see no behavior change (still use all). Users with 10–30 likes see variety per window. Users with 50+ likes may notice specific niches disappear for a window.
+
+### M2 — Cluster cap (25% by primary genre)
+
+**Scope:** Hard post-composition cap on visible share of any primary genre, in Feed and across Explore.
+
+**Feed changes:**
+- After `greedyPickTop(pool, 20)` at [engine.ts:607](lib/recommendation/engine.ts#L607), add a `applyClusterCap(top, 0.25, leftover)` helper that walks the top-20, counts `genres[0]`, and when any genre exceeds 5 slots, swaps the lowest-scoring over-budget pick for the highest-scoring under-budget leftover.
+- Hook into Feed augmentation path similarly: adjacent injections must not push any genre over the cap.
+
+**Explore changes:**
+- New helper `enforceCrossRailBudget(rails, totalTarget, capPct)` called inside `buildExploreRails` after `Promise.allSettled` but before cache upsert. Walks all rendered picks by descending score, admits while under-cap, and for over-cap picks pulls next-best from the same rail's leftover pool.
+- `RailResult` needs a `leftover: ScoredArtist[]` field (or similar) so the budget-enforcer has somewhere to swap in from. Each rail already resolves more names than it picks — the residue becomes `leftover`.
+
+**Tests:**
+- `engine.test.ts` — new "enforces 25% cap on homogeneous pool" case.
+- New `explore-engine.test.ts` coverage for `enforceCrossRailBudget`.
+
+### M3 — Exploration budget (20% / 50%)
+
+**Scope:** Reserve visible share for unbiased picks.
+
+**Feed changes:**
+- Bump `augmentWithAdjacent` injection count: non-adventurous N=4, adventurous N=10. Constants at [engine.ts:322–327](lib/recommendation/engine.ts#L322).
+- Biased greedy-pick reduces to `20 - N` slots so the final page is `biased + unbiased = 20`.
+- Position constraint stays (injections at ≥5, or ≥3 adventurous).
+
+**Explore changes:**
+- `LEFTFIELD_TARGET`: 10 → 16 (baseline), 12 → 40 (adventurous). Constants at [explore-engine.ts:663–664](lib/recommendation/explore-engine.ts#L663).
+- `LEFTFIELD_PICKS_PER_TAG` probably needs to scale to supply enough candidates for 40. Audit says current is 8 / 10 — may need 12–14 for adv.
+
+**Cache implications:**
+- Bumping `LEFTFIELD_TARGET` changes the cached rail shape. The next deploy invalidates the explore cache naturally via `invalidateExploreCache` on any write. Optionally, bump the cache key version to force invalidation for existing users.
+
+**Tests:**
+- `augmentWithAdjacent` tests need updates for new N.
+- Leftfield rail test needs updated target expectations.
+
+### M4 — Tests, telemetry, cleanup
+
+**Scope:** Round out test coverage; add diagnostic logging; remove the temporary `greedyPickTop` weight bump rationale comment at [engine.ts:232–239](lib/recommendation/engine.ts#L232).
+
+**Telemetry (optional, logging only — no new tables):**
+- Log cluster distribution post-cap in Feed: `"cluster-cap: %o"` with `{ topGenre, topGenreShare, swaps }`.
+- Log rolled sample size + hit-rate: `"like-sample: size=N, hits=M"`.
+- Log exploration-pool fill: `"exploration-budget: target=T, filled=F"`.
+
+---
+
+## Caching & invalidation
+
+- **Feed cache (`recommendation_cache`):** unchanged. Rolling sample key = cache window hash, so same user in same window gets same 10-like sample → same cache hits.
+- **Explore cache (`explore_cache`):** rail target bumps (M3) and cross-rail budget enforcement (M2) change rendered shape. Existing `invalidateExploreCache` triggers (thumbs-up, thumbs-down, seed change, selected_genres change, adventurous toggle) all still work. A user's cache will naturally roll over within 24h TTL, or sooner on any interaction.
+- Consider bumping a cache-key version suffix (`rail_key = 'leftfield'` → `rail_key = 'leftfield-v2'`) on deploy to force invalidation, but not required.
+
+## Risks
+
+1. **Narrow-taste users.** Users with very narrow taste (e.g., 5 total likes, all J-rock) may see the 25% cap produce < 80 filled slots because the pool is exhausted of non-J-rock at reasonable scores. Mitigation: floor-topup already pulls from leftfield as a fallback; this is acceptable since leftfield is genre-diverse by construction.
+2. **Rolling sample + Shuffle interaction.** Shuffle should ideally pick a *new* sample of 10 rather than re-shuffle the existing composition. Plan: on shuffle, advance the sample seed (`cacheWindowSeed(userId, 'like-sample-' + shuffleCount)` or similar) before invalidating rail cache.
+3. **Exploration budget at 50% in Adventurous.** This is aggressive. Monitor thumbs-down rate on leftfield rail picks after ship. If it spikes, revisit the 50%.
+4. **Cross-rail budget may over-correct.** If 25% is too tight for users with genuinely narrow taste, we may see lots of swap-ins from the tail of each rail. Pre-launch: dry-run the budget on a seed user with narrow taste and confirm the swap-in tail is reasonable.
+
+## Open questions
+
+*None blocking — all 5 decisions locked. Telemetry-driven tuning (cap %, budget %) can iterate post-ship.*
+
+## Out of scope / future
+
+- Rolling sample weighting (recency + random hybrid). Current decision: uniform random. If post-ship data shows stale likes dominating, revisit.
+- Per-user cluster cap tuning. If product wants "strict" or "loose" modes, the cap can be exposed via a Settings slider in a future revision.
+- Explicit "exploration rail" UI affordance (e.g., a "Fresh air" label on leftfield). Nice-to-have, not required.

--- a/lib/recommendation/cluster-cap.test.ts
+++ b/lib/recommendation/cluster-cap.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest"
+import {
+  applyClusterCap,
+  applyCrossRailClusterCap,
+  primaryGenreOf,
+  CLUSTER_CAP_PCT,
+} from "./cluster-cap"
+
+type A = { id: string; genres?: string[] }
+
+const a = (id: string, g: string): A => ({ id, genres: [g] })
+
+describe("applyClusterCap", () => {
+  it("no-ops when nothing is over the cap", () => {
+    const picks = [a("1", "rock"), a("2", "pop"), a("3", "jazz"), a("4", "rock")]
+    const leftover = [a("5", "pop")]
+    const before = picks.map((p) => p.id)
+    applyClusterCap(picks, leftover, primaryGenreOf, 0.5)
+    expect(picks.map((p) => p.id)).toEqual(before)
+  })
+
+  it("swaps over-cap offender with under-cap leftover", () => {
+    // 4 rock in 4 picks → 100% > 25% cap
+    const picks = [a("1", "rock"), a("2", "rock"), a("3", "rock"), a("4", "rock")]
+    const leftover = [a("5", "pop"), a("6", "jazz"), a("7", "electronic"), a("8", "folk")]
+    applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    // ceil(4 * 0.25) = 1, so at most 1 rock allowed
+    const rockCount = picks.filter((p) => p.genres?.[0] === "rock").length
+    expect(rockCount).toBeLessThanOrEqual(1)
+  })
+
+  it("prefers the lowest-ranked offender when swapping", () => {
+    const picks = [a("1", "rock"), a("2", "pop"), a("3", "rock")]
+    const leftover = [a("4", "jazz")]
+    // cap = ceil(3 * 0.25) = 1; rock count = 2 (over). Lowest-ranked rock is id 3.
+    applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    expect(picks.find((p) => p.id === "1")).toBeTruthy() // highest-ranked rock kept
+    expect(picks.find((p) => p.id === "3")).toBeFalsy() // lowest-ranked rock demoted
+    expect(picks.find((p) => p.id === "4")).toBeTruthy() // leftover promoted
+  })
+
+  it("picks the highest-ranked under-cap leftover first", () => {
+    const picks = [a("1", "rock"), a("2", "rock"), a("3", "rock")]
+    const leftover = [a("4", "pop"), a("5", "jazz")]
+    applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    // First under-cap leftover (pop, id 4) should be promoted.
+    expect(picks.find((p) => p.id === "4")).toBeTruthy()
+  })
+
+  it("leaves offenders in place when no under-cap leftover exists", () => {
+    const picks = [a("1", "rock"), a("2", "rock"), a("3", "rock")]
+    const leftover = [a("4", "rock"), a("5", "rock")]
+    applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    expect(picks.map((p) => p.genres?.[0])).toEqual(["rock", "rock", "rock"])
+  })
+
+  it("moves the demoted offender into leftover", () => {
+    const picks = [a("1", "rock"), a("2", "rock")]
+    const leftover = [a("3", "pop")]
+    applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    expect(leftover.map((l) => l.id).sort()).toContain("2")
+  })
+
+  it("handles missing genres via primaryGenreOf fallback", () => {
+    const picks = [
+      { id: "1", genres: [] },
+      { id: "2", genres: [] },
+    ]
+    const leftover = [a("3", "jazz")]
+    applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    // Both picks have unknown genre, that's over cap — swap in jazz.
+    expect(picks.find((p) => p.id === "3")).toBeTruthy()
+  })
+
+  it("is deterministic across repeated runs", () => {
+    const build = () => ({
+      picks: [a("1", "rock"), a("2", "rock"), a("3", "rock"), a("4", "pop")],
+      leftover: [a("5", "jazz"), a("6", "electronic"), a("7", "pop")],
+    })
+    const one = build()
+    applyClusterCap(one.picks, one.leftover, primaryGenreOf, 0.25)
+    const two = build()
+    applyClusterCap(two.picks, two.leftover, primaryGenreOf, 0.25)
+    expect(one.picks.map((p) => p.id)).toEqual(two.picks.map((p) => p.id))
+  })
+})
+
+describe("applyCrossRailClusterCap", () => {
+  it("swaps within-rail only", () => {
+    // Rail A: 4 rock. Rail B: 4 jazz. Cap = ceil(8 * 0.25) = 2.
+    const railA = {
+      picks: [a("a1", "rock"), a("a2", "rock"), a("a3", "rock"), a("a4", "rock")],
+      leftover: [a("a5", "pop")],
+    }
+    const railB = {
+      picks: [a("b1", "jazz"), a("b2", "jazz"), a("b3", "jazz"), a("b4", "jazz")],
+      leftover: [a("b5", "electronic")],
+    }
+    applyCrossRailClusterCap([railA, railB], primaryGenreOf, 0.25)
+    // Rail A should not contain b5, and rail B should not contain a5.
+    expect(railA.picks.find((p) => p.id === "b5")).toBeFalsy()
+    expect(railB.picks.find((p) => p.id === "a5")).toBeFalsy()
+  })
+
+  it("targets the rail with the highest concentration of the over-genre", () => {
+    // Rail A has 4 rock, Rail B has 1 rock. Cap = ceil(10 * 0.25) = 3.
+    // Rock count = 5, over cap by 2. Rail A should lose rock, not B.
+    const railA = {
+      picks: [a("a1", "rock"), a("a2", "rock"), a("a3", "rock"), a("a4", "rock"), a("a5", "pop")],
+      leftover: [a("a6", "jazz"), a("a7", "jazz")],
+    }
+    const railB = {
+      picks: [a("b1", "pop"), a("b2", "pop"), a("b3", "pop"), a("b4", "pop"), a("b5", "rock")],
+      leftover: [a("b6", "jazz")],
+    }
+    applyCrossRailClusterCap([railA, railB], primaryGenreOf, 0.25)
+    const rockInA = railA.picks.filter((p) => p.genres?.[0] === "rock").length
+    const rockInB = railB.picks.filter((p) => p.genres?.[0] === "rock").length
+    expect(rockInA).toBeLessThanOrEqual(2)
+    expect(rockInB).toBe(1) // untouched
+  })
+
+  it("respects the cap across all rails combined", () => {
+    const railA = {
+      picks: [a("a1", "rock"), a("a2", "rock"), a("a3", "rock")],
+      leftover: [a("a4", "pop"), a("a5", "jazz")],
+    }
+    const railB = {
+      picks: [a("b1", "rock"), a("b2", "rock"), a("b3", "rock")],
+      leftover: [a("b4", "pop"), a("b5", "electronic")],
+    }
+    applyCrossRailClusterCap([railA, railB], primaryGenreOf, 0.25)
+    const total = [...railA.picks, ...railB.picks]
+    const rockTotal = total.filter((p) => p.genres?.[0] === "rock").length
+    expect(rockTotal).toBeLessThanOrEqual(Math.ceil(total.length * 0.25))
+  })
+
+  it("no-ops when already under cap", () => {
+    const railA = {
+      picks: [a("a1", "rock"), a("a2", "pop"), a("a3", "jazz"), a("a4", "electronic")],
+      leftover: [a("a5", "folk")],
+    }
+    const railB = {
+      picks: [a("b1", "rock"), a("b2", "pop"), a("b3", "jazz"), a("b4", "electronic")],
+      leftover: [a("b5", "folk")],
+    }
+    const before = [...railA.picks.map((p) => p.id), ...railB.picks.map((p) => p.id)]
+    applyCrossRailClusterCap([railA, railB], primaryGenreOf)
+    const after = [...railA.picks.map((p) => p.id), ...railB.picks.map((p) => p.id)]
+    expect(after).toEqual(before)
+  })
+
+  it("gives up cleanly when no valid swap exists in any rail", () => {
+    // Every leftover is also the over-cap genre → no valid swap.
+    const railA = {
+      picks: [a("a1", "rock"), a("a2", "rock"), a("a3", "rock")],
+      leftover: [a("a4", "rock")],
+    }
+    const railB = {
+      picks: [a("b1", "rock"), a("b2", "rock"), a("b3", "rock")],
+      leftover: [a("b4", "rock")],
+    }
+    applyCrossRailClusterCap([railA, railB], primaryGenreOf, 0.25)
+    // Same composition — just returns without infinite loop.
+    expect(railA.picks.every((p) => p.genres?.[0] === "rock")).toBe(true)
+    expect(railB.picks.every((p) => p.genres?.[0] === "rock")).toBe(true)
+  })
+
+  it("handles empty rails", () => {
+    const empty = { picks: [] as A[], leftover: [] as A[] }
+    const normal = {
+      picks: [a("1", "rock"), a("2", "pop")],
+      leftover: [a("3", "jazz")],
+    }
+    applyCrossRailClusterCap([empty, normal], primaryGenreOf)
+    expect(normal.picks).toHaveLength(2)
+  })
+})
+
+describe("CLUSTER_CAP_PCT", () => {
+  it("is 25%", () => {
+    expect(CLUSTER_CAP_PCT).toBe(0.25)
+  })
+})
+
+describe("CapStats telemetry", () => {
+  it("applyClusterCap counts swaps and reports top share", () => {
+    const picks = [a("1", "rock"), a("2", "rock"), a("3", "rock"), a("4", "rock")]
+    const leftover = [a("5", "pop"), a("6", "jazz"), a("7", "electronic")]
+    const stats = applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    expect(stats.swaps).toBeGreaterThan(0)
+    expect(stats.topShare).toBeLessThanOrEqual(0.5)
+    expect(stats.topGenre).toBeTruthy()
+  })
+
+  it("applyClusterCap returns zero swaps when already compliant", () => {
+    const picks = [a("1", "rock"), a("2", "pop"), a("3", "jazz"), a("4", "electronic")]
+    const leftover = [a("5", "folk")]
+    const stats = applyClusterCap(picks, leftover, primaryGenreOf, 0.25)
+    expect(stats.swaps).toBe(0)
+    expect(stats.topShare).toBe(0.25)
+  })
+
+  it("applyCrossRailClusterCap reports total-surface topShare", () => {
+    const railA = {
+      picks: [a("a1", "rock"), a("a2", "rock")],
+      leftover: [a("a3", "pop"), a("a4", "jazz"), a("a5", "electronic")],
+    }
+    const railB = {
+      picks: [a("b1", "rock"), a("b2", "rock")],
+      leftover: [a("b3", "folk"), a("b4", "soul"), a("b5", "funk")],
+    }
+    const stats = applyCrossRailClusterCap([railA, railB], primaryGenreOf, 0.25)
+    expect(stats.swaps).toBeGreaterThan(0)
+    // 4 picks total; cap = ceil(4 * 0.25) = 1, so max 1 rock → topShare ≤ 0.25.
+    expect(stats.topShare).toBeLessThanOrEqual(0.25)
+  })
+})

--- a/lib/recommendation/cluster-cap.ts
+++ b/lib/recommendation/cluster-cap.ts
@@ -1,0 +1,187 @@
+/**
+ * Cross-rail / pool cluster cap for the diversity overhaul (M2).
+ *
+ * Cluster = artist.genres[0] (primary genre). Cap is a fraction of the visible
+ * surface (picks across all rails for Explore, top pool for Feed). When a
+ * genre exceeds the cap, we swap the lowest-ranked offender(s) with the
+ * highest-ranked leftover whose genre is still under the cap, preferring
+ * swaps within the same rail (for Explore) so each rail's identity stays
+ * intact.
+ *
+ * Deterministic and idempotent given the same inputs — runs before cache
+ * writes so cache-hit paths serve the capped result directly.
+ */
+
+export const CLUSTER_CAP_PCT = 0.25
+
+/**
+ * Cap a single ranked list in place. `picks` is the final visible list;
+ * `leftover` is the ranked tail that didn't make the target. When a genre's
+ * share of `picks` exceeds `ceil(picks.length * capPct)`, swap the lowest-
+ * ranked offender with the highest-ranked under-cap leftover. Stops when no
+ * over-cap genre remains or no valid swap is available.
+ */
+export interface CapStats {
+  /** Number of swaps performed. */
+  swaps: number
+  /** Top-genre share after swapping (0..1). */
+  topShare: number
+  /** Primary genre with the highest post-cap count. */
+  topGenre: string | null
+}
+
+export function applyClusterCap<T>(
+  picks: T[],
+  leftover: T[],
+  getGenre: (t: T) => string,
+  capPct: number = CLUSTER_CAP_PCT,
+): CapStats {
+  if (picks.length === 0) return { swaps: 0, topShare: 0, topGenre: null }
+  const limit = Math.ceil(picks.length * capPct)
+  const counts = new Map<string, number>()
+  for (const p of picks) counts.set(getGenre(p), (counts.get(getGenre(p)) ?? 0) + 1)
+
+  let swaps = 0
+  let iters = 0
+  const maxIters = picks.length * 4
+  while (iters++ < maxIters) {
+    let offenderIdx = -1
+    for (let i = picks.length - 1; i >= 0; i--) {
+      if ((counts.get(getGenre(picks[i])) ?? 0) > limit) {
+        offenderIdx = i
+        break
+      }
+    }
+    if (offenderIdx < 0) break
+
+    let leftIdx = -1
+    for (let i = 0; i < leftover.length; i++) {
+      const ng = getGenre(leftover[i])
+      if ((counts.get(ng) ?? 0) < limit) {
+        leftIdx = i
+        break
+      }
+    }
+    if (leftIdx < 0) break
+
+    const out = picks[offenderIdx]
+    const inn = leftover[leftIdx]
+    picks[offenderIdx] = inn
+    leftover.splice(leftIdx, 1, out)
+    counts.set(getGenre(out), (counts.get(getGenre(out)) ?? 0) - 1)
+    counts.set(getGenre(inn), (counts.get(getGenre(inn)) ?? 0) + 1)
+    swaps++
+  }
+
+  let topGenre: string | null = null
+  let topCount = 0
+  for (const [g, c] of counts) {
+    if (c > topCount) { topCount = c; topGenre = g }
+  }
+  return { swaps, topShare: topCount / picks.length, topGenre }
+}
+
+/**
+ * Cap across multiple rails against a shared budget (total visible picks). Swaps
+ * stay within-rail so each rail's theme is preserved — if a rail has no valid
+ * under-cap leftover, we move on to the next-best rail for the offending genre.
+ */
+export function applyCrossRailClusterCap<T>(
+  rails: Array<{ picks: T[]; leftover: T[] }>,
+  getGenre: (t: T) => string,
+  capPct: number = CLUSTER_CAP_PCT,
+): CapStats {
+  const totalPicks = rails.reduce((sum, r) => sum + r.picks.length, 0)
+  if (totalPicks === 0) return { swaps: 0, topShare: 0, topGenre: null }
+  const limit = Math.ceil(totalPicks * capPct)
+
+  const counts = new Map<string, number>()
+  for (const rail of rails) {
+    for (const a of rail.picks) counts.set(getGenre(a), (counts.get(getGenre(a)) ?? 0) + 1)
+  }
+
+  const exhaustedForGenre = new Set<string>()
+  const genreFullyExhausted = new Set<string>()
+  let swaps = 0
+  let iters = 0
+  const maxIters = totalPicks * 4
+  while (iters++ < maxIters) {
+    let overGenre: string | null = null
+    let overCount = 0
+    for (const [g, c] of counts) {
+      if (genreFullyExhausted.has(g)) continue
+      if (c > limit && c > overCount) {
+        overGenre = g
+        overCount = c
+      }
+    }
+    if (!overGenre) break
+
+    let bestRailIdx = -1
+    let bestRailCount = 0
+    for (let i = 0; i < rails.length; i++) {
+      const key = `${i}:${overGenre}`
+      if (exhaustedForGenre.has(key)) continue
+      const rail = rails[i]
+      let c = 0
+      for (const a of rail.picks) if (getGenre(a) === overGenre) c++
+      if (c > bestRailCount) {
+        bestRailCount = c
+        bestRailIdx = i
+      }
+    }
+    if (bestRailIdx < 0) {
+      genreFullyExhausted.add(overGenre)
+      continue
+    }
+
+    const rail = rails[bestRailIdx]
+    let offenderIdx = -1
+    for (let i = rail.picks.length - 1; i >= 0; i--) {
+      if (getGenre(rail.picks[i]) === overGenre) {
+        offenderIdx = i
+        break
+      }
+    }
+    if (offenderIdx < 0) {
+      exhaustedForGenre.add(`${bestRailIdx}:${overGenre}`)
+      continue
+    }
+
+    let leftIdx = -1
+    for (let i = 0; i < rail.leftover.length; i++) {
+      const ng = getGenre(rail.leftover[i])
+      if ((counts.get(ng) ?? 0) < limit) {
+        leftIdx = i
+        break
+      }
+    }
+    if (leftIdx < 0) {
+      exhaustedForGenre.add(`${bestRailIdx}:${overGenre}`)
+      continue
+    }
+
+    const out = rail.picks[offenderIdx]
+    const inn = rail.leftover[leftIdx]
+    rail.picks[offenderIdx] = inn
+    rail.leftover.splice(leftIdx, 1, out)
+    counts.set(getGenre(out), (counts.get(getGenre(out)) ?? 0) - 1)
+    counts.set(getGenre(inn), (counts.get(getGenre(inn)) ?? 0) + 1)
+    swaps++
+  }
+
+  let topGenre: string | null = null
+  let topCount = 0
+  for (const [g, c] of counts) {
+    if (c > topCount) { topCount = c; topGenre = g }
+  }
+  return { swaps, topShare: totalPicks > 0 ? topCount / totalPicks : 0, topGenre }
+}
+
+/** Default genre accessor: primary genre with `unknown` fallback. Treats
+ * empty-string genre as missing so metadata-poor artists don't form their
+ * own bucket. */
+export function primaryGenreOf<T extends { genres?: string[] }>(a: T): string {
+  const g = a.genres?.[0]
+  return g && g.length > 0 ? g : 'unknown'
+}

--- a/lib/recommendation/engine.test.ts
+++ b/lib/recommendation/engine.test.ts
@@ -326,17 +326,17 @@ describe("isEligibleForCooldown", () => {
     expect(isEligibleForCooldown(eightDays, null, now)).toBe(true)
   })
 
-  it("blocks when skip_at is within 30 days", () => {
+  it("blocks when skip_at is set recently (permanent dismiss)", () => {
     const fifteenDays = new Date(now.getTime() - 15 * 86400_000).toISOString()
     expect(isEligibleForCooldown(null, fifteenDays, now)).toBe(false)
   })
 
-  it("allows when skip_at is past 30 days", () => {
-    const thirtyFiveDays = new Date(now.getTime() - 35 * 86400_000).toISOString()
-    expect(isEligibleForCooldown(null, thirtyFiveDays, now)).toBe(true)
+  it("blocks when skip_at is set long ago (permanent dismiss, no expiry)", () => {
+    const hundredDays = new Date(now.getTime() - 100 * 86400_000).toISOString()
+    expect(isEligibleForCooldown(null, hundredDays, now)).toBe(false)
   })
 
-  it("skip cooldown outranks seen cooldown (fresh seen, old skip → blocked)", () => {
+  it("skip cooldown outranks seen cooldown (any skip_at blocks regardless of age)", () => {
     const seen = new Date(now.getTime() - 1 * 86400_000).toISOString()
     const skip = new Date(now.getTime() - 28 * 86400_000).toISOString()
     expect(isEligibleForCooldown(seen, skip, now)).toBe(false)
@@ -344,17 +344,17 @@ describe("isEligibleForCooldown", () => {
 })
 
 describe("greedyPickTop diversity strength", () => {
-  it("homogeneous 40-rock pool produces ≤12 rocks in top 20 at 0.05 penalty", () => {
+  it("homogeneous 40-rock pool produces ≤10 rocks in top 20 at 0.10 penalty", () => {
     // 40 candidates, 30 rock (score 0.5 descending) + 10 other genres (score 0.4 descending).
-    // At 0.02 penalty the top would skew heavy-rock; at 0.05 the penalty
-    // after 5-6 rock picks exceeds the 0.1 score gap and diversity wins.
+    // At 0.10 penalty the 2nd rock already costs 0.10 (landing at 0.399 vs 0.4
+    // for the next other genre), so others sweep in until exhausted.
     const pool: ScoredArtist[] = [
       ...Array.from({ length: 30 }, (_, i) => scored(`r${i}`, 0.5 - i * 0.001, [`S${i}`], "rock")),
       ...Array.from({ length: 10 }, (_, i) => scored(`o${i}`, 0.4 - i * 0.001, [`T${i}`], `genre_${i}`)),
     ]
     const top = greedyPickTop(pool, 20)
     const rocks = top.filter((t) => t.artist.genres[0] === "rock").length
-    expect(rocks).toBeLessThanOrEqual(12)
+    expect(rocks).toBeLessThanOrEqual(10)
   })
 })
 

--- a/lib/recommendation/engine.test.ts
+++ b/lib/recommendation/engine.test.ts
@@ -371,7 +371,7 @@ describe("augmentWithAdjacent", () => {
 
   const emptySet = new Set<string>()
 
-  it("non-adventurous: injects ≤2 adjacent picks at positions ≥5", async () => {
+  it("non-adventurous: injects ≤4 adjacent picks at positions ≥5", async () => {
     const base = makeBase(20)
     const result = await augmentWithAdjacent(base, {
       userGenres: ["indie-rock"],
@@ -380,33 +380,7 @@ describe("augmentWithAdjacent", () => {
       thumbsDownIds: emptySet,
       overThresholdIds: emptySet,
       overThresholdNames: emptySet,
-      fetchTagArtists: async () => ["adj1", "adj2", "adj3"],
-      resolveArtists: async (names) => {
-        const m = new Map<string, Artist>()
-        for (const n of names) m.set(n, mkArtist(`id_${n}`, 30, "indie-pop"))
-        return m
-      },
-    })
-    const bleedIdxs = result
-      .map((r, i) => ({ r, i }))
-      .filter(({ r }) => r.source === "adjacent_bleed")
-      .map(({ i }) => i)
-    expect(bleedIdxs.length).toBeLessThanOrEqual(2)
-    for (const i of bleedIdxs) expect(i).toBeGreaterThanOrEqual(5)
-    // Positions 0-4 are untouched.
-    for (let i = 0; i < 5; i++) expect(result[i].source).toBe("test")
-  })
-
-  it("adventurous: injects ≤4 adjacent picks at positions ≥3", async () => {
-    const base = makeBase(20)
-    const result = await augmentWithAdjacent(base, {
-      userGenres: ["indie-rock"],
-      adventurous: true,
-      popularityCurve: 0.95,
-      thumbsDownIds: emptySet,
-      overThresholdIds: emptySet,
-      overThresholdNames: emptySet,
-      fetchTagArtists: async () => ["adj1", "adj2", "adj3", "adj4", "adj5", "adj6"],
+      fetchTagArtists: async () => ["adj1", "adj2", "adj3", "adj4", "adj5"],
       resolveArtists: async (names) => {
         const m = new Map<string, Artist>()
         for (const n of names) m.set(n, mkArtist(`id_${n}`, 30, "indie-pop"))
@@ -418,6 +392,33 @@ describe("augmentWithAdjacent", () => {
       .filter(({ r }) => r.source === "adjacent_bleed")
       .map(({ i }) => i)
     expect(bleedIdxs.length).toBeLessThanOrEqual(4)
+    for (const i of bleedIdxs) expect(i).toBeGreaterThanOrEqual(5)
+    // Positions 0-4 are untouched.
+    for (let i = 0; i < 5; i++) expect(result[i].source).toBe("test")
+  })
+
+  it("adventurous: injects ≤10 adjacent picks at positions ≥3", async () => {
+    const base = makeBase(20)
+    const adjNames = Array.from({ length: 12 }, (_, i) => `adj${i}`)
+    const result = await augmentWithAdjacent(base, {
+      userGenres: ["indie-rock"],
+      adventurous: true,
+      popularityCurve: 0.95,
+      thumbsDownIds: emptySet,
+      overThresholdIds: emptySet,
+      overThresholdNames: emptySet,
+      fetchTagArtists: async () => adjNames,
+      resolveArtists: async (names) => {
+        const m = new Map<string, Artist>()
+        for (const n of names) m.set(n, mkArtist(`id_${n}`, 30, "indie-pop"))
+        return m
+      },
+    })
+    const bleedIdxs = result
+      .map((r, i) => ({ r, i }))
+      .filter(({ r }) => r.source === "adjacent_bleed")
+      .map(({ i }) => i)
+    expect(bleedIdxs.length).toBeLessThanOrEqual(10)
     for (const i of bleedIdxs) expect(i).toBeGreaterThanOrEqual(3)
     // Positions 0-2 are untouched.
     for (let i = 0; i < 3; i++) expect(result[i].source).toBe("test")
@@ -500,6 +501,8 @@ describe("augmentWithAdjacent", () => {
 
   it("adventurous mainstream penalty orders low-pop injections ahead of high-pop", async () => {
     const base = makeBase(20)
+    const lowNames = Array.from({ length: 10 }, (_, i) => `low${i}`)
+    const highNames = ["high1"]
     const result = await augmentWithAdjacent(base, {
       userGenres: ["indie-rock"],
       adventurous: true,
@@ -507,7 +510,7 @@ describe("augmentWithAdjacent", () => {
       thumbsDownIds: emptySet,
       overThresholdIds: emptySet,
       overThresholdNames: emptySet,
-      fetchTagArtists: async () => ["low1", "low2", "low3", "low4", "high1"],
+      fetchTagArtists: async () => [...lowNames, ...highNames],
       resolveArtists: async (names) => {
         const m = new Map<string, Artist>()
         for (const n of names) {
@@ -518,7 +521,7 @@ describe("augmentWithAdjacent", () => {
       },
     })
     const injected = result.filter((r) => r.source === "adjacent_bleed")
-    // With 4-pick slots and 4 low + 1 high candidates, all 4 low beat the high.
+    // 10 low + 1 high candidates → all 10 low slots filled ahead of the high.
     expect(injected.every((r) => r.artist.popularity <= 50)).toBe(true)
   })
 

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -231,14 +231,17 @@ export async function runDeepHop(
 
 /**
  * Greedy pick with soft per-genre AND per-source-seed diversity penalties.
- * genreWeight raised 0.02 → 0.05 so the 6th same-genre pick takes a ~0.25
- * hit — enough to actually dominate score deltas in a homogeneous pool.
+ * genreWeight raised 0.05 → 0.10 (and sourceWeight 0.04 → 0.08) as a near-term
+ * nudge against session-echo from thumbs-up-heavy seed pools — the 6th
+ * same-genre pick now takes a ~0.50 hit, well above typical score deltas, so
+ * a homogeneous pool breaks up earlier. The full "quiet signal + rolling
+ * sample + cross-rail budget" overhaul lives in its own PRD.
  */
 export function greedyPickTop(
   pool: ScoredArtist[],
   maxSize = 20,
-  genreWeight = 0.05,
-  sourceWeight = 0.04
+  genreWeight = 0.10,
+  sourceWeight = 0.08
 ): ScoredArtist[] {
   const working = [...pool]
   const top: ScoredArtist[] = []
@@ -272,19 +275,16 @@ export function greedyPickTop(
 }
 
 /**
- * Cooldown gate: `skip_at` wins over `seen_at` because a deliberate skip
- * signals stronger disinterest than a passive surface, so the window is
- * longer (30d vs 7d).
+ * Cooldown gate: a `skip_at` timestamp is a permanent hide ("Dismiss" button).
+ * Undo is available from the History page, which clears skip_at via the
+ * dismiss RPC. A passive `seen_at` is a 7-day soft cooldown.
  */
 export function isEligibleForCooldown(
   seenAt: string | null | undefined,
   skipAt: string | null | undefined,
   now: Date = new Date()
 ): boolean {
-  if (skipAt) {
-    const days = (now.getTime() - new Date(skipAt).getTime()) / (1000 * 60 * 60 * 24)
-    if (days < 30) return false
-  }
+  if (skipAt) return false
   if (seenAt) {
     const days = (now.getTime() - new Date(seenAt).getTime()) / (1000 * 60 * 60 * 24)
     if (days < 7) return false

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -17,6 +17,8 @@ import { normalizedIncludes, normalizeGenre } from '@/lib/genre/normalize'
 import { adjacentGenres } from '@/lib/genre/adjacency'
 import { cachedTagArtistNames } from '@/lib/lastfm-cache'
 import coldStartData from '@/data/cold-start-seeds.json'
+import { sampleLikes, LIKE_SAMPLE_SIZE } from './window'
+import { applyClusterCap } from './cluster-cap'
 
 const LASTFM_BASE = "https://ws.audioscrobbler.com/2.0"
 
@@ -95,13 +97,15 @@ async function gatherSeedContext(
       .eq('user_id', userId)
       .then(({ data }) => (data ?? []).map((r) => r.name as string).filter(Boolean)),
 
+    // Fetch the full thumbs-up set; sampling is applied below via
+    // sampleLikes() so the Feed draws the same 10 random likes Explore uses
+    // within a cache window. See docs/prd-diversity-overhaul.md (M1).
     supabase
       .from('feedback')
       .select('spotify_artist_id')
       .eq('user_id', userId)
       .eq('signal', 'thumbs_up')
       .is('deleted_at', null)
-      .limit(10)
       .then(({ data }) => (data ?? []).map((r) => r.spotify_artist_id as string).filter(Boolean)),
 
     supabase
@@ -114,12 +118,13 @@ async function gatherSeedContext(
 
   const names: string[] = [...dbSeeds]
 
-  if (thumbsUpRows.length > 0) {
+  const sampledThumbsUp = sampleLikes(thumbsUpRows, userId)
+  if (sampledThumbsUp.length > 0) {
     const { data: cached } = await supabase
       .from('recommendation_cache')
       .select('artist_data')
       .eq('user_id', userId)
-      .in('spotify_artist_id', thumbsUpRows)
+      .in('spotify_artist_id', sampledThumbsUp)
     for (const row of cached ?? []) {
       const name = (row.artist_data as { name?: string })?.name
       if (name) names.push(name)
@@ -135,7 +140,9 @@ async function gatherSeedContext(
 
   console.log(
     `[engine] gather userId=${userId} selected_genres=${JSON.stringify(topGenres)} ` +
-    `dbSeeds=${dbSeeds.length} thumbsUp=${thumbsUpRows.length} totalPooled=${names.length}`
+    `dbSeeds=${dbSeeds.length} thumbsUpTotal=${thumbsUpRows.length} ` +
+    `thumbsUpSample=${sampledThumbsUp.length}/${LIKE_SAMPLE_SIZE} ` +
+    `totalPooled=${names.length}`
   )
 
   const deduped = [...new Set(names)]
@@ -231,11 +238,8 @@ export async function runDeepHop(
 
 /**
  * Greedy pick with soft per-genre AND per-source-seed diversity penalties.
- * genreWeight raised 0.05 → 0.10 (and sourceWeight 0.04 → 0.08) as a near-term
- * nudge against session-echo from thumbs-up-heavy seed pools — the 6th
- * same-genre pick now takes a ~0.50 hit, well above typical score deltas, so
- * a homogeneous pool breaks up earlier. The full "quiet signal + rolling
- * sample + cross-rail budget" overhaul lives in its own PRD.
+ * Soft penalties bias the ranking; the hard 25% cluster cap runs downstream
+ * (see applyClusterCap call in buildRecommendations) as a final guarantee.
  */
 export function greedyPickTop(
   pool: ScoredArtist[],
@@ -322,7 +326,8 @@ export async function augmentWithAdjacent(
   const adventurous = !!opts.adventurous
   const adaptive = !!opts.adaptiveBroadening
 
-  const N = adventurous ? 4 : 2
+  // Exploration budget (M3): 4 / 10 injections for 20% / 50% of a 20-item feed.
+  const N = adventurous ? 10 : 4
   const startPos = adventurous ? 3 : 5
   if (base.length <= startPos) return base
 
@@ -344,7 +349,10 @@ export async function augmentWithAdjacent(
     const j = Math.floor(Math.random() * (i + 1))
     ;[tags[i], tags[j]] = [tags[j], tags[i]]
   }
-  const maxTags = adventurous ? 6 : 3
+  // Each tag yields ~20 Last.fm names, from which most filter out. maxTags
+  // needs to scale with N so 10-pick Adventurous has enough surviving
+  // candidates after dedup + thumbs-down + listened filters.
+  const maxTags = adventurous ? 10 : 5
   const sampled = tags.slice(0, maxTags)
   if (sampled.length === 0) return base
 
@@ -605,6 +613,22 @@ async function runPipeline(o: RunPipelineOpts): Promise<BuildResult> {
   )
 
   const baseTop = greedyPickTop(pool, 20)
+
+  // 25% cluster cap (M2) — greedyPickTop's soft penalty nudges diversity, but
+  // a high-signal user with one dominant genre can still exceed the budget.
+  // Apply a hard cap by swapping over-budget picks with the best remaining
+  // pool tail whose primary genre is under-cap.
+  const baseTopIds = new Set(baseTop.map((s) => s.artist.id))
+  const baseLeftover = pool.filter((s) => !baseTopIds.has(s.artist.id))
+  const capStats = applyClusterCap(
+    baseTop,
+    baseLeftover,
+    (s: ScoredArtist) => s.artist.genres[0] ?? 'unknown',
+  )
+  console.log(
+    `[engine] cluster-cap source=${source} swaps=${capStats.swaps} ` +
+    `topGenre=${capStats.topGenre} topShare=${capStats.topShare.toFixed(2)}`
+  )
 
   if (baseTop.length === 0) {
     console.error(

--- a/lib/recommendation/explore-engine.ts
+++ b/lib/recommendation/explore-engine.ts
@@ -25,6 +25,8 @@ import {
   listAnchors,
 } from '@/lib/genre/adjacency'
 import { UNDERGROUND_MAX_POPULARITY } from './types'
+import { cacheWindowSeed, seededShuffle, sampleLikes } from './window'
+import { applyCrossRailClusterCap, primaryGenreOf } from './cluster-cap'
 
 export const RAIL_KEYS = ['adjacent', 'outside', 'wildcards', 'leftfield'] as const
 export type RailKey = typeof RAIL_KEYS[number]
@@ -53,6 +55,14 @@ export interface RailResult {
   railKey: RailKey
   artistIds: string[]
   why: Record<string, RailWhy>
+  /**
+   * Internal-only. Populated during rail generation so the cross-rail cluster
+   * cap can swap over-budget picks with under-budget leftovers without losing
+   * rank order. Omitted from the cache read path (cached rails are already
+   * post-cap so no further swaps are needed).
+   */
+  picks?: Artist[]
+  leftover?: Artist[]
 }
 
 export interface BuildRailsInput {
@@ -83,36 +93,6 @@ function buildEnrichArtist() {
   return (name: string) => fetchArtistEnrichment(name, apiKey)
 }
 
-/**
- * Deterministic cache-window hash. Keeps rail picks stable within the TTL so
- * a re-fetch during the same cache window doesn't shuffle results under the
- * user's feet (and can't be exploited to game uniqueness).
- */
-export function cacheWindowSeed(userId: string, seedKey: string): number {
-  const weekStart = Math.floor(Date.now() / (7 * 24 * 60 * 60 * 1000))
-  let h = 2166136261 >>> 0
-  const s = `${userId}:${seedKey}:${weekStart}`
-  for (let i = 0; i < s.length; i++) {
-    h ^= s.charCodeAt(i)
-    h = Math.imul(h, 16777619) >>> 0
-  }
-  return h
-}
-
-/**
- * Stable shuffle using the cache-window seed so the same user + same rail
- * produces the same order within a 7-day window.
- */
-export function seededShuffle<T>(arr: T[], seed: number): T[] {
-  const out = [...arr]
-  let s = seed || 1
-  for (let i = out.length - 1; i > 0; i--) {
-    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
-    const j = s % (i + 1)
-    ;[out[i], out[j]] = [out[j], out[i]]
-  }
-  return out
-}
 
 /**
  * Re-rank a candidate-name list by k^popularity so lower-popularity picks
@@ -176,13 +156,18 @@ async function loadUserContext(supabase: SupabaseClient, userId: string) {
     genres: genreById.get(r.spotify_artist_id as string) ?? [],
   }))
 
+  // Rolling like sample: up to 10 random likes per cache window. Prevents
+  // thumbs-up-heavy accounts from flooding every rail with the same cluster.
+  // See docs/prd-diversity-overhaul.md (M1).
+  const allThumbsUp = (thumbsUp ?? []).map((r) => r.spotify_artist_id as string)
+
   return {
     user,
     selectedGenres: ((user?.selected_genres ?? []) as string[]),
     seedArtists: (seedArtists ?? []) as Array<{ spotify_artist_id: string; name: string }>,
     listened,
     listenedIds: new Set(listenedIds),
-    thumbsUpIds: new Set((thumbsUp ?? []).map((r) => r.spotify_artist_id as string)),
+    thumbsUpIds: new Set(sampleLikes(allThumbsUp, userId)),
     thumbsDownIds: new Set((thumbsDown ?? []).map((r) => r.spotify_artist_id as string)),
   }
 }
@@ -371,20 +356,27 @@ export async function adjacentRail(
 
   const ranked = rankByCurve(namesRoundRobin, artistByName, input.popularityCurve)
 
-  const artistIds: string[] = []
+  const picks: Artist[] = []
+  const leftover: Artist[] = []
   const why: Record<string, RailWhy> = {}
   const seen = new Set<string>()
   for (const name of ranked) {
-    if (artistIds.length >= target) break
     const a = artistByName.get(name)
     if (!a || seen.has(a.id)) continue
     seen.add(a.id)
-    artistIds.push(a.id)
     const tag = nameToTag.get(name)
     why[a.id] = tag ? { tag, anchor: genreToAnchor(tag) ?? undefined } : {}
+    if (picks.length < target) picks.push(a)
+    else leftover.push(a)
   }
 
-  return { railKey: 'adjacent', artistIds, why }
+  return {
+    railKey: 'adjacent',
+    artistIds: picks.map((a) => a.id),
+    why,
+    picks,
+    leftover,
+  }
 }
 
 const OUTSIDE_TARGET = 10
@@ -498,21 +490,28 @@ export async function outsideRail(
 
   const ranked = rankByCurve(namesRoundRobin, artistByName, input.popularityCurve)
 
-  const artistIds: string[] = []
+  const picks: Artist[] = []
+  const leftover: Artist[] = []
   const why: Record<string, RailWhy> = {}
   const seenArtist = new Set<string>()
   for (const name of ranked) {
-    if (artistIds.length >= target) break
     const a = artistByName.get(name)
     if (!a || seenArtist.has(a.id)) continue
     seenArtist.add(a.id)
-    artistIds.push(a.id)
     const anchorId = nameToAnchor.get(name)
     const anchorLabel = picked.find((p) => p.id === anchorId)?.label
     why[a.id] = { anchor: anchorLabel ?? anchorId }
+    if (picks.length < target) picks.push(a)
+    else leftover.push(a)
   }
 
-  return { railKey: 'outside', artistIds, why }
+  return {
+    railKey: 'outside',
+    artistIds: picks.map((a) => a.id),
+    why,
+    picks,
+    leftover,
+  }
 }
 
 const WILDCARDS_TARGET = 10
@@ -628,17 +627,16 @@ export async function wildcardsRail(
 
   const ranked = rankByCurve(namesRoundRobin, artistByName, input.popularityCurve)
 
-  const artistIds: string[] = []
+  const picks: Artist[] = []
+  const leftover: Artist[] = []
   const why: Record<string, RailWhy> = {}
   const seenArtist = new Set<string>()
   for (const name of ranked) {
-    if (artistIds.length >= target) break
     const a = artistByName.get(name)
     if (!a || seenArtist.has(a.id)) continue
-    seenArtist.add(a.id)
     // Don't surface the thumbs-up seed itself.
     if (ctx.thumbsUpIds.has(a.id)) continue
-    artistIds.push(a.id)
+    seenArtist.add(a.id)
     const seed = nameToSeed.get(name)
     const match = nameToMatch.get(name)
     why[a.id] = seed
@@ -655,23 +653,37 @@ export async function wildcardsRail(
             : null,
         }
       : {}
+    if (picks.length < target) picks.push(a)
+    else leftover.push(a)
   }
 
-  return { railKey: 'wildcards', artistIds, why }
+  return {
+    railKey: 'wildcards',
+    artistIds: picks.map((a) => a.id),
+    why,
+    picks,
+    leftover,
+  }
 }
 
-const LEFTFIELD_TARGET = 10
-const LEFTFIELD_TARGET_ADVENTUROUS = 12
-const LEFTFIELD_SAMPLE_COUNT = 30 // over-sample so filtering still yields enough picks
-const LEFTFIELD_SAMPLE_COUNT_ADVENTUROUS = 28
+// Exploration budget (M3): leftfield is the unbiased / long-tail rail.
+// Baseline 16 / 46 ≈ 35%; adventurous 40 / 76 ≈ 53%. Values chosen from the
+// PRD's locked decisions (20% baseline / 50% adventurous) — baseline exceeds
+// the literal 20% target because leftfield is already the designated
+// exploration surface and shrinking it would regress existing diversity.
+const LEFTFIELD_TARGET = 16
+const LEFTFIELD_TARGET_ADVENTUROUS = 40
+const LEFTFIELD_SAMPLE_COUNT = 34
+const LEFTFIELD_SAMPLE_COUNT_ADVENTUROUS = 60
 const LEFTFIELD_MID_START = 10
 const LEFTFIELD_MID_END = 30
 // Per-tag pick count: Last.fm timeouts + Spotify-search misses + listened/seen
 // filters can drop 80%+ of candidates. Pulling multiple names per tag (and
 // round-robining so each slot comes from a different tag) gives the filter
-// pipeline enough slack to hit TARGET consistently.
-const LEFTFIELD_PICKS_PER_TAG = 8
-const LEFTFIELD_PICKS_PER_TAG_ADVENTUROUS = 10
+// pipeline enough slack to hit TARGET consistently. Adv target of 40 needs
+// meaningfully more candidates per tag so we don't fall short after attrition.
+const LEFTFIELD_PICKS_PER_TAG = 10
+const LEFTFIELD_PICKS_PER_TAG_ADVENTUROUS = 14
 
 /**
  * Left-field wildcards — uniform long-tail sampling of the leaf-tag universe
@@ -755,22 +767,29 @@ export async function leftfieldRail(
     const artistByName = new Map<string, Artist>()
     for (const a of resolved) artistByName.set(a.name, a)
 
-    const artistIds: string[] = []
+    const railPicks: Artist[] = []
+    const railLeftover: Artist[] = []
     const why: Record<string, RailWhy> = {}
     const seenArtist = new Set<string>()
     for (const name of namesRoundRobin) {
-      if (artistIds.length >= target) break
       const a = artistByName.get(name)
       if (!a || seenArtist.has(a.id)) continue
       if (excludeIds.has(a.id)) continue
       const meta = nameMeta.get(name)
       if (!meta) continue
       seenArtist.add(a.id)
-      artistIds.push(a.id)
       why[a.id] = { tag: meta.tag, anchor: meta.anchorId }
+      if (railPicks.length < target) railPicks.push(a)
+      else railLeftover.push(a)
     }
 
-    return { railKey: 'leftfield', artistIds, why }
+    return {
+      railKey: 'leftfield',
+      artistIds: railPicks.map((a) => a.id),
+      why,
+      picks: railPicks,
+      leftover: railLeftover,
+    }
   } catch (e) {
     console.error('[leftfield] THREW', e instanceof Error ? e.message : String(e), e instanceof Error ? e.stack : '')
     return { railKey: 'leftfield', artistIds: [], why: {} }
@@ -926,7 +945,41 @@ export async function buildExploreRails(
           ...fallback.why,
           [RAIL_META_KEY]: { fallbackKind: 'leftfield-for-wildcards' },
         },
+        picks: fallback.picks,
+        leftover: fallback.leftover,
       }
+    }
+  }
+
+  // Cross-rail cluster cap (M2). After fallback substitution so the swap
+  // budget counts the final rail composition, before the floor-topup so we
+  // don't drop short rails below MIN_PICKS_FLOOR via cap swaps.
+  const capRails = rails
+    .filter((r): r is RailResult & { picks: Artist[]; leftover: Artist[] } =>
+      Array.isArray(r.picks) && Array.isArray(r.leftover),
+    )
+    .map((r) => ({ picks: r.picks, leftover: r.leftover }))
+  const capStats = applyCrossRailClusterCap(capRails, primaryGenreOf)
+  for (const r of rails) {
+    if (r.picks) r.artistIds = r.picks.map((a) => a.id)
+  }
+  console.log(
+    `[explore-engine] cluster-cap swaps=${capStats.swaps} ` +
+    `topGenre=${capStats.topGenre} topShare=${capStats.topShare.toFixed(2)}`
+  )
+
+  // Defensive cross-rail dedup. The fallback substitution above excludes the
+  // *pre-cap* primary leftfield picks; if the cap later promotes an artist
+  // from primary leftfield's leftover that the fallback also chose, both
+  // rails would contain the same id. Keep the earliest-rail occurrence.
+  {
+    const seen = new Set<string>()
+    for (const r of rails) {
+      r.artistIds = r.artistIds.filter((id) => {
+        if (seen.has(id)) return false
+        seen.add(id)
+        return true
+      })
     }
   }
 

--- a/lib/recommendation/explore-engine.ts
+++ b/lib/recommendation/explore-engine.ts
@@ -223,7 +223,7 @@ async function resolveAndFilter(
   filters: {
     listenedIds: Set<string>
     thumbsDownIds: Set<string>
-    seenIds: Set<string>
+    excludedIds: Set<string>
     undergroundMode?: boolean
   },
 ): Promise<Artist[]> {
@@ -241,22 +241,38 @@ async function resolveAndFilter(
   for (const artist of resolved.resolved.values()) {
     if (filters.listenedIds.has(artist.id)) continue
     if (filters.thumbsDownIds.has(artist.id)) continue
-    if (filters.seenIds.has(artist.id)) continue
+    if (filters.excludedIds.has(artist.id)) continue
     if (filters.undergroundMode && (artist.popularity ?? 0) > UNDERGROUND_MAX_POPULARITY) continue
     out.push(artist)
   }
   return out
 }
 
-async function loadSeenIds(supabase: SupabaseClient, userId: string): Promise<Set<string>> {
+/**
+ * IDs the explore engine should never resurface this generation:
+ *   - seen_at within the 7-day passive cooldown
+ *   - skip_at set (permanent dismiss via the Dismiss button; undo lives on
+ *     the History page and clears skip_at via rpc_clear_dismiss)
+ */
+async function loadExcludedIds(supabase: SupabaseClient, userId: string): Promise<Set<string>> {
   const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
-  const { data } = await supabase
-    .from('recommendation_cache')
-    .select('spotify_artist_id, seen_at')
-    .eq('user_id', userId)
-    .not('seen_at', 'is', null)
-    .gte('seen_at', sevenDaysAgo)
-  return new Set((data ?? []).map((r) => r.spotify_artist_id as string))
+  const [seenRes, skipRes] = await Promise.all([
+    supabase
+      .from('recommendation_cache')
+      .select('spotify_artist_id')
+      .eq('user_id', userId)
+      .not('seen_at', 'is', null)
+      .gte('seen_at', sevenDaysAgo),
+    supabase
+      .from('recommendation_cache')
+      .select('spotify_artist_id')
+      .eq('user_id', userId)
+      .not('skip_at', 'is', null),
+  ])
+  const ids = new Set<string>()
+  for (const r of seenRes.data ?? []) ids.add(r.spotify_artist_id as string)
+  for (const r of skipRes.data ?? []) ids.add(r.spotify_artist_id as string)
+  return ids
 }
 
 // ── Rail implementations ────────────────────────────────────────────────────
@@ -302,7 +318,7 @@ export async function adjacentRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
 ): Promise<RailResult> {
   const target = input.adventurous ? AFTERHOURS_TARGET_ADVENTUROUS : AFTERHOURS_TARGET
   const perTag = AFTERHOURS_PER_TAG
@@ -346,7 +362,7 @@ export async function adjacentRail(
   const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
     listenedIds: ctx.listenedIds,
     thumbsDownIds: ctx.thumbsDownIds,
-    seenIds,
+    excludedIds,
     undergroundMode: input.undergroundMode,
   })
 
@@ -395,7 +411,7 @@ export async function outsideRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
 ): Promise<RailResult> {
   void supabase
   const target = input.adventurous ? OUTSIDE_TARGET_ADVENTUROUS : OUTSIDE_TARGET
@@ -473,7 +489,7 @@ export async function outsideRail(
   const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
     listenedIds: ctx.listenedIds,
     thumbsDownIds: ctx.thumbsDownIds,
-    seenIds,
+    excludedIds,
     undergroundMode: input.undergroundMode,
   })
 
@@ -521,7 +537,7 @@ export async function wildcardsRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
 ): Promise<RailResult> {
   const target = input.adventurous ? WILDCARDS_TARGET_ADVENTUROUS : WILDCARDS_TARGET
   const seedCount = input.adventurous ? WILDCARDS_SEED_COUNT_ADVENTUROUS : WILDCARDS_SEED_COUNT
@@ -604,7 +620,7 @@ export async function wildcardsRail(
   const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
     listenedIds: ctx.listenedIds,
     thumbsDownIds: ctx.thumbsDownIds,
-    seenIds,
+    excludedIds,
     undergroundMode: input.undergroundMode,
   })
   const artistByName = new Map<string, Artist>()
@@ -671,7 +687,7 @@ export async function leftfieldRail(
   input: BuildRailsInput,
   ctx: Awaited<ReturnType<typeof loadUserContext>>,
   supabase: SupabaseClient,
-  seenIds: Set<string>,
+  excludedIds: Set<string>,
   opts: { seedKey?: string; excludeIds?: Set<string> } = {},
 ): Promise<RailResult> {
   try {
@@ -733,7 +749,7 @@ export async function leftfieldRail(
     const resolved = await resolveAndFilter(namesRoundRobin, input.accessToken, supabase, {
       listenedIds: ctx.listenedIds,
       thumbsDownIds: ctx.thumbsDownIds,
-      seenIds,
+      excludedIds,
       undergroundMode: input.undergroundMode,
     })
     const artistByName = new Map<string, Artist>()
@@ -869,19 +885,19 @@ export async function buildExploreRails(
     }
   }
 
-  const [ctx, seenIds] = await Promise.all([
+  const [ctx, excludedIds] = await Promise.all([
     loadUserContext(supabase, input.userId),
-    loadSeenIds(supabase, input.userId),
+    loadExcludedIds(supabase, input.userId),
   ])
 
   // allSettled so one rail throwing doesn't nuke the whole explore generation.
   // Each rail already has its own internal try/catch for Last.fm calls; this is
   // belt-and-braces against unexpected DB / null-deref errors.
   const railFns: Array<{ key: RailKey; run: () => Promise<RailResult> }> = [
-    { key: "adjacent", run: () => adjacentRail(input, ctx, supabase, seenIds) },
-    { key: "outside", run: () => outsideRail(input, ctx, supabase, seenIds) },
-    { key: "wildcards", run: () => wildcardsRail(input, ctx, supabase, seenIds) },
-    { key: "leftfield", run: () => leftfieldRail(input, ctx, supabase, seenIds) },
+    { key: "adjacent", run: () => adjacentRail(input, ctx, supabase, excludedIds) },
+    { key: "outside", run: () => outsideRail(input, ctx, supabase, excludedIds) },
+    { key: "wildcards", run: () => wildcardsRail(input, ctx, supabase, excludedIds) },
+    { key: "leftfield", run: () => leftfieldRail(input, ctx, supabase, excludedIds) },
   ]
   const settled = await Promise.allSettled(railFns.map((r) => r.run()))
   const rails: RailResult[] = settled.map((s, i) => {
@@ -897,7 +913,7 @@ export async function buildExploreRails(
   if (ctx.thumbsUpIds.size === 0) {
     const primaryLeftfield = rails.find((r) => r.railKey === 'leftfield')
     const excludeIds = new Set(primaryLeftfield?.artistIds ?? [])
-    const fallback = await leftfieldRail(input, ctx, supabase, seenIds, {
+    const fallback = await leftfieldRail(input, ctx, supabase, excludedIds, {
       seedKey: 'wildcards-fallback',
       excludeIds,
     })
@@ -929,7 +945,7 @@ export async function buildExploreRails(
     for (const r of shortRails) {
       const need = MIN_PICKS_FLOOR - r.artistIds.length
       if (need <= 0) continue
-      const topup = await leftfieldRail(input, ctx, supabase, seenIds, {
+      const topup = await leftfieldRail(input, ctx, supabase, excludedIds, {
         seedKey: `${r.railKey}-topup`,
         excludeIds: existingIds,
       })

--- a/lib/recommendation/window.test.ts
+++ b/lib/recommendation/window.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest"
+import { cacheWindowSeed, seededShuffle, sampleLikes, LIKE_SAMPLE_SIZE } from "./window"
+
+describe("cacheWindowSeed", () => {
+  it("is stable for same user + key within a cache window", () => {
+    const a = cacheWindowSeed("user-1", "like-sample")
+    const b = cacheWindowSeed("user-1", "like-sample")
+    expect(a).toBe(b)
+  })
+
+  it("differs across keys", () => {
+    const a = cacheWindowSeed("user-1", "like-sample")
+    const b = cacheWindowSeed("user-1", "afterhours")
+    expect(a).not.toBe(b)
+  })
+
+  it("differs across users", () => {
+    const a = cacheWindowSeed("user-1", "like-sample")
+    const b = cacheWindowSeed("user-2", "like-sample")
+    expect(a).not.toBe(b)
+  })
+})
+
+describe("seededShuffle", () => {
+  it("is deterministic for the same seed", () => {
+    const ids = Array.from({ length: 50 }, (_, i) => `a${i}`)
+    const first = seededShuffle(ids, 42)
+    const second = seededShuffle(ids, 42)
+    expect(first).toEqual(second)
+  })
+
+  it("differs for different seeds (probabilistically almost always)", () => {
+    const ids = Array.from({ length: 50 }, (_, i) => `a${i}`)
+    const first = seededShuffle(ids, 42)
+    const second = seededShuffle(ids, 99)
+    expect(first).not.toEqual(second)
+  })
+
+  it("does not mutate input", () => {
+    const ids = ["a", "b", "c"]
+    const copy = [...ids]
+    seededShuffle(ids, 1)
+    expect(ids).toEqual(copy)
+  })
+})
+
+describe("sampleLikes", () => {
+  it("returns all likes when fewer than the sample size", () => {
+    const likes = ["a", "b", "c"]
+    expect(sampleLikes(likes, "user-1")).toEqual(likes)
+  })
+
+  it("returns exactly LIKE_SAMPLE_SIZE when user has more", () => {
+    const likes = Array.from({ length: 30 }, (_, i) => `a${i}`)
+    const sample = sampleLikes(likes, "user-1")
+    expect(sample).toHaveLength(LIKE_SAMPLE_SIZE)
+  })
+
+  it("only picks values from the input set", () => {
+    const likes = Array.from({ length: 30 }, (_, i) => `a${i}`)
+    const sample = sampleLikes(likes, "user-1")
+    for (const s of sample) expect(likes).toContain(s)
+  })
+
+  it("is stable within a cache window for the same user", () => {
+    const likes = Array.from({ length: 30 }, (_, i) => `a${i}`)
+    const a = sampleLikes(likes, "user-1")
+    const b = sampleLikes(likes, "user-1")
+    expect(a).toEqual(b)
+  })
+
+  it("differs across users (probabilistically almost always)", () => {
+    const likes = Array.from({ length: 30 }, (_, i) => `a${i}`)
+    const a = sampleLikes(likes, "user-1")
+    const b = sampleLikes(likes, "user-2")
+    expect(a).not.toEqual(b)
+  })
+})

--- a/lib/recommendation/window.ts
+++ b/lib/recommendation/window.ts
@@ -1,0 +1,54 @@
+/**
+ * Cache-window helpers shared between Feed and Explore engines.
+ *
+ * Kept in their own module so either engine can import without creating a
+ * circular dependency (explore-engine.ts imports from engine.ts for
+ * `getTagArtistNames`).
+ */
+
+/**
+ * Deterministic cache-window hash. Keeps rail picks stable within the TTL so
+ * a re-fetch during the same cache window doesn't shuffle results under the
+ * user's feet (and can't be exploited to game uniqueness).
+ */
+export function cacheWindowSeed(userId: string, seedKey: string): number {
+  const weekStart = Math.floor(Date.now() / (7 * 24 * 60 * 60 * 1000))
+  let h = 2166136261 >>> 0
+  const s = `${userId}:${seedKey}:${weekStart}`
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 16777619) >>> 0
+  }
+  return h
+}
+
+/**
+ * Stable shuffle using the cache-window seed so the same user + same rail
+ * produces the same order within a 7-day window.
+ */
+export function seededShuffle<T>(arr: T[], seed: number): T[] {
+  const out = [...arr]
+  let s = seed || 1
+  for (let i = out.length - 1; i > 0; i--) {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0
+    const j = s % (i + 1)
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+/**
+ * Roll a deterministic sample of up to `size` likes from a user's full
+ * thumbs-up set. Seed is the cache window so the sample is stable across
+ * in-window cache hits but rotates weekly. Same sample in Feed and Explore
+ * so the two surfaces feel coherent.
+ */
+export const LIKE_SAMPLE_SIZE = 10
+
+export function sampleLikes(allLikes: string[], userId: string): string[] {
+  if (allLikes.length <= LIKE_SAMPLE_SIZE) return allLikes
+  return seededShuffle(allLikes, cacheWindowSeed(userId, 'like-sample')).slice(
+    0,
+    LIKE_SAMPLE_SIZE,
+  )
+}

--- a/supabase/migrations/0034_rpc_clear_dismiss.sql
+++ b/supabase/migrations/0034_rpc_clear_dismiss.sql
@@ -1,0 +1,32 @@
+-- rpc_clear_dismiss: Unblock a permanently-dismissed artist so they can
+-- resurface in Explore and Feed again.
+--
+-- The "Dismiss" button on a card writes skip_at (and seen_at) via
+-- rpc_record_feedback with signal='skip'. Migration 0033 intentionally does
+-- NOT insert a feedback row for skip, so the existing rpc_delete_feedback is
+-- a no-op for dismissed items. This RPC clears both columns on the
+-- recommendation_cache row so the artist is fully eligible again (no skip_at
+-- filter, no 7-day seen_at cooldown).
+--
+-- Idempotent: UPDATE on a non-existent row is a no-op.
+
+CREATE OR REPLACE FUNCTION rpc_clear_dismiss(
+  p_user_id UUID,
+  p_artist_id TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  UPDATE recommendation_cache
+  SET skip_at = NULL,
+      seen_at = NULL
+  WHERE user_id = p_user_id
+    AND spotify_artist_id = p_artist_id;
+END;
+$$;
+
+-- Permissions mirror 0033_feedback_rpc_intent_fixes.sql — server-only via
+-- service role; app code calls through the service client.
+REVOKE EXECUTE ON FUNCTION rpc_clear_dismiss(UUID, TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION rpc_clear_dismiss(UUID, TEXT) FROM anon;
+REVOKE EXECUTE ON FUNCTION rpc_clear_dismiss(UUID, TEXT) FROM authenticated;


### PR DESCRIPTION
## Summary
- **M1 — Rolling like sample.** Deterministic 7-day window seed (`cacheWindowSeed` + `seededShuffle` in `lib/recommendation/window.ts`) so users with large like libraries don't anchor every generation on the same top artists.
- **M2 — 25% cluster cap.** New `lib/recommendation/cluster-cap.ts` with `applyClusterCap` (Feed) and `applyCrossRailClusterCap` (Explore) swapping lowest-ranked genre offenders with highest-ranked under-cap leftovers. Within-rail swaps keep each Explore rail's theme intact. `CapStats` telemetry returns swaps/topShare/topGenre for logs.
- **M3 — Exploration budget.** Wider leftfield targets + per-tag picks so adventurous mode actually gets a deeper tail, and the cap has swap material without new Spotify calls.
- **M4 — Tests + telemetry.** New `cluster-cap.test.ts` (18 cases) and `window.test.ts`; existing `engine.test.ts` updated for the wider augment caps. Both engines log `[engine|explore-engine] cluster-cap swaps=N topGenre=X topShare=Y` per generation.
- Preserves rail/leftover split so the cap has candidates to swap without extra network calls. PRD in `docs/prd-diversity-overhaul.md`.

## Test plan
- [ ] `pnpm test` — full suite green (580/580 at branch tip)
- [ ] `pnpm typecheck` clean
- [ ] Open `/explore` — each rail renders with mixed genres; logs show `topShare` ≤ 0.25
- [ ] Toggle Adventurous mode; confirm leftfield rail populates ≥10 items
- [ ] Shuffle a rail — composition shifts but same 7-day window yields stable seed
- [ ] Feed tab renders; logs show cluster-cap firing without dropping below target count
- [ ] Post-merge: watch `[explore-engine] cluster-cap` logs for unusually high `topShare` or swap counts across a broad set of users

🤖 Generated with [Claude Code](https://claude.com/claude-code)