### PR TITLE
Mobile nav refactor + dismiss flow + Explore polish + perf

### DIFF
--- a/app/(marketing)/onboarding/page.tsx
+++ b/app/(marketing)/onboarding/page.tsx
@@ -146,9 +146,9 @@ export default function OnboardingPage() {
 
         {/* Header */}
         <div style={{ marginBottom: 32, textAlign: "center" }}>
-          <div className="topnav-brand" style={{ justifyContent: "center", marginBottom: 12 }}>
+          <div className="appnav-brand" style={{ justifyContent: "center", marginBottom: 12 }}>
             <span className="dot" />
-            flipside
+            <span className="wordmark">flipside</span>
           </div>
           <div className="serif" style={{ fontSize: 26, lineHeight: 1.25, marginBottom: 8 }}>
             How should we seed your feed?

--- a/app/(marketing)/sign-in/page.tsx
+++ b/app/(marketing)/sign-in/page.tsx
@@ -86,11 +86,11 @@ export default function SignInPage() {
         {/* Brand */}
         <div style={{ marginBottom: 32, textAlign: "center" }}>
           <div
-            className="topnav-brand"
+            className="appnav-brand"
             style={{ justifyContent: "center", marginBottom: 8 }}
           >
             <span className="dot" />
-            flipside
+            <span className="wordmark">flipside</span>
           </div>
           <div className="serif" style={{ fontSize: 22, color: "var(--text-primary)", lineHeight: 1.3 }}>
             Pick a username.

--- a/app/globals.css
+++ b/app/globals.css
@@ -162,7 +162,7 @@ body::after {
 .app-main {
   flex: 1;
   width: 100%;
-  padding: 0 16px 96px;
+  padding: 0 16px 24px;
   display: flex;
   justify-content: center;
 }
@@ -174,131 +174,123 @@ body::after {
   .app-main { padding: 0 32px 64px; }
 }
 
-/* ── Mobile bottom tab bar ─────────────────────────────────────── */
-.tabbar {
-  position: fixed;
-  left: 12px;
-  right: 12px;
-  bottom: calc(12px + env(safe-area-inset-bottom));
-  height: 64px;
+/* ── Unified app nav (top sticky, mobile + desktop) ────────────── */
+.appnav {
+  position: sticky;
+  top: 0;
+  padding-top: env(safe-area-inset-top);
   background: rgba(8,8,8,0.85);
   backdrop-filter: blur(18px) saturate(1.15);
   -webkit-backdrop-filter: blur(18px) saturate(1.15);
-  border: 1px solid var(--border);
-  border-radius: 28px;
-  box-shadow: 0 10px 30px rgba(0,0,0,0.35), 0 2px 8px rgba(0,0,0,0.25);
-  display: flex;
-  z-index: 50;
-  overflow: hidden;
-}
-.tabbar a {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  text-decoration: none;
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  transition: color .2s var(--easing);
-}
-.tabbar a.active { color: var(--text-primary); }
-.tabbar a svg { width: 22px; height: 22px; }
-
-/* Adventurous-mode treatment: brighter glass + static rainbow ring drawn
-   via a pseudo-element so the 28px border-radius is preserved (border-image
-   does not follow border-radius). */
-.tabbar.adventurous {
-  backdrop-filter: blur(18px) saturate(1.5) brightness(1.08);
-  -webkit-backdrop-filter: blur(18px) saturate(1.5) brightness(1.08);
-  overflow: visible;
-}
-.tabbar.adventurous::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 2px;
-  background: linear-gradient(90deg, #f5b047, #ec6fb5, #7dd9c6, #a8c7fa);
-  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-          mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
-  -webkit-mask-composite: xor;
-          mask-composite: exclude;
-  pointer-events: none;
-}
-
-/* Very narrow viewports (< 360px, i.e. iPhone SE & smaller): shrink labels so
-   nothing clips. 6 tabs at ~53px each can't comfortably fit "Settings" at 11px. */
-@media (max-width: 359px) {
-  .tabbar a { font-size: 9.5px; gap: 2px; }
-  .tabbar a svg { width: 20px; height: 20px; }
-}
-@media (min-width: 900px) { .tabbar { display: none; } }
-
-/* Mini-player pill — lift above the bottom tabbar on mobile so controls
-   and tab labels don't overlap. The tabbar is now a floating pill with
-   12px top + bottom margins, so total vertical footprint is 64 + 24 = 88. */
-@media (max-width: 899px) {
-  .mini-player-pill {
-    bottom: calc(88px + env(safe-area-inset-bottom)) !important;
-  }
-}
-
-/* ── Desktop top nav ───────────────────────────────────────────── */
-.topnav {
-  display: none;
-  position: sticky;
-  top: 0;
-  height: 64px;
-  padding: 0 32px;
-  align-items: center;
-  justify-content: space-between;
-  background: rgba(8,8,8,0.85);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--border);
   z-index: 50;
 }
-@media (min-width: 900px) { .topnav { display: flex; } }
-.topnav-brand {
+.appnav-inner {
+  height: 64px;
   display: flex;
-  align-items: baseline;
+  align-items: stretch;
+  padding: 0 12px;
+  gap: 8px;
+}
+.appnav-brand {
+  display: flex;
+  align-items: center;
   gap: 10px;
+  flex: 0 0 auto;
   font-family: var(--font-display);
   font-variation-settings: var(--font-display-settings);
   font-weight: 800;
   font-size: 19px;
   letter-spacing: -0.02em;
+  color: var(--text-primary);
 }
-.topnav-brand .dot {
+.appnav-brand .dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background: var(--accent);
   display: inline-block;
   box-shadow: 0 0 12px var(--accent-glow);
+  flex-shrink: 0;
 }
-.topnav-links { display: flex; gap: 28px; }
-.topnav-links a {
+.appnav .appnav-brand .wordmark { display: none; }
+.appnav-avatar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+}
+.appnav-tabs {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: stretch;
+}
+.appnav-tabs a {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
   text-decoration: none;
   color: var(--text-muted);
-  font-size: 13px;
-  font-weight: 500;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   position: relative;
-  padding: 6px 0;
-  transition: color .2s;
+  padding: 6px 4px;
+  border-radius: 12px;
+  background: transparent;
+  transition: color .2s var(--easing), background .2s var(--easing);
 }
-.topnav-links a.active { color: var(--text-primary); }
-.topnav-links a.active::after {
+.appnav-tabs a.active {
+  color: var(--text-primary);
+  background: rgba(255,255,255,0.06);
+  background: color-mix(in srgb, var(--tab-color, var(--accent)) 14%, transparent);
+}
+.appnav-tabs a svg { width: 22px; height: 22px; }
+@media (max-width: 359px) {
+  .appnav-tabs a { font-size: 9.5px; gap: 2px; padding: 4px 2px; }
+  .appnav-tabs a svg { width: 20px; height: 20px; }
+}
+@media (min-width: 900px) {
+  .appnav-inner {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 0 32px;
+    gap: 24px;
+  }
+  .appnav .appnav-brand .wordmark { display: inline; }
+  .appnav-tabs {
+    flex: 0 1 auto;
+    margin: 0 auto;
+    justify-content: center;
+    gap: 12px;
+  }
+  .appnav-tabs a {
+    flex: 0 0 auto;
+    min-width: 110px;
+    font-size: 12px;
+    padding: 6px 12px;
+  }
+}
+
+/* Adventurous mode: replace border-bottom with a 2px rainbow strip,
+   plus the existing brighter-glass treatment. */
+.appnav.adventurous {
+  border-bottom: none;
+  backdrop-filter: blur(18px) saturate(1.5) brightness(1.08);
+  -webkit-backdrop-filter: blur(18px) saturate(1.5) brightness(1.08);
+}
+.appnav.adventurous::after {
   content: "";
   position: absolute;
-  left: 0; right: 0; bottom: -2px;
+  left: 0; right: 0;
+  bottom: 0;
   height: 2px;
-  background: var(--accent);
-  border-radius: 2px;
+  background: linear-gradient(90deg, #f5b047, #ec6fb5, #7dd9c6, #a8c7fa);
+  pointer-events: none;
 }
 
 /* ── Page head ─────────────────────────────────────────────────── */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -88,7 +88,7 @@ export default function RootLayout({
             __html: `
               @supports ((backdrop-filter: blur(30px)) or (-webkit-backdrop-filter: blur(30px))) {
                 .fs-card { backdrop-filter: blur(30px) saturate(1.1); -webkit-backdrop-filter: blur(30px) saturate(1.1); }
-                .tabbar, .topnav { backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px); }
+                .appnav { backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px); }
               }
             `,
           }}

--- a/components/nav/app-nav.tsx
+++ b/components/nav/app-nav.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, type CSSProperties } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { Music2, Bookmark, Settings, Clock, BarChart3, Compass } from "lucide-react"
@@ -45,55 +45,39 @@ export function AppNav({ userSeed = "user", initialAdventurous = false }: AppNav
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(href + "/")
 
-  const tabbarClass = `tabbar${adventurous ? " adventurous" : ""}`
-
   return (
-    <>
-      {/* ── Desktop top nav (≥ 900px) ── */}
-      <header className="topnav">
-        {/* Brand mark */}
-        <span className="topnav-brand">
+    <header className={`appnav${adventurous ? " adventurous" : ""}`}>
+      <div className="appnav-inner">
+        <span className="appnav-brand">
           <span className="dot" />
-          <span>flipside</span>
+          <span className="wordmark">flipside</span>
         </span>
 
-        {/* Nav links */}
-        <nav className="topnav-links">
-          {navLinks.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              prefetch={href === "/explore" ? true : undefined}
-              className={isActive(href) ? "active" : ""}
-            >
-              {label}
-              <NavLinkStatus />
-            </Link>
-          ))}
+        <nav className="appnav-tabs">
+          {navLinks.map(({ href, label, icon: Icon, color }) => {
+            const active = isActive(href)
+            const styleVars = { "--tab-color": color } as CSSProperties
+            return (
+              <Link
+                key={href}
+                href={href}
+                prefetch={href === "/explore" ? true : undefined}
+                aria-current={active ? "page" : undefined}
+                className={active ? "active" : ""}
+                style={styleVars}
+              >
+                <Icon size={22} style={{ color }} />
+                <span>{label}</span>
+                <NavLinkStatus />
+              </Link>
+            )
+          })}
         </nav>
 
-        {/* Avatar */}
-        <IdenticonAvatar seed={userSeed} size={32} />
-      </header>
-
-      {/* ── Mobile bottom tab bar (< 900px) ── */}
-      <nav className={tabbarClass}>
-        {navLinks.map(({ href, label, icon: Icon, color }) => {
-          const active = isActive(href)
-          return (
-            <Link
-              key={href}
-              href={href}
-              prefetch={href === "/explore" ? true : undefined}
-              className={active ? "active" : ""}
-            >
-              <Icon size={22} style={{ color }} />
-              <span>{label}</span>
-              <NavLinkStatus />
-            </Link>
-          )
-        })}
-      </nav>
-    </>
+        <span className="appnav-avatar">
+          <IdenticonAvatar seed={userSeed} size={32} />
+        </span>
+      </div>
+    </header>
   )
 }


### PR DESCRIPTION
## Summary

Batch of work on the `Nick` branch ready for `main`. Eight commits, grouped:

**Mobile nav refactor (new in this push)**
- Bottom tabbar → unified top-sticky nav across mobile + desktop
- Active state is a soft tinted fill in the tab's color (color-mix at 14%), no more underline
- Adventurous mode: rainbow gradient strip along the nav's bottom edge replaces the old pill ring
- Mini-player drops back to 24px-from-bottom (the 88px mobile lift was only there to clear the old pill)
- Marketing pages (sign-in, onboarding) repointed from `.topnav-brand` → `.appnav-brand`; wordmark hide is scoped to `.appnav` so marketing pages keep their wordmark on mobile

**Dismiss + History UX**
- Permanent hide with undo from History
- Sync button + diversity nudge

**Explore + Feed**
- All 4 rails guaranteed to populate for every user
- Pop-50 hard cap + popularity curve
- Orphan auto-prune
- Render perf via request-scoped user cache
- Artist search empty state
- Prod-hardening pass

**Listening behavior**
- Thumbs-up keeps card visible so playback continues

**Bug sweeps**
- Feedback RPC intent fix
- Toggle race fix

## Test plan

- [ ] Sign in on a clean profile, verify the new top nav renders at both mobile and desktop widths
- [ ] Resize through 900px breakpoint — wordmark appears/disappears next to the dot
- [ ] Tap each tab; active tinted fill recolors per tab (purple Feed, orange Explore, teal History, pink Saved, blue Stats, coral Settings)
- [ ] Toggle adventurous mode in Settings — rainbow strip appears at nav bottom
- [ ] Start playback — mini-player sits 24px above the bottom edge with no excess gap
- [ ] Visit `/sign-in` and `/onboarding` — wordmark visible on mobile (the only branding there)
- [ ] Dismiss a card from Feed; confirm it's hidden permanently and recoverable from History
- [ ] Confirm Explore shows all 4 rails populated
- [ ] Confirm thumbs-up no longer collapses the card mid-listen
- [ ] Confirm artist search shows the empty state when no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)