### PR TITLE
Performance sweep: memo, useCallback, LCP priority, parallel DB queries

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,15 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
       "port": 3000
+    },
+    {
+      "name": "dev-worktree",
+      "runtimeExecutable": "/bin/bash",
+      "runtimeArgs": [
+        "-c",
+        "cd /Users/flux/.config/superpowers/worktrees/flipside/fix-itunes-tracks && PORT=3001 npm run dev"
+      ],
+      "port": 3001
     }
   ]
 }

--- a/app/(app)/feed/page.tsx
+++ b/app/(app)/feed/page.tsx
@@ -99,13 +99,25 @@ export default async function FeedPage() {
     )
   }
 
-  // Fetch tracks for the recommendations
+  // Fetch tracks + signal counts in parallel — counts depend only on user.id,
+  // tracks fetch needs artistIds (already known). Saves one DB round-trip vs.
+  // running tracks sequentially before the count Promise.all.
   const artistIds = validRecs.map((r) => r.spotify_artist_id)
-  
-  const { data: tracksCache } = await supabase
-    .from("artist_tracks_cache")
-    .select("spotify_artist_id, tracks")
-    .in("spotify_artist_id", artistIds)
+
+  const [
+    { data: tracksCache },
+    { count: artistCount },
+    { count: feedbackCount },
+    { count: saveCount },
+  ] = await Promise.all([
+    supabase
+      .from("artist_tracks_cache")
+      .select("spotify_artist_id, tracks")
+      .in("spotify_artist_id", artistIds),
+    supabase.from("listened_artists").select("*", { count: "exact", head: true }).eq("user_id", user.id),
+    supabase.from("feedback").select("*", { count: "exact", head: true }).eq("user_id", user.id).is("deleted_at", null),
+    supabase.from("saves").select("*", { count: "exact", head: true }).eq("user_id", user.id),
+  ])
 
   const tracksMap = new Map<string, Rec["artist_data"]["topTracks"]>()
   for (const row of tracksCache ?? []) {
@@ -118,11 +130,6 @@ export default async function FeedPage() {
     return { ...rec, artist_color }
   })
 
