### PR TITLE
#162: persist preview confirms to artist_tracks_cache (+ 24h negative cache)

### DIFF
--- a/app/api/recommendations/generate/route.ts
+++ b/app/api/recommendations/generate/route.ts
@@ -191,7 +191,7 @@ export const POST = withAuthedCsrfRoute(async ({ userId, request }): Promise<Res
     // work runs after logging and is intentionally excluded.
     resetCalls()
     const genStart = Date.now()
-    const { count: recCount, runSecondary, softenedFilters, metrics } = await buildRecommendations({
+    const { count: recCount, runSecondary, flushConfirms, softenedFilters, metrics } = await buildRecommendations({
       userId: user.id,
       accessToken,
       playThreshold,
@@ -232,6 +232,22 @@ export const POST = withAuthedCsrfRoute(async ({ userId, request }): Promise<Res
           console.error(`[generate] background-fail err=${err instanceof Error ? err.message : err}`)
         }
       }
+
+      // Persist every confirmed preview (tier-1 + tier-2 + secondary) to
+      // artist_tracks_cache in one batch, AFTER runSecondary so the collector
+      // has accumulated all phases. Runs even when runSecondary is null.
+      // flushConfirms never throws, but guard defensively. (#162)
+      try {
+        await flushConfirms?.()
+      } catch (err) {
+        console.error(`[generate] flush-confirms-fail err=${err instanceof Error ? err.message : err}`)
+      }
+
+      // Full-generation call counts (blocking + background). The [gen-timing]
+      // log above snapshots only the blocking window; this exposes the true
+      // per-gen iTunes/Spotify totals for the #162 measurement gate.
+      const bgCalls = snapshotCalls()
+      console.log(`[gen-timing-bg] itunesCalls=${bgCalls.itunes} spotifyCalls=${bgCalls.spotify} lastfmCalls=${bgCalls.lastfm.total}`)
 
       const { data: cachedRecs } = await supabase
         .from("recommendation_cache")

--- a/lib/music-provider/types.ts
+++ b/lib/music-provider/types.ts
@@ -20,6 +20,13 @@ export interface Artist {
    * valid; `ArtistWithTracks` narrows it to required for the scored pool.
    */
   topTracks?: Track[]
+  /**
+   * Transient generation-time flag (#162): set by `rehydrateTopTracks` when
+   * `artist_tracks_cache` holds a confirmed-empty row within the negative TTL.
+   * Signals the confirm step to skip iTunes/Spotify and drop the artist rather
+   * than re-query a recently-confirmed dead end. Never persisted.
+   */
+  knownEmpty?: boolean
 }
 
 export interface Track {

--- a/lib/recommendation/confirm-previews.test.ts
+++ b/lib/recommendation/confirm-previews.test.ts
@@ -6,6 +6,7 @@ import {
   confirmToTarget,
   type ConfirmPreviewDeps,
   type ConfirmInput,
+  type ConfirmOutcome,
 } from "./confirm-previews"
 import type { Artist, Track } from "@/lib/music-provider/types"
 
@@ -61,14 +62,17 @@ function makeDeps(opts: {
   itunesCallCount: number
   spotifyCallCount: number
   spotifyCalledWith: Array<string | null>
+  outcomes: ConfirmOutcome[]
 } {
   let itunesCallCount = 0
   let spotifyCallCount = 0
   const spotifyCalledWith: Array<string | null> = []
+  const outcomes: ConfirmOutcome[] = []
   return {
     get itunesCallCount() { return itunesCallCount },
     get spotifyCallCount() { return spotifyCallCount },
     get spotifyCalledWith() { return spotifyCalledWith },
+    outcomes,
     searchItunes: async () => {
       itunesCallCount++
       if (opts.itunesRejects) throw new Error("iTunes unavailable")
@@ -80,6 +84,7 @@ function makeDeps(opts: {
       if (opts.spotifyRejects) throw new Error("Spotify unavailable")
       return opts.spotifyResult ?? []
     },
+    onConfirmOutcome: (o) => { outcomes.push(o) },
   }
 }
 
@@ -279,6 +284,87 @@ describe("confirmPlayableTracks — error resilience", () => {
   it("both deps reject → returns [], no throw", async () => {
     const deps = makeDeps({ itunesRejects: true, spotifyRejects: true })
     await expect(confirmPlayableTracks(baseArtist, deps)).resolves.toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// confirmPlayableTracks — onConfirmOutcome persistence callback (#162)
+// ---------------------------------------------------------------------------
+
+describe("confirmPlayableTracks — onConfirmOutcome firing matrix", () => {
+  it("iTunes playable → fires ONE positive outcome (source itunes), Spotify not called", async () => {
+    const deps = makeDeps({ itunesResult: [withPreview, withPreview2] })
+    await confirmPlayableTracks(baseArtist, deps)
+    expect(deps.outcomes).toHaveLength(1)
+    expect(deps.outcomes[0]).toMatchObject({ artistId: "artist-1", definitiveEmpty: false, source: "itunes" })
+    expect(deps.outcomes[0].tracks.map((t) => t.id)).toEqual(["p1", "p2"])
+    expect(deps.spotifyCallCount).toBe(0)
+  })
+
+  it("Spotify fallback playable → fires ONE positive outcome (source spotify)", async () => {
+    const deps = makeDeps({ itunesResult: [], spotifyResult: [withPreview] })
+    await confirmPlayableTracks({ ...baseArtist, spotifyId: "sp-1" }, deps)
+    expect(deps.outcomes).toHaveLength(1)
+    expect(deps.outcomes[0]).toMatchObject({ artistId: "artist-1", definitiveEmpty: false, source: "spotify" })
+  })
+
+  it("iTunes real-[] AND no spotifyId → fires ONE definitive negative", async () => {
+    const deps = makeDeps({ itunesResult: [], spotifyResult: [] })
+    await confirmPlayableTracks(baseArtist, deps) // baseArtist has no spotifyId
+    expect(deps.outcomes).toHaveLength(1)
+    expect(deps.outcomes[0]).toMatchObject({ artistId: "artist-1", definitiveEmpty: true, source: "itunes" })
+    expect(deps.outcomes[0].tracks).toHaveLength(0)
+  })
+
+  it("iTunes non-playable tracks (still it !== null) AND no spotifyId → definitive negative", async () => {
+    const deps = makeDeps({ itunesResult: [nullPreview, emptyPreview], spotifyResult: [] })
+    await confirmPlayableTracks(baseArtist, deps)
+    expect(deps.outcomes).toHaveLength(1)
+    expect(deps.outcomes[0]).toMatchObject({ definitiveEmpty: true, source: "itunes" })
+  })
+
+  it("iTunes failure (throws → null) AND no spotifyId → NO outcome (stays unconfirmed)", async () => {
+    // itunesRejects makes searchItunes throw → confirmPlayableTracks's .catch
+    // yields a genuine `it === null` (the mock's `?? []` can't produce a raw null).
+    const deps = makeDeps({ itunesRejects: true, spotifyResult: [] })
+    await confirmPlayableTracks(baseArtist, deps)
+    expect(deps.outcomes).toHaveLength(0)
+  })
+
+  it("iTunes real-[] but spotifyId present + Spotify [] → NO outcome (Spotify [] is ambiguous)", async () => {
+    const deps = makeDeps({ itunesResult: [], spotifyResult: [] })
+    await confirmPlayableTracks({ ...baseArtist, spotifyId: "sp-1" }, deps)
+    expect(deps.outcomes).toHaveLength(0)
+  })
+
+  it("positive cache reuse → NO outcome, no network", async () => {
+    const deps = makeDeps()
+    await confirmPlayableTracks({ ...baseArtist, topTracks: [withPreview] }, deps)
+    expect(deps.outcomes).toHaveLength(0)
+    expect(deps.itunesCallCount).toBe(0)
+  })
+})
+
+describe("confirmPlayableTracks — knownEmpty short-circuit (#162)", () => {
+  it("knownEmpty + no topTracks → returns [], no network, no outcome", async () => {
+    const deps = makeDeps({ itunesResult: [withPreview] })
+    const result = await confirmPlayableTracks({ ...baseArtist, knownEmpty: true }, deps)
+    expect(result).toHaveLength(0)
+    expect(deps.itunesCallCount).toBe(0)
+    expect(deps.spotifyCallCount).toBe(0)
+    expect(deps.outcomes).toHaveLength(0)
+  })
+
+  it("positive topTracks ALWAYS beats knownEmpty → returns playable, no network, no outcome", async () => {
+    const deps = makeDeps()
+    const result = await confirmPlayableTracks(
+      { ...baseArtist, knownEmpty: true, topTracks: [withPreview] },
+      deps,
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("p1")
+    expect(deps.itunesCallCount).toBe(0)
+    expect(deps.outcomes).toHaveLength(0)
   })
 })
 

--- a/lib/recommendation/confirm-previews.ts
+++ b/lib/recommendation/confirm-previews.ts
@@ -18,6 +18,23 @@ export function hasPlayablePreview(
   return !!tracks && tracks.some((t) => t.previewUrl != null && t.previewUrl !== "")
 }
 
+/**
+ * Emitted by `confirmPlayableTracks` ONCE per LIVE confirm so callers can
+ * persist the result to `artist_tracks_cache` (#162). NOT emitted on cache
+ * reuse or the `knownEmpty` short-circuit (nothing new was learned). See the
+ * firing matrix in `confirmPlayableTracks`.
+ */
+export interface ConfirmOutcome {
+  /** The minted uuid identity (artists.id) — the artist_tracks_cache key. */
+  artistId: string
+  /** Playable tracks found ([] when definitiveEmpty). */
+  tracks: Track[]
+  /** True only for the confirmed-no-preview negative case (iTunes real-[] + no spotifyId). */
+  definitiveEmpty: boolean
+  /** Which source produced the tracks. Negative rows persist as source 'none'. */
+  source: 'itunes' | 'spotify'
+}
+
 export interface ConfirmPreviewDeps {
   /** iTunes search by artist name. Returns tracks, [] for no match, or null on failure. */
   searchItunes: (name: string) => Promise<Track[] | null>
@@ -28,6 +45,12 @@ export interface ConfirmPreviewDeps {
    * internal uuid identity, which would 404 and trip the breaker.
    */
   getSpotifyTopTracks: (spotifyId: string | null) => Promise<Track[]>
+  /**
+   * Optional persistence hook (#162). Called ONCE per live confirm — see the
+   * firing matrix in `confirmPlayableTracks`. Never called on cache reuse or
+   * the `knownEmpty` short-circuit.
+   */
+  onConfirmOutcome?: (o: ConfirmOutcome) => void
 }
 
 export interface ConfirmInput {
@@ -50,6 +73,14 @@ export interface ConfirmInput {
    *  - [..]       → confirmed: reuse (filtered to playable), no network
    */
   topTracks?: Track[]
+  /**
+   * Fresh negative-cache flag (#162), set by `rehydrateTopTracks` when
+   * `artist_tracks_cache` holds a confirmed-empty row within the negative TTL.
+   * When true (and there's no positive `topTracks` to reuse), skip the network
+   * and return [] — the artist was recently confirmed to have no preview. A
+   * positive `topTracks` ALWAYS beats this flag (checked first).
+   */
+  knownEmpty?: boolean
 }
 
 /**
@@ -128,16 +159,35 @@ export async function confirmPlayableTracks(
     return playableTracks(artist.topTracks)
   }
 
-  // 2. iTunes-first
+  // 2. Fresh negative-cache short-circuit (#162). A positive cache above always
+  //    wins; only here do we honor a known-empty. No network, no callback (the
+  //    negative was already persisted — nothing new to learn).
+  if (artist.knownEmpty) return []
+
+  // 3. iTunes-first
   const it = await deps.searchItunes(artist.name).catch(() => null)
   const p = playableTracks(it ?? [])
-  if (p.length > 0) return p
+  if (p.length > 0) {
+    deps.onConfirmOutcome?.({ artistId: artist.id, tracks: p, definitiveEmpty: false, source: 'itunes' })
+    return p
+  }
 
-  // 3. Spotify fallback — keyed on the SPOTIFY id, never the uuid identity.
+  // 4. Spotify fallback — keyed on the SPOTIFY id, never the uuid identity.
   const sp = await deps.getSpotifyTopTracks(artist.spotifyId ?? null).catch(() => [])
   const p2 = playableTracks(sp)
-  if (p2.length > 0) return p2
+  if (p2.length > 0) {
+    deps.onConfirmOutcome?.({ artistId: artist.id, tracks: p2, definitiveEmpty: false, source: 'spotify' })
+    return p2
+  }
 
-  // 4. Nothing found
+  // 5. Nothing playable. Emit a negative ONLY when iTunes gave a DEFINITIVE
+  //    answer (it !== null — not a failure/breaker/timeout) AND there's no
+  //    Spotify id, so the empty isn't Spotify-ambiguous. iTunes null → no
+  //    callback (artist stays unconfirmed). iTunes real-[] but a spotifyId is
+  //    present and Spotify also came back empty → Spotify [] is failure-
+  //    ambiguous, so still no negative.
+  if (it !== null && artist.spotifyId == null) {
+    deps.onConfirmOutcome?.({ artistId: artist.id, tracks: [], definitiveEmpty: true, source: 'itunes' })
+  }
   return []
 }

--- a/lib/recommendation/engine.integration.test.ts
+++ b/lib/recommendation/engine.integration.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { createFakeSupabase, type Tables, type Row } from "./__fixtures__/fake-supabase"
 import { isValidArtistId } from "@/lib/spotify-ids"
-import type { Track } from "@/lib/music-provider/types"
+import type { Artist, Track } from "@/lib/music-provider/types"
 import type { SimilarArtistRef } from "@/lib/music-provider"
 
 // ── Hoisted mock control surface ──────────────────────────────────────────────
@@ -68,7 +68,7 @@ vi.mock("@/lib/music-provider/itunes", () => ({
 }))
 
 // Imported AFTER mocks are registered.
-import { buildRecommendations } from "./engine"
+import { buildRecommendations, rehydrateTopTracks } from "./engine"
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 function track(seed: string): Track {
@@ -141,6 +141,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllEnvs()
+  // Restore any vi.spyOn (e.g. the cold-start test's getSimilarArtistNames spy,
+  // the run-2 test's Math.random spy) so it can't leak into a later test's
+  // module mocks. Mirrors the explore integration suite's afterEach.
+  vi.restoreAllMocks()
 })
 
 // ── 1. Happy path: seeds → fan-out → resolve(miss→mint) → confirm → write ────
@@ -318,5 +322,114 @@ describe("buildRecommendations — cold start", () => {
     for (const row of cacheRows()) {
       expect(isValidArtistId(row.artist_id)).toBe(true)
     }
+  })
+})
+
+// ── 7. #162: persist confirmed previews to artist_tracks_cache ────────────────
+function tracksCacheRows(): Row[] {
+  return h.fake.tables.artist_tracks_cache ?? []
+}
+
+describe("buildRecommendations — persist confirms (#162)", () => {
+  it("flushConfirms writes positive rows with source + fetched_at", async () => {
+    seed({ seed_artists: [{ user_id: "u1", name: "SeedA" }] })
+    h.similars.set("SeedA", similarRefs(Array.from({ length: 6 }, (_, i) => `Pos${i}`)))
+
+    const result = await buildRecommendations(baseInput())
+    await result.runSecondary?.()
+    await result.flushConfirms?.()
+
+    const rows = tracksCacheRows()
+    expect(rows.length).toBeGreaterThan(0)
+    for (const row of rows) {
+      expect(isValidArtistId(row.artist_id)).toBe(true)
+      expect(row.source).toBe("itunes")
+      expect(row.tracks.length).toBeGreaterThan(0)
+      expect(typeof row.fetched_at).toBe("string")
+    }
+  })
+
+  it("writes a confirmed-empty negative row; iTunes failure (null) writes NOTHING", async () => {
+    const negId = "1a2b3c4d-0000-4000-8000-000000000001"
+    const failId = "5e6f7a8b-0000-4000-8000-000000000002"
+    seed({
+      seed_artists: [{ user_id: "u1", name: "SeedA" }],
+      artists: [artistsRow(negId, "NegArtist"), artistsRow(failId, "FailArtist")],
+    })
+    h.similars.set("SeedA", similarRefs(["Good0", "Good1", "Good2", "NegArtist", "FailArtist"]))
+    h.itunes.set("NegArtist", []) // real [] + no spotifyId → confirmed-empty negative
+    h.itunes.set("FailArtist", null) // failure → no callback → no row
+
+    const result = await buildRecommendations(baseInput())
+    await result.runSecondary?.()
+    await result.flushConfirms?.()
+
+    const rows = tracksCacheRows()
+    const neg = rows.find((r) => r.artist_id === negId)
+    expect(neg).toBeTruthy()
+    expect(neg!.tracks).toEqual([])
+    expect(neg!.source).toBe("none")
+    // The failure artist was never definitively confirmed → no negative row.
+    expect(rows.find((r) => r.artist_id === failId)).toBeUndefined()
+  })
+
+  it("run 2 makes ZERO iTunes calls for artists confirmed + persisted in run 1", async () => {
+    // Pin shuffle nondeterminism so both runs resolve the same candidate set.
+    const rand = vi.spyOn(Math, "random").mockReturnValue(0.42)
+    const names = Array.from({ length: 10 }, (_, i) => `Warm${i}`)
+    seed({ seed_artists: [{ user_id: "u1", name: "SeedA" }] })
+    h.similars.set("SeedA", similarRefs(names))
+
+    // Run 1 (cold): confirms via iTunes, persists positives to artist_tracks_cache.
+    const r1 = await buildRecommendations(baseInput())
+    await r1.runSecondary?.()
+    await r1.flushConfirms?.()
+    expect(h.calls.itunes.length).toBeGreaterThan(0)
+    expect(tracksCacheRows().length).toBeGreaterThan(0)
+
+    // Run 2 (warm): rehydrate short-circuits every confirm — no iTunes at all.
+    h.calls.itunes = []
+    const r2 = await buildRecommendations(baseInput())
+    await r2.runSecondary?.()
+    expect(h.calls.itunes).toEqual([])
+
+    rand.mockRestore()
+  })
+})
+
+// ── 8. #162: rehydrateTopTracks negative-row TTL handling ─────────────────────
+function bareArtist(id: string, name: string): { artist: Artist } {
+  return { artist: { id, name, genres: [], imageUrl: null, popularity: 0 } }
+}
+
+describe("rehydrateTopTracks — negative TTL (#162)", () => {
+  it("positive row → topTracks; fresh negative row → knownEmpty", async () => {
+    const posId = "aaaaaaaa-0000-4000-8000-000000000001"
+    const negId = "bbbbbbbb-0000-4000-8000-000000000002"
+    const fake = createFakeSupabase({
+      artist_tracks_cache: [
+        { artist_id: posId, tracks: [track("pos")], source: "itunes", fetched_at: new Date().toISOString() },
+        { artist_id: negId, tracks: [], source: "none", fetched_at: new Date().toISOString() },
+      ],
+    })
+    const cands = [bareArtist(posId, "Pos"), bareArtist(negId, "Neg")]
+    await rehydrateTopTracks(fake.client, cands)
+
+    expect(cands[0].artist.topTracks).toHaveLength(1)
+    expect(cands[0].artist.knownEmpty).toBeUndefined()
+    expect(cands[1].artist.topTracks).toBeUndefined()
+    expect(cands[1].artist.knownEmpty).toBe(true)
+  })
+
+  it("expired negative row → ignored (no knownEmpty, artist re-confirms)", async () => {
+    const negId = "bbbbbbbb-0000-4000-8000-000000000002"
+    const expired = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString() // 25h > 24h TTL
+    const fake = createFakeSupabase({
+      artist_tracks_cache: [{ artist_id: negId, tracks: [], source: "none", fetched_at: expired }],
+    })
+    const cands = [bareArtist(negId, "Neg")]
+    await rehydrateTopTracks(fake.client, cands)
+    expect(cands[0].artist.knownEmpty).toBeUndefined()
+    expect(cands[0].artist.topTracks).toBeUndefined()
   })
 })

--- a/lib/recommendation/engine.test.ts
+++ b/lib/recommendation/engine.test.ts
@@ -638,6 +638,27 @@ describe("runWithSoftening cascade order", () => {
     expect(result.softenedFilters).toBeUndefined()
   })
 
+  it("chains every run's flushConfirms so softening doesn't discard earlier runs' confirms (#162)", async () => {
+    const flushed: string[] = []
+    let idx = 0
+    const counts = [0, 5]
+    const run = async (opts: RunPipelineOpts): Promise<BuildResult> => {
+      const label = opts.source
+      const count = counts[idx++] ?? 0
+      return {
+        count,
+        runSecondary: null,
+        flushConfirms: async () => { flushed.push(label) },
+        metrics: { primaryMs: 0, previewMs: 0, firstBatchMs: 0, misses: 0, retries: 0, rateLimited: false },
+      }
+    }
+    const result = await runWithSoftening(baseOpts, { run, coldStartSeeds: coldSeeds })
+    expect(result.count).toBe(5)
+    await result.flushConfirms?.()
+    // BOTH the failed primary's and the successful soften run's collectors flush.
+    expect(flushed.sort()).toEqual(["multi_source", "soften_play_threshold"])
+  })
+
   it("applies playThreshold+5 first; stops when it succeeds", async () => {
     const { run, calls } = makeRunner([0, 5])
     const result = await runWithSoftening(baseOpts, { run, coldStartSeeds: coldSeeds })

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -1213,7 +1213,21 @@ export async function runWithSoftening(
   baseOpts: RunPipelineOpts,
   deps: SoftenDeps
 ): Promise<BuildResult> {
-  const primary = await deps.run(baseOpts)
+  // Each deps.run() is a full runPipeline with its OWN confirm collector.
+  // Only the returned result's flushConfirms would ever be called, so a
+  // softened retry would silently discard the earlier runs' confirmed
+  // previews (#162 — e.g. tier-1 positives suppressed by cooldown still cost
+  // live iTunes calls worth persisting). Chain every run's flush onto the
+  // returned result so the route's single after() flush covers them all.
+  const flushes: Array<() => Promise<void>> = []
+  const withChainedFlush = (result: BuildResult): BuildResult => {
+    if (result.flushConfirms) flushes.push(result.flushConfirms)
+    if (flushes.length <= 1) return result
+    const all = [...flushes]
+    return { ...result, flushConfirms: async () => { await Promise.all(all.map((f) => f())) } }
+  }
+
+  const primary = withChainedFlush(await deps.run(baseOpts))
   if (primary.count > 0) return primary
 
   const softened: SoftenedFilters = { playThreshold: false, coldStart: false }
@@ -1222,11 +1236,11 @@ export async function runWithSoftening(
   // Soften 1: bump play threshold.
   console.log(`[engine] soften_play_threshold userId=${baseOpts.userId} from=${originalPlayThreshold} to=${originalPlayThreshold + 5}`)
   softened.playThreshold = true
-  const r1 = await deps.run({
+  const r1 = withChainedFlush(await deps.run({
     ...baseOpts,
     playThreshold: originalPlayThreshold + 5,
     source: 'soften_play_threshold',
-  })
+  }))
   if (r1.count > 0) return { ...r1, softenedFilters: softened }
 
   // Soften 2: cold-start fallback. undergroundMode is intentionally off here —
@@ -1234,14 +1248,14 @@ export async function runWithSoftening(
   // curated starter picks are treated as an exception to the cap promise.
   console.log(`[engine] soften_cold_start userId=${baseOpts.userId}`)
   softened.coldStart = true
-  const r3 = await deps.run({
+  const r3 = withChainedFlush(await deps.run({
     ...baseOpts,
     seedNames: deps.coldStartSeeds(),
     playThreshold: originalPlayThreshold + 5,
     undergroundMode: false,
     source: 'soften_cold_start',
     userGenres: [],
-  })
+  }))
   return { ...r3, softenedFilters: softened }
 }
 

--- a/lib/recommendation/engine.ts
+++ b/lib/recommendation/engine.ts
@@ -12,7 +12,8 @@ import {
 import { ArtistNameCache } from './artist-name-cache'
 import { resolveArtistsByName } from './resolve-candidates'
 import { ensureArtist, type ArtistsSupabaseClient } from '@/lib/artists'
-import { confirmPlayableTracks, confirmToTarget } from './confirm-previews'
+import { confirmPlayableTracks, confirmToTarget, type ConfirmOutcome } from './confirm-previews'
+import { createConfirmCollector, NEGATIVE_TTL_MS } from './persist-confirms'
 import { searchTracksByArtist } from '@/lib/music-provider/itunes'
 import { fetchArtistEnrichment, buildEnrichArtist } from './enrich-artist'
 import { normalizeArtistName } from '@/lib/listened-artists'
@@ -156,11 +157,21 @@ export function lastfmResolve(name: string): Promise<Artist[]> {
  * Shared by the primary, secondary, and adjacent-bleed resolves so the
  * playability guarantee holds across the whole For You pipeline.
  */
-export function buildConfirmPreview(accessToken: string) {
+export function buildConfirmPreview(
+  accessToken: string,
+  onConfirmOutcome?: (o: ConfirmOutcome) => void,
+) {
   return (artist: Artist) =>
     confirmPlayableTracks(
-      { id: artist.id, name: artist.name, spotifyId: artist.spotifyId, topTracks: artist.topTracks },
       {
+        id: artist.id,
+        name: artist.name,
+        spotifyId: artist.spotifyId,
+        topTracks: artist.topTracks,
+        knownEmpty: artist.knownEmpty,
+      },
+      {
+        onConfirmOutcome,
         searchItunes: (name) => searchTracksByArtist(name, 'US', 5),
         // Spotify top-tracks keyed on the SPOTIFY id (not the uuid identity).
         // No id (Last.fm-only artist) or no token → no-op to [].
@@ -224,11 +235,16 @@ export async function rehydrateTopTracks(
   if (ids.length === 0) return
 
   const tracksById = new Map<string, Track[]>()
+  // Fresh confirmed-empty rows (#162): within NEGATIVE_TTL_MS → short-circuit
+  // the confirm step (knownEmpty) instead of re-hitting iTunes. Expired
+  // negatives are ignored (artist stays unconfirmed → re-confirms).
+  const knownEmptyIds = new Set<string>()
+  const now = Date.now()
   for (let i = 0; i < ids.length; i += TRACKS_REHYDRATE_CHUNK_SIZE) {
     const chunk = ids.slice(i, i + TRACKS_REHYDRATE_CHUNK_SIZE)
     const { data, error } = await supabase
       .from('artist_tracks_cache')
-      .select('artist_id, tracks')
+      .select('artist_id, tracks, fetched_at')
       .in('artist_id', chunk)
     if (error) {
       console.log(`[engine] rehydrate read-fail err="${error.message}" chunk=${i}-${i + chunk.length} total=${ids.length}`)
@@ -238,14 +254,22 @@ export async function rehydrateTopTracks(
       const id = row.artist_id as string | null
       if (!id) continue
       const tracks = (row.tracks as Track[] | null) ?? []
-      if (tracks.length > 0) tracksById.set(id, tracks)
+      if (tracks.length > 0) {
+        tracksById.set(id, tracks)
+      } else if (row.fetched_at && now - new Date(row.fetched_at as string).getTime() < NEGATIVE_TTL_MS) {
+        knownEmptyIds.add(id)
+      }
     }
   }
 
-  if (tracksById.size === 0) return
+  if (tracksById.size === 0 && knownEmptyIds.size === 0) return
   for (const { artist } of candidates) {
     const cached = tracksById.get(artist.id)
-    if (cached) artist.topTracks = cached
+    if (cached) {
+      artist.topTracks = cached // positive always wins
+    } else if (knownEmptyIds.has(artist.id)) {
+      artist.knownEmpty = true
+    }
   }
 }
 
@@ -650,6 +674,12 @@ async function runPipeline(o: RunPipelineOpts): Promise<BuildResult> {
     source, genre, undergroundMode, deepDiscovery, adventurous, userGenres = [],
   } = o
 
+  // ONE collector per run (#162). Every confirm tier (tier-1 blocking, tier-2
+  // deferred, secondary) records outcomes here; the route flushes it once in
+  // after() so a single batch-upsert covers all three phases.
+  const confirmCollector = createConfirmCollector()
+  const flushConfirms = () => confirmCollector.flush(supabase)
+
   const widenSeedCap = userGenres.length >= ADAPTIVE_BROADEN_THRESHOLD
   const seedCap = widenSeedCap ? 15 : 10
   const capSeedNames = seedNames.slice(0, seedCap)
@@ -691,7 +721,7 @@ async function runPipeline(o: RunPipelineOpts): Promise<BuildResult> {
 
   if (uniqueNames.length === 0) {
     console.error(`[engine] FAIL no_unique seeds=${capSeedNames.length} lfm=${lfmTotal} source=${source}`)
-    return { count: 0, runSecondary: null, metrics: { primaryMs: 0, previewMs: 0, firstBatchMs: 0, misses: 0, retries: 0, rateLimited: false } }
+    return { count: 0, runSecondary: null, flushConfirms, metrics: { primaryMs: 0, previewMs: 0, firstBatchMs: 0, misses: 0, retries: 0, rateLimited: false } }
   }
 
   const candidateMap = new Map<string, { artist: Artist; seedArtists: string[] }>()
@@ -855,7 +885,7 @@ async function runPipeline(o: RunPipelineOpts): Promise<BuildResult> {
       `uniq=${uniqueNames.length} ok=${resolved.searchOk} fail=${resolved.searchFail} ` +
       `filtListened=${filtListened} cands=${candidateMap.size} source=${source}`
     )
-    return { count: 0, runSecondary: null, metrics: { primaryMs: Date.now() - primaryStart, previewMs, firstBatchMs: 0, misses: resolved.cacheMisses, retries: resolved.searchRetries, rateLimited: resolved.rateLimited } }
+    return { count: 0, runSecondary: null, flushConfirms, metrics: { primaryMs: Date.now() - primaryStart, previewMs, firstBatchMs: 0, misses: resolved.cacheMisses, retries: resolved.searchRetries, rateLimited: resolved.rateLimited } }
   }
 
   // Post-pipeline adjacent-genre bleed. Skipped when the user has filtered
@@ -916,7 +946,7 @@ async function runPipeline(o: RunPipelineOpts): Promise<BuildResult> {
   //   Tier 2 (deferred): finish primary to TARGET, then secondary pool — all in after().
   // Every artist written in ANY phase is confirmed-playable (comes through confirmToTarget).
 
-  const confirmFn = buildConfirmPreview(accessToken)
+  const confirmFn = buildConfirmPreview(accessToken, confirmCollector.onConfirmOutcome)
   const inTop = new Set(top.map((t) => t.artist.id))
   const tail = pool.filter((s) => !inTop.has(s.artist.id)) // already score-sorted
   const ordered = [...top, ...tail]
@@ -1117,7 +1147,7 @@ async function runPipeline(o: RunPipelineOpts): Promise<BuildResult> {
     const { kept: secConfirmed } = await confirmToTarget(
       secondaryScored,
       TARGET,
-      buildConfirmPreview(accessToken),
+      buildConfirmPreview(accessToken, confirmCollector.onConfirmOutcome),
     )
 
     if (secConfirmed.length > 0) {
@@ -1144,6 +1174,7 @@ async function runPipeline(o: RunPipelineOpts): Promise<BuildResult> {
   return {
     count: tier1Written,
     runSecondary,
+    flushConfirms,
     metrics: {
       primaryMs,
       previewMs,

--- a/lib/recommendation/explore-engine.integration.test.ts
+++ b/lib/recommendation/explore-engine.integration.test.ts
@@ -242,3 +242,32 @@ describe("buildExploreRails — rail failure isolation", () => {
     expect(h.fake.tables.explore_cache.length).toBe(RAIL_KEYS.length)
   }, 20000)
 })
+
+// ── 6d. #162: freshly confirmed picks are hydratable (read-after-write) ───────
+describe("buildExploreRails — freshly confirmed picks hydrate with previews (#162)", () => {
+  it("persists confirmed tracks BEFORE hydration reads them, so no rail pick is a dead card", async () => {
+    seed(withLikedSeed())
+    h.similars.set("LikedArtist", [
+      { name: "W0", match: 0.9 },
+      { name: "W1", match: 0.3 },
+      { name: "W2", match: 0.2 },
+      { name: "W3", match: 0.1 },
+    ])
+
+    const { rails, hydrated } = await buildExploreRails(baseInput(), { hydrate: true })
+    expect(hydrated).toBeDefined()
+
+    const ids = allRailIds(rails)
+    expect(ids.length).toBeGreaterThan(0)
+
+    // The tracks cache was written during THIS request (the resolveAndFilter
+    // flush) — before hydrateRailArtists read it. Every surfaced rail pick
+    // therefore hydrates WITH a playable preview instead of topTracks:[].
+    expect((h.fake.tables.artist_tracks_cache ?? []).length).toBeGreaterThan(0)
+    for (const id of ids) {
+      const rec = hydrated!.get(id)
+      expect(rec).toBeTruthy()
+      expect(rec!.topTracks?.some((t) => t.previewUrl)).toBe(true)
+    }
+  }, 20000)
+})

--- a/lib/recommendation/explore-engine.ts
+++ b/lib/recommendation/explore-engine.ts
@@ -17,8 +17,10 @@ import { createServiceClient } from '@/lib/supabase/server'
 import { ArtistNameCache } from './artist-name-cache'
 import { resolveArtistsByName } from './resolve-candidates'
 import { buildEnrichArtist } from './enrich-artist'
-import { getTagArtistNames, buildConfirmPreview, buildMintArtist, lastfmResolve } from './engine'
+import { getTagArtistNames, buildConfirmPreview, buildMintArtist, lastfmResolve, rehydrateTopTracks } from './engine'
 import { confirmToTarget } from './confirm-previews'
+import { createConfirmCollector, resetPersisted, snapshotPersisted } from './persist-confirms'
+import { resetCalls, snapshotCalls } from './api-call-counter'
 import {
   allLeavesWithAnchor,
   genreToAnchor,
@@ -235,19 +237,30 @@ async function resolveAndFilter(
     candidates.push({ artist, name })
   }
 
+  // Pre-confirm rehydrate (#162): warm positives from artist_tracks_cache skip
+  // iTunes entirely, and fresh confirmed-empty negatives short-circuit (dropped
+  // without a re-query). The generation path has always done this; the Explore
+  // confirm slice never did.
+  await rehydrateTopTracks(supabase, candidates)
+
   // Confirm up to `confirmTarget` artists. Per-rail callers set this to
-  // displayTarget + HEADROOM so smaller rails confirm fewer candidates.
-  const { kept } = await confirmToTarget(candidates, confirmTarget, buildConfirmPreview(accessToken))
+  // displayTarget + HEADROOM so smaller rails confirm fewer candidates. The
+  // collector records each live confirm so the flush below persists them.
+  const collector = createConfirmCollector()
+  const { kept } = await confirmToTarget(candidates, confirmTarget, buildConfirmPreview(accessToken, collector.onConfirmOutcome))
 
   // Write the confirmed topTracks back into artist_search_cache under the
-  // resolver's name key (#145/#143 fix). Explore persists only artist IDs in
-  // explore_cache and re-hydrates artist_data from artist_search_cache by id —
-  // so without this write-back the baked topTracks are discarded and every
-  // freshly-resolved rail card hydrates with topTracks:[] → a dead card. This
-  // also makes the next generation's resolver a warm, network-free preview hit.
-  await Promise.all(
-    kept.map((k) => nameCache.write(k.name, k.artist).catch(() => {})),
-  )
+  // resolver's name key (#145/#143 fix) AND persist confirmed previews to
+  // artist_tracks_cache (#162). The tracks-cache write MUST land before
+  // hydrateRailArtists reads it in the same request — that read-after-write is
+  // the fix for the 76% cached-pick drop. Both flush inside this one awaited
+  // Promise.all. Explore persists only artist IDs in explore_cache and
+  // re-hydrates artist_data by id, so without these writes every freshly-
+  // resolved rail card hydrated with topTracks:[] → a dead card.
+  await Promise.all([
+    ...kept.map((k) => nameCache.write(k.name, k.artist).catch(() => {})),
+    collector.flush(supabase),
+  ])
 
   return kept.map((k) => k.artist)
 }
@@ -996,6 +1009,11 @@ export async function buildExploreRails(
 ): Promise<BuildRailsResult> {
   const supabase = createServiceClient()
   const now = new Date()
+  // Reset call/persist counters so the [explore-timing] snapshot below reflects
+  // only this build's outbound work (#162 measurement gate). Measurement-only —
+  // interleaving concurrent builds is acceptable (same caveat as generation).
+  resetCalls()
+  resetPersisted()
   // `regenerate` defaults to true to preserve existing behaviour. When false,
   // the function never triggers a 54-74s build — it returns whatever is
   // cached (possibly empty/partial rails) instead. Used by the read-only
@@ -1174,6 +1192,12 @@ export async function buildExploreRails(
   }
 
   enforceUndergroundCap(rails, hydrated, input.undergroundMode)
+
+  const calls = snapshotCalls()
+  console.log(
+    `[explore-timing] itunes=${calls.itunes} spotify=${calls.spotify} ` +
+    `lastfm=${calls.lastfm.total} persisted=${snapshotPersisted()}`,
+  )
   return { rails, cacheHit: false, hydrated }
 }
 

--- a/lib/recommendation/explore-rail-payloads.ts
+++ b/lib/recommendation/explore-rail-payloads.ts
@@ -60,12 +60,18 @@ export function hydrateRailArtists(
   artistById: Map<string, HydratedRailArtist>,
 ): RailArtist[] {
   const out: RailArtist[] = []
+  // Diagnostic (#162): distinguish drops with NO hydration row (id not in the
+  // map — the artist_tracks_cache / artists read missed) from drops of a
+  // confirmed-negative row (topTracks present but unplayable). The guard
+  // decisions below are unchanged — this only counts them.
+  let droppedNoRow = 0
+  let droppedNegative = 0
   for (const id of ids) {
     const a = artistById.get(id)
-    if (!a) continue
+    if (!a) { droppedNoRow++; continue }
     // Defensive: drop only when topTracks is present AND confirmed unplayable.
     // Legacy cached rows have topTracks=undefined — keep those.
-    if (a.topTracks !== undefined && !hasPlayablePreview(a.topTracks)) continue
+    if (a.topTracks !== undefined && !hasPlayablePreview(a.topTracks)) { droppedNegative++; continue }
     out.push({
       id: a.id,
       name: a.name,
@@ -83,6 +89,12 @@ export function hydrateRailArtists(
           }
         : undefined,
     })
+  }
+  if (droppedNoRow > 0 || droppedNegative > 0) {
+    console.log(
+      `[explore-hydrate] kept=${out.length} droppedNoRow=${droppedNoRow} ` +
+      `droppedNegative=${droppedNegative} total=${ids.length}`,
+    )
   }
   return out
 }

--- a/lib/recommendation/persist-confirms.test.ts
+++ b/lib/recommendation/persist-confirms.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest"
+import { createConfirmCollector } from "./persist-confirms"
+import type { ConfirmOutcome } from "./confirm-previews"
+import type { Track } from "@/lib/music-provider/types"
+
+const UUID_A = "aaaaaaaa-0000-4000-8000-000000000001"
+const UUID_B = "bbbbbbbb-0000-4000-8000-000000000002"
+
+function track(id: string): Track {
+  return {
+    id,
+    spotifyTrackId: null,
+    name: `Track ${id}`,
+    previewUrl: `https://audio.example.com/${id}.m4a`,
+    durationMs: 30000,
+    albumName: "Album",
+    albumImageUrl: null,
+    source: "itunes",
+  }
+}
+
+function positive(artistId: string): ConfirmOutcome {
+  return { artistId, tracks: [track("t1")], definitiveEmpty: false, source: "itunes" }
+}
+function negative(artistId: string): ConfirmOutcome {
+  return { artistId, tracks: [], definitiveEmpty: true, source: "itunes" }
+}
+
+/** Minimal Supabase stub recording upsert calls. `fail` mode surfaces an error. */
+function fakeClient(mode: "ok" | "error" | "throw" = "ok") {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const upserts: Array<{ rows: any[]; opts: any }> = []
+  const client = {
+    from() {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        async upsert(rows: any[], opts: any) {
+          if (mode === "throw") throw new Error("connection reset")
+          upserts.push({ rows, opts })
+          return { error: mode === "error" ? { message: "upsert boom" } : null }
+        },
+      }
+    },
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { client: client as any, upserts }
+}
+
+describe("createConfirmCollector", () => {
+  it("no-op when nothing collected (no upsert call)", async () => {
+    const { client, upserts } = fakeClient()
+    await createConfirmCollector().flush(client)
+    expect(upserts).toHaveLength(0)
+  })
+
+  it("collects a positive as source=itunes with tracks + fetched_at", async () => {
+    const { client, upserts } = fakeClient()
+    const c = createConfirmCollector()
+    c.onConfirmOutcome(positive(UUID_A))
+    await c.flush(client)
+    expect(upserts).toHaveLength(1)
+    expect(upserts[0].opts).toEqual({ onConflict: "artist_id" })
+    const row = upserts[0].rows[0]
+    expect(row).toMatchObject({ artist_id: UUID_A, source: "itunes" })
+    expect(row.tracks).toHaveLength(1)
+    expect(typeof row.fetched_at).toBe("string")
+  })
+
+  it("collects a negative as source=none with empty tracks", async () => {
+    const { client, upserts } = fakeClient()
+    const c = createConfirmCollector()
+    c.onConfirmOutcome(negative(UUID_A))
+    await c.flush(client)
+    const row = upserts[0].rows[0]
+    expect(row).toMatchObject({ artist_id: UUID_A, source: "none" })
+    expect(row.tracks).toEqual([])
+  })
+
+  it("skips non-uuid artistIds", async () => {
+    const { client, upserts } = fakeClient()
+    const c = createConfirmCollector()
+    c.onConfirmOutcome(positive("not-a-uuid"))
+    c.onConfirmOutcome(positive(UUID_A))
+    await c.flush(client)
+    expect(upserts[0].rows.map((r: { artist_id: string }) => r.artist_id)).toEqual([UUID_A])
+  })
+
+  it("dedupes by artistId — last write wins", async () => {
+    const { client, upserts } = fakeClient()
+    const c = createConfirmCollector()
+    c.onConfirmOutcome(positive(UUID_A)) // first: positive
+    c.onConfirmOutcome(negative(UUID_A)) // last: negative → wins
+    c.onConfirmOutcome(positive(UUID_B))
+    await c.flush(client)
+    const rows: Array<{ artist_id: string; source: string }> = upserts[0].rows
+    expect(rows).toHaveLength(2)
+    expect(rows.find((r) => r.artist_id === UUID_A)?.source).toBe("none")
+    expect(rows.find((r) => r.artist_id === UUID_B)?.source).toBe("itunes")
+  })
+
+  it("swallows an upsert error (never throws)", async () => {
+    const { client } = fakeClient("error")
+    const c = createConfirmCollector()
+    c.onConfirmOutcome(positive(UUID_A))
+    await expect(c.flush(client)).resolves.toBeUndefined()
+  })
+
+  it("swallows a thrown upsert (never throws)", async () => {
+    const { client } = fakeClient("throw")
+    const c = createConfirmCollector()
+    c.onConfirmOutcome(positive(UUID_A))
+    await expect(c.flush(client)).resolves.toBeUndefined()
+  })
+})

--- a/lib/recommendation/persist-confirms.ts
+++ b/lib/recommendation/persist-confirms.ts
@@ -1,0 +1,102 @@
+/**
+ * Persist confirmed previews to `artist_tracks_cache` (#162).
+ *
+ * The generation and Explore confirm paths learn, per artist, whether a
+ * playable preview exists. Before #162 that knowledge was thrown away — only
+ * the lazy per-card tracks route ever wrote this table — so Explore dropped its
+ * own freshly-confirmed picks and every generation re-paid iTunes. This module
+ * collects `ConfirmOutcome`s emitted by `confirmPlayableTracks` and batch-
+ * upserts them (positives AND confirmed-empty negatives) so the tracks route,
+ * feed rehydration, and Explore hydration all read the same shared rows.
+ */
+
+import type { createServiceClient } from "@/lib/supabase/server"
+import { isValidArtistId } from "@/lib/spotify-ids"
+import type { ConfirmOutcome } from "./confirm-previews"
+
+type SupabaseClient = ReturnType<typeof createServiceClient>
+
+/**
+ * Negative-row TTL. Deliberately 24h — same as the tracks route's CACHE_TTL_MS
+ * — and NOT longer, because (a) the nightly MusicBrainz backfill (#159) can give
+ * a spotifyId-less artist a Spotify id, and a long negative would blind
+ * generation to the newly-reachable Spotify preview; (b) iTunes name-spelling
+ * mismatches (#164) can yield legitimate-looking empties that should get
+ * re-checked soon.
+ */
+export const NEGATIVE_TTL_MS = 24 * 60 * 60 * 1000
+
+/** Defensive chunk size for the batch upsert (one call unless > this). */
+const UPSERT_CHUNK_SIZE = 500
+
+// Process-global tally of rows persisted, for the [explore-timing] log line.
+// Measurement-only (same concurrency caveat as api-call-counter): interleaving
+// concurrent builds is acceptable — it never drives behavior.
+let persistedRows = 0
+export function snapshotPersisted(): number {
+  return persistedRows
+}
+export function resetPersisted(): void {
+  persistedRows = 0
+}
+
+export interface ConfirmCollector {
+  /** Wire into buildConfirmPreview so each live confirm is recorded. */
+  onConfirmOutcome: (o: ConfirmOutcome) => void
+  /** Batch-upsert all collected outcomes. NEVER throws. No-op when empty. */
+  flush: (supabase: SupabaseClient) => Promise<void>
+}
+
+/**
+ * Create a per-run outcome collector. Dedupes by artistId (last write wins),
+ * skips non-uuid ids, and on flush batch-upserts one row per artist:
+ *   { artist_id, tracks, source, fetched_at }
+ * with `source: 'none'` for confirmed-empty negatives. Flush swallows all
+ * errors — a cache-write blip must never break generation.
+ */
+export function createConfirmCollector(): ConfirmCollector {
+  const outcomes = new Map<string, ConfirmOutcome>()
+
+  return {
+    onConfirmOutcome(o) {
+      outcomes.set(o.artistId, o) // dedupe by artistId, last wins
+    },
+
+    async flush(supabase) {
+      if (outcomes.size === 0) return
+      const fetchedAt = new Date().toISOString()
+      const rows: Array<{ artist_id: string; tracks: ConfirmOutcome["tracks"]; source: string; fetched_at: string }> = []
+      let pos = 0
+      let neg = 0
+      for (const o of outcomes.values()) {
+        if (!isValidArtistId(o.artistId)) continue
+        if (o.definitiveEmpty) neg++
+        else pos++
+        rows.push({
+          artist_id: o.artistId,
+          tracks: o.tracks,
+          source: o.definitiveEmpty ? "none" : o.source,
+          fetched_at: fetchedAt,
+        })
+      }
+      if (rows.length === 0) return
+
+      try {
+        for (let i = 0; i < rows.length; i += UPSERT_CHUNK_SIZE) {
+          const chunk = rows.slice(i, i + UPSERT_CHUNK_SIZE)
+          const { error } = await supabase
+            .from("artist_tracks_cache")
+            .upsert(chunk, { onConflict: "artist_id" })
+          if (error) {
+            console.log(`[persist-confirms] fail err="${error.message}" n=${pos}/${neg}`)
+            return
+          }
+        }
+        persistedRows += rows.length
+        console.log(`[persist-confirms] ok n=${pos}/${neg}`)
+      } catch (err) {
+        console.log(`[persist-confirms] fail err="${err instanceof Error ? err.message : String(err)}" n=${pos}/${neg}`)
+      }
+    },
+  }
+}

--- a/lib/recommendation/types.ts
+++ b/lib/recommendation/types.ts
@@ -44,6 +44,13 @@ export interface BuildResult {
    */
   runSecondary: (() => Promise<number>) | null
   /**
+   * Flush confirmed-preview outcomes to `artist_tracks_cache` (#162). The route
+   * calls this inside `after()` AFTER `runSecondary` completes, so one batch
+   * upsert covers tier-1 + tier-2 + secondary confirms. Optional so pipeline
+   * mocks/early-fail shapes stay valid; a run with no confirms flushes a no-op.
+   */
+  flushConfirms?: () => Promise<void>
+  /**
    * Set when the pipeline auto-softened filters to avoid an empty pool.
    * `undefined` on normal (non-softened) runs.
    */


### PR DESCRIPTION
Closes #162.

Generation confirmed playable previews via iTunes, then threw the evidence away — explore re-read an empty tracks cache in the same request and its own playability guard hid **76% of cached rail picks** (Curveballs 0/18). Every generation also re-paid iTunes for artists confirmed before, tripping the shared key's breaker mid-build.

Now every live confirm is persisted to `artist_tracks_cache` at the moment it happens, including **negative rows** (confirmed no-preview) honored for 24h. The display guard is byte-identical: nothing without a playable preview ever renders — it just stops being starved of the data it needed.

## Design (pressure-tested by two adversarial reviews before implementation)

- `confirmPlayableTracks` emits a `ConfirmOutcome` per live confirm — the only layer where iTunes-failure (`null`) vs genuinely-no-results (`[]`) is distinguishable. **Failures never write negatives.** Negatives only when iTunes definitively returned empty AND the artist has no Spotify id (the Spotify fallback can't distinguish failure from empty).
- Collectors batch-write per phase: explore **awaits** its flush before rail hydration (the read-after-write that fixes the drop); the feed flushes inside `after()` so first paint pays nothing. Soften retries chain every run's flush (delta-sweep finding, fixed + regression test).
- `rehydrateTopTracks` sets an explicit `knownEmpty` flag for fresh negatives (positives always win); explore's confirm slice gains the pre-confirm rehydrate it never had.
- Negative TTL = 24h deliberately (not 7d): the nightly MusicBrainz backfill can make an artist Spotify-resolvable, and iTunes name-mismatch empties (#164) shouldn't freeze for a week. Unifies with the lazy route's existing 24h TTL.
- New observability: `[gen-timing-bg]` (full-gen call counts — the old line stopped at the blocking window), `[persist-confirms] n=pos/neg`, `[explore-timing]`, `[explore-hydrate]` drop diagnostics.
- **No migration** — the table already had the exact shape. Rollback = revert; rows are TTL'd/self-healing.

## Live verification (localhost prod build, smoke user)

| Criterion | Result |
|---|---|
| Explore regen renders its picks | **39/39 rendered, 100% playable** (baseline: 76% dropped) |
| 2nd feed gen ~0 iTunes calls | blocking tier **8 → 0**, full gen **48 → 9** (the 9 = new artists, now persisted) |
| Persist writes | run 1: 40 pos / 6 neg; run 2: 7 / 2 |
| Gen total time | 14.8s → 6.5s |

## Verification

- 692 tests green (62 files), tsc + prod build clean. (Note: earlier "1026" counts were inflated by stale-worktree duplicates vitest was collecting; 692 is the true count.)
- Layered review: adversarial plan reviews (design + ops) → Opus implementation → my line review of the negative-rule and await-ordering hunks → live acceptance run → Opus delta sweep (no correctness regressions; its one perf finding fixed in the final commit).

Known accepted seams (documented in code): a spotifyId gained by the nightly backfill is invisible to generation for ≤24h; concurrent explore+feed builds on one warm instance can interleave the measurement counters (logging only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)