-  const [{ count: artistCount }, { count: feedbackCount }, { count: saveCount }] = await Promise.all([
-    supabase.from("listened_artists").select("*", { count: "exact", head: true }).eq("user_id", user.id),
-    supabase.from("feedback").select("*", { count: "exact", head: true }).eq("user_id", user.id).is("deleted_at", null),
-    supabase.from("saves").select("*", { count: "exact", head: true }).eq("user_id", user.id),
-  ])
   const signalCount = (artistCount ?? 0) + (feedbackCount ?? 0) + (saveCount ?? 0)
 
   return (

--- a/components/explore/challenge-card.tsx
+++ b/components/explore/challenge-card.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react"
 import { Sparkles } from "lucide-react"
 
 export interface ChallengeCardProps {
@@ -9,7 +10,7 @@ export interface ChallengeCardProps {
   adventurous?: boolean
 }
 
-export function ChallengeCard({
+export const ChallengeCard = memo(function ChallengeCard({
   title,
   description,
   progress,
@@ -116,4 +117,4 @@ export function ChallengeCard({
       </div>
     </section>
   )
-}
+})

--- a/components/feed/artist-card.tsx
+++ b/components/feed/artist-card.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { memo, useState, useEffect, useMemo } from "react"
+import { memo, useCallback, useState, useEffect, useMemo } from "react"
 import Image from "next/image"
 import { motion } from "framer-motion"
 import { SkipForward, Bookmark, Check, Share2 } from "lucide-react"
@@ -57,6 +57,57 @@ export interface ArtistCardProps {
    *   - "skip"         → collapsed 56px bar, neutral "Dismissed"
    */
   dismissSignal?: string | null
+  /** When true, hero image is preloaded (set on the LCP card only). */
+  priority?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Module-scope static styles — hoisted out of the render path. Each object
+// here has zero prop/state references; dynamic styles stay inline below.
+// ---------------------------------------------------------------------------
+
+const heroWrapStyle: React.CSSProperties = {
+  position: "relative",
+  height: 340,
+  overflow: "hidden",
+}
+
+const heroScrimStyle: React.CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  background: "linear-gradient(to top, #000 0%, transparent 65%)",
+}
+
+const heroNameWrapStyle: React.CSSProperties = {
+  position: "absolute",
+  left: 24,
+  right: 24,
+  bottom: 20,
+}
+
+const cardBodyStyle: React.CSSProperties = {
+  padding: "18px 20px 20px",
+}
+
+const noTracksPlaceholderStyle: React.CSSProperties = {
+  height: 64,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  borderRadius: 12,
+  background: "rgba(255,255,255,0.025)",
+  border: "1px solid var(--border)",
+}
+
+const reasonPillStyle: React.CSSProperties = {
+  marginTop: 18,
+  padding: "14px 16px",
+  background: "rgba(255,255,255,0.025)",
+  borderRadius: 12,
+  fontSize: 14,
+  textAlign: "center",
+  color: "var(--text-secondary)",
+  lineHeight: 1.4,
 }
 
 // ---------------------------------------------------------------------------
@@ -77,6 +128,7 @@ function ArtistCardImpl({
   onFeedback,
   isSaved = false,
   dismissSignal = null,
+  priority = false,
 }: ArtistCardProps) {
   const isLiked = dismissSignal === "thumbs_up"
   const isCollapsed = signalCollapses(dismissSignal)
@@ -125,9 +177,12 @@ function ArtistCardImpl({
     onSave()
   }
 
-  function handlePlay(track: Track) {
-    play(track, artist_data.name, artist_data.imageUrl, artistColor)
-  }
+  const handlePlay = useCallback(
+    (track: Track) => {
+      play(track, artist_data.name, artist_data.imageUrl, artistColor)
+    },
+    [play, artist_data.name, artist_data.imageUrl, artistColor],
+  )
 
   function handleShare(e: React.MouseEvent) {
     e.stopPropagation()
@@ -224,13 +279,14 @@ function ArtistCardImpl({
       }}
     >
       {/* Hero image */}
-      <div style={{ position: "relative", height: 340, overflow: "hidden" }}>
+      <div style={heroWrapStyle}>
         {artist_data.imageUrl ? (
           <Image
             src={artist_data.imageUrl}
             alt={artist_data.name}
             fill
             sizes="(min-width: 900px) 680px, 100vw"
+            priority={priority}
             style={{
               objectFit: "cover",
               filter: "saturate(0.85) contrast(1.05)",
@@ -259,16 +315,10 @@ function ArtistCardImpl({
         )}
 
         {/* Dark gradient scrim */}
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            background: "linear-gradient(to top, #000 0%, transparent 65%)",
-          }}
-        />
+        <div style={heroScrimStyle} />
 
         {/* Name + genre */}
-        <div style={{ position: "absolute", left: 24, right: 24, bottom: 20 }}>
+        <div style={heroNameWrapStyle}>
           <div
             className="display"
             style={{
@@ -299,7 +349,7 @@ function ArtistCardImpl({
       </div>
 
       {/* Body */}
-      <div style={{ padding: "18px 20px 20px" }}>
+      <div style={cardBodyStyle}>
         {/* Track strip */}
         {localTracks.length > 0 ? (
           <div onClick={(e) => e.stopPropagation()}>
@@ -312,17 +362,7 @@ function ArtistCardImpl({
             />
           </div>
         ) : (
-          <div
-            style={{
-              height: 64,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              borderRadius: 12,
-              background: "rgba(255,255,255,0.025)",
-              border: "1px solid var(--border)",
-            }}
-          >
+          <div style={noTracksPlaceholderStyle}>
             <span className="mono" style={{ fontSize: 11, color: "var(--text-muted)" }}>
               {isFetchingTracks ? "Loading tracks…" : "No tracks available"}
             </span>
@@ -330,18 +370,7 @@ function ArtistCardImpl({
         )}
 
         {reasonText && (
-          <div
-            style={{
-              marginTop: 18,
-              padding: "14px 16px",
-              background: "rgba(255,255,255,0.025)",
-              borderRadius: 12,
-              fontSize: 14,
-              textAlign: "center",
-              color: "var(--text-secondary)",
-              lineHeight: 1.4,
-            }}
-          >
+          <div style={reasonPillStyle}>
             {reasonText}
           </div>
         )}

--- a/components/feed/cold-start-banner.tsx
+++ b/components/feed/cold-start-banner.tsx
@@ -3,66 +3,65 @@ interface ColdStartBannerProps {
   threshold?: number
 }
 
+const containerStyle: React.CSSProperties = {
+  padding: "12px 16px",
+  background: "rgba(15,15,15,0.65)",
+  backdropFilter: "blur(18px)",
+  WebkitBackdropFilter: "blur(18px)",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 14,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+}
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "baseline",
+  justifyContent: "space-between",
+  gap: 12,
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 10.5,
+  fontWeight: 600,
+  color: "var(--accent)",
+  textTransform: "uppercase",
+  letterSpacing: "0.18em",
+  whiteSpace: "nowrap",
+}
+
+const subtitleStyle: React.CSSProperties = {
+  fontSize: 12,
+  color: "var(--text-muted)",
+  lineHeight: 1.3,
+  textAlign: "right",
+  minWidth: 0,
+}
+
+const trackStyle: React.CSSProperties = {
+  height: 4,
+  borderRadius: 999,
+  background: "rgba(255,255,255,0.06)",
+  overflow: "hidden",
+}
+
 export function ColdStartBanner({ signalCount, threshold = 5 }: ColdStartBannerProps) {
   if (signalCount >= threshold) return null
 
   const pct = Math.min(100, Math.round((signalCount / threshold) * 100))
 
   return (
-    <div
-      style={{
-        padding: "12px 16px",
-        background: "rgba(15,15,15,0.65)",
-        backdropFilter: "blur(18px)",
-        WebkitBackdropFilter: "blur(18px)",
-        border: "1px solid rgba(255,255,255,0.08)",
-        borderRadius: 14,
-        display: "flex",
-        flexDirection: "column",
-        gap: 8,
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "baseline",
-          justifyContent: "space-between",
-          gap: 12,
-        }}
-      >
-        <span
-          className="mono"
-          style={{
-            fontSize: 10.5,
-            fontWeight: 600,
-            color: "var(--accent)",
-            textTransform: "uppercase",
-            letterSpacing: "0.18em",
-            whiteSpace: "nowrap",
-          }}
-        >
+    <div style={containerStyle}>
+      <div style={rowStyle}>
+        <span className="mono" style={labelStyle}>
           Flipside signal · {signalCount} of {threshold}
         </span>
-        <span
-          style={{
-            fontSize: 12,
-            color: "var(--text-muted)",
-            lineHeight: 1.3,
-            textAlign: "right",
-            minWidth: 0,
-          }}
-        >
+        <span style={subtitleStyle}>
           Keep exploring — recs get smarter.
         </span>
       </div>
-      <div
-        style={{
-          height: 4,
-          borderRadius: 999,
-          background: "rgba(255,255,255,0.06)",
-          overflow: "hidden",
-        }}
-      >
+      <div style={trackStyle}>
         <div
           style={{
             height: "100%",

--- a/components/feed/feed-client.tsx
+++ b/components/feed/feed-client.tsx
@@ -57,6 +57,13 @@ function buildSequence(recs: Recommendation[]): FeedItem[] {
   return recs.map((rec) => ({ kind: "card", rec, key: `c-${rec.spotify_artist_id}` }))
 }
 
+// Module-scope: zero prop/state deps, so identity stays stable across renders.
+const FEED_PALETTE = `
+    radial-gradient(50% 40% at 18% 20%, rgba(139, 92, 246, 0.22) 0%, transparent 70%),
+    radial-gradient(55% 45% at 82% 30%, rgba(236, 111, 181, 0.18) 0%, transparent 70%),
+    radial-gradient(70% 55% at 50% 90%, rgba(125, 217, 198, 0.14) 0%, transparent 70%)
+  `
+
 // ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
@@ -75,12 +82,6 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
   // and the final server state can disagree with the user's last intent.
   const feedbackQueueRef = useRef(createKeyedSerializer())
   const router = useRouter()
-
-  const palette = `
-    radial-gradient(50% 40% at 18% 20%, rgba(139, 92, 246, 0.22) 0%, transparent 70%),
-    radial-gradient(55% 45% at 82% 30%, rgba(236, 111, 181, 0.18) 0%, transparent 70%),
-    radial-gradient(70% 55% at 50% 90%, rgba(125, 217, 198, 0.14) 0%, transparent 70%)
-  `
 
   const sequence = useMemo(() => buildSequence(recommendations), [recommendations])
 
@@ -209,7 +210,7 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
 
   return (
     <div style={{ position: "relative" }}>
-      <Ambient palette={palette} />
+      <Ambient palette={FEED_PALETTE} />
 
       {/* Page header */}
       <div className="page-head">
@@ -220,7 +221,7 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
       {/* Feed sequence */}
       <div className="col" style={{ gap: 24, marginTop: 8 }}>
         <ColdStartBanner signalCount={signalCount} />
-        {sequence.map((item) => {
+        {sequence.map((item, index) => {
           const { rec } = item
           const id = rec.spotify_artist_id
           return (
@@ -232,6 +233,7 @@ export function FeedClient({ recommendations, musicPlatform, signalCount }: Feed
               dismissSignal={dismissedSignals.get(id) ?? null}
               onSaveAction={handleSave}
               onFeedbackAction={handleFeedback}
+              priority={index === 0}
             />
           )
         })}
@@ -261,6 +263,7 @@ interface FeedCardRowProps {
   dismissSignal: string | null
   onSaveAction: (artistId: string) => Promise<void> | void
   onFeedbackAction: (artistId: string, signal: string) => Promise<void> | void
+  priority?: boolean
 }
 
 const FeedCardRow = memo(function FeedCardRow({
@@ -270,6 +273,7 @@ const FeedCardRow = memo(function FeedCardRow({
   dismissSignal,
   onSaveAction,
   onFeedbackAction,
+  priority = false,
 }: FeedCardRowProps) {
   const id = rec.spotify_artist_id
   const onSave = useCallback(() => { void onSaveAction(id) }, [id, onSaveAction])
@@ -282,6 +286,7 @@ const FeedCardRow = memo(function FeedCardRow({
       dismissSignal={dismissSignal}
       onSave={onSave}
       onFeedback={onFeedback}
+      priority={priority}
     />
   )
 })

--- a/components/feed/track-strip.tsx
+++ b/components/feed/track-strip.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { memo, useState } from "react"
 import Image from "next/image"
 import { Play } from "lucide-react"
 import { hexToRgba } from "@/lib/color-utils"
@@ -23,7 +23,7 @@ export interface TrackStripProps {
 // Component
 // ---------------------------------------------------------------------------
 
-export function TrackStrip({
+export const TrackStrip = memo(function TrackStrip({
   tracks,
   artistColor = "#8b5cf6",
   compact = false,
@@ -167,4 +167,4 @@ export function TrackStrip({
       )}
     </div>
   )
-}
+})


### PR DESCRIPTION
## Summary

- `memo()` wraps on `ChallengeCard` and `TrackStrip` to prevent unnecessary re-renders
- `useCallback` + static style extraction on `ArtistCard` for stable references
- `priority` prop threaded through `FeedClient` → `ArtistCard` for LCP image optimization
- `Promise.all` parallelization of DB signal-count queries in `feed/page.tsx` (saves one round-trip)
- Module-scope style constant extraction in `ColdStartBanner` and `FeedClient` for stable identities
- Worktree dev launcher config added to `.claude/launch.json`

## Test plan

- [ ] Feed renders correctly, artist cards display and play as expected
- [ ] No visual regressions on cold-start banner or challenge cards
- [ ] Check network tab — feed page DB queries run in parallel (single waterfall entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